### PR TITLE
docs: fix `operator` param in `isOperatorFor` func

### DIFF
--- a/docs/contracts/digital-asset.md
+++ b/docs/contracts/digital-asset.md
@@ -139,7 +139,7 @@ Returns amount of tokens `operator` address has access to from `tokenOwner`. Ope
 | Name         | Type    | Description                               |
 | :----------- | :------ | :---------------------------------------- |
 | `tokenOwner` | address | The token owner.                          |
-| `tokenOwner` | address | The address to query operator status for. |
+| `operator`   | address | The address to query operator status for. |
 
 #### Return Values:
 


### PR DESCRIPTION
## What Changes this PR introduce ?
- [x] Remove duplicated param and replace it with the proper one. 
