### PR TITLE
Add lsp-factory guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Live URL: <https://docs.lukso.tech/>
 1. Run typedoc command in erc725.js repo
 
 ```sh
-npx typedoc --out docs src/index.ts --includeVersion --hideInPageTOC true --sort visibility
+npx typedoc --out docs/technical-reference src/index.ts --includeVersion --hideInPageTOC true --sort visibility
 ```
 
-2. Replace content of tools/erc725js/technical-reference/ with content generated in docs/
+2. Replace content of tools/erc725js/technical-reference/ with content generated in docs/technical-reference
 ## Installation
 
 ```console

--- a/docs/tools/lsp-factoryjs/constructing-lsp3-data.md
+++ b/docs/tools/lsp-factoryjs/constructing-lsp3-data.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 1.2
+---
+
+# Constructing LSP3 Metadata
+
+When deploying a Universal Profile you can specify your Universal Profile metadata using the `lsp3Profile` key.
+
+
+This object contains your UP metadata. 
+
+```javascript
+const myUniversalProfileData = {
+    name: "My Universal Profile",
+    description: "My cool Universal Profile",
+    profileImage: [
+        {
+            width: 500,
+            height: 500,
+            hashFunction: "keccak256(bytes)",
+            hash: "0x...", // bytes32 hex string of the image hash
+            url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
+        },
+    ],
+    backgroundImage: [
+        {
+            width: 500,
+            height: 500,
+            hashFunction: "keccak256(bytes)",
+            hash: "0x...", // bytes32 hex string of the image hash
+            url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
+        },
+    ],
+    tags: ['Fashion', 'Design'],
+    links: ['www.my-website.com'],
+},
+```
+
+`File` objects can also be passed to `profileImage` and `backgroundImage` fields to allow easy drag and drop of images from a user interface:
+
+```javascript
+<input type="file" id="input">
+
+<script>
+    const myLocalFile = document.getElementById('input').files[0];
+
+    const myUniversalProfileData = {
+        name: "My Universal Profile",
+        description: "My cool Universal Profile",
+        profileImage: myLocalFile,
+        backgroundImage: myLocalFile,
+        tags: ['Fashion', 'Design'],
+        links: ['www.my-website.com'],
+    },
+<script/>
+```
+
+If a `File` object is passed it will will automatically be uploaded to IPFS.
+
+## Uploading LSP3 metadata to IPFS
+
+
+If you wish to upload your LSP3 metadata before deploying you can do so using the static `uploadProfileData` method. This uses the same `lsp3Profile` object schema defined above for `myUniversalProfileData`:
+
+```javascript
+const uploadResult = await LSP3UniversalProfile.uploadProfileData({
+    ...myUniversalProfileData
+});
+
+const myUniversalProfileIPFSUrl = uploadResult.url; // 'https://ipfs.lukso.network/ipfs/QmPzUfdKhY6vfcTNDnitwKnnpm5GqjYSmw9todNVmi4bqy'
+```
+
+Then deploy your UP  
+
+```javascript
+const myContracts = await lspFactory.ERC725UniversalProfile.deploy({
+    controllingAccounts: ['0x...'],
+    lsp3Profile: myUniversalProfileIPFSUrl | myUniversalProfileData // LSP3 Metadata object or IPFS url
+  });
+};
+```

--- a/docs/tools/lsp-factoryjs/getting-started.md
+++ b/docs/tools/lsp-factoryjs/getting-started.md
@@ -1,15 +1,8 @@
 ---
-id: getting-started
-title: Getting Started
 sidebar_position: 1.1
 ---
 
-:::caution
-
-This package is a work in progress.
-
-:::
-
+# Getting Started
 
 The `@lukso/lsp-factory.js` package allows simple deployments of [LSP3-UniversalProfiles](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile.md) and [LSP4-DigitalCertificates](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalCertificate.md).
 
@@ -19,5 +12,76 @@ The `@lukso/lsp-factory.js` package allows simple deployments of [LSP3-Universal
 ## Installation
 
 ```bash
-npm i @lukso/lsp-factory.js
+npm install @lukso/lsp-factory.js
+```
+
+## Instantiation
+
+```javascript
+import { LSPFactory } from "@lukso/lsp-factory.js";
+
+const signer = '0x...' // Private key of the account which will deploy UPs
+const provider = "https://rpc.l14.lukso.network" // RPC url used to connect to the network
+
+const lspFactory = new LSPFactory(signer, provider);
+```
+
+## Usage
+
+Deploying a Universal Profile is as simple as running 
+
+```javascript
+const myContracts = await lspFactory.ERC725UniversalProfile.deploy({
+    controllingAccounts: ['0x...'], // Account address which will controll the UP
+    lsp3Profile: myUniversalProfileData
+  });
+};
+```
+
+
+`lsp3Profile` contains the LSP3 metadata of your Universal Profile. This is the 'face' of your Universal Profile and contains all the public information people will see when they view your UP like your name, description and profile image.
+
+```javascript
+const myUniversalProfileData = {
+    name: "My Universal Profile",
+    description: "My cool Universal Profile",
+    profileImage: [
+      {
+          width: 500,
+          height: 500,
+          hashFunction: "keccak256(bytes)",
+          hash: "0x...", // bytes32 hex string of the image hash
+          url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
+      },
+    ],
+    backgroundImage: [
+      {
+          width: 500,
+          height: 500,
+          hashFunction: "keccak256(bytes)",
+          hash: "0x...", // bytes32 hex string of the image hash
+          url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
+      },
+    ],
+    tags: ['Fashion', 'Design'],
+    links: ['www.my-website.com'],
+},
+```
+
+When deploying your UP your LSP3 data will be automatically uploaded to IPFS.
+
+If you already have LSP3 data uploaded then simply pass an IPFS url:
+```javascript
+const myUniversalProfileData = 'https://ipfs.lukso.network/ipfs/QmPzUfdKhY6vfcTNDnitwKnnpm5GqjYSmw9todNVmi4bqy'
+```
+
+
+
+To create a 'faceless' Universal Profile omit the `lsp3Profile` value. This can be useful if you wish to create the LSP3 metadata later or create an anonymous UP. 
+
+
+You can now continue using your UP address
+
+```javascript
+const myUPAddress = myContracts.erc725Account.address;
 ```

--- a/docs/tools/lsp-factoryjs/reactive-deployment.md
+++ b/docs/tools/lsp-factoryjs/reactive-deployment.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 1.3
+---
+
+# Reactive Deployment
+
+LSPFactory uses [`rxjs`](https://github.com/ReactiveX/rxjs) to deploy Universal Profiles. This can be leveraged to achieve reactive deployment of Universal Profiles.
+
+Use the `reactiveDeploy` function with `subscribe` to listen for deployment events.
+
+```typescript
+let deploymentEvents = [];
+
+lspFactory.LSP3UniversalProfile
+  .deploy(// ... omitted for brevity)
+  .subscribe({
+    next: (deploymentEvent: DeploymentEvent<any>) => {
+      deploymenLogs.push(deploymentEvent);
+    },
+    complete: () => {
+      console.log(deploymentEvents);
+    },
+  });
+```
+
+The function defined in `next` will be called whenever a new deployment event is created. In this case we are simply pushing every deployment event into a `deploymentEvents` array.
+
+The function defined in `complete` will be called once after deployment is finished. Here we log the `deploymentEvents` array.
+
+
+```typescript title="console.log output"
+[
+  { type: 'PROXY',        contractName: 'ERC725Account',                                              status: 'PENDING',  transaction:  {} },
+  { type: "PROXY",        contractName: 'ERC725Account',                                              status: 'PENDING',  receipt:      {} },
+  { type: "PROXY",        contractName: 'ERC725Account',           functionName: 'initialize',        status: 'PENDING',  transaction:  {} },
+  { type: "PROXY",        contractName: 'ERC725Account',           functionName: 'initialize',        status: 'COMPLETE', receipt:      {} },
+
+  { type: 'CONTRACT',     contractName: 'KeyManager',                                                 status: 'PENDING',  transaction:  {} },
+  { type: "PROXY",        contractName: 'UniversalReceiver...',                                       status: 'PENDING',  transaction:  {} },
+  { type: 'CONTRACT',     contractName: 'KeyManager',                                                 status: 'COMPLETE', receipt:      {} },
+  { type: "PROXY",        contractName: 'UniversalReceiver...',                                       status: 'PENDING',  receipt:      {} },
+  { type: "PROXY",        contractName: 'UniversalReceiver...',    functionName: 'initialize',        status: 'PENDING',  transaction:  {} },
+  { type: "PROXY",        contractName: 'UniversalReceiver...',    functionName: 'initialize',        status: 'COMPLETE', receipt:      {} },
+
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setDataMultiple',   status: 'PENDING',  transaction:  {} },
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setDataMultiple',   status: 'COMPLETE', receipt:      {} },
+
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'transferOwnership', status: 'PENDING',  transaction:  {} },
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'transferOwnership', status: 'COMPLETE', receipt:      {} },
+];
+```
+
+## Use cases
+Reactive Deployment may be useful for certain front end behaviours to give better feedback to users when they trigger a UP deployment from a user interface. For example you may want to implement a loading bar to tell users how deployment is progressing, or display details and addresses of the contracts as they are deployed.


### PR DESCRIPTION
Adds `lsp-factory` guides for `Getting Started`, `Constructing LSP3 Data`, and `Reactive Deployment` .

Will add auto generated Technical Reference separately when updates to LspFactory are final