### PR TITLE
Remove deprecated key for `SupportedStandards:`

### DIFF
--- a/docs/tools/getting-started.md
+++ b/docs/tools/getting-started.md
@@ -96,10 +96,10 @@ import { ERC725 } from '@erc725/erc725.js';
 // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
 const schema = [
   {
-    name: 'SupportedStandards:ERC725Account',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
     keyType: 'Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
   },
   {
@@ -134,7 +134,7 @@ console.log(data);
 
 ```json title="console.log(data)"
 {
-  "SupportedStandards:ERC725Account": "0xafdeb5d6",
+  "SupportedStandards:LSP3UniversalProfile": "0xabe425d6",
   "LSP3Profile": {
     "LSP3Profile": {
       "name": "My Universal Profile",


### PR DESCRIPTION
# What does this PR introduce?

**Tools > Getting Started**

Replaced deprecated key `SupportedKey:ERC725Account` by `SupportedStandards:LSP3UniversalProfile`.
This key has been deprecated since 0.2.2 version of the lsp-universalprofile-smart-contracts.