### PR TITLE
docs: update relayer execute docs

### DIFF
--- a/docs/tools/relayer-api/execute-transaction.md
+++ b/docs/tools/relayer-api/execute-transaction.md
@@ -119,8 +119,8 @@ const payload = {
     keyManagerAddress,
         transaction: {
             abi: abiPayload,
-            signature: signature,
-            nonce: parseInt(nonce),
+            signature,
+            nonce,
     };,
 };
 


### PR DESCRIPTION
Multi channel nonces can be very big numbers, so these should not be parsed as integers before sending to relayer.