### PR TITLE
fix: switch constructor method to lowercase

### DIFF
--- a/docs/standards/smart-contracts/lsp1-universal-receiver-delegate-up.md
+++ b/docs/standards/smart-contracts/lsp1-universal-receiver-delegate-up.md
@@ -20,7 +20,7 @@ In order to execute the logic written above, the **LSP0ERC725Account** contract 
 
 ## Functions
 
-### Constructor
+### constructor
 
 ```solidity
   constructor()

--- a/docs/standards/smart-contracts/lsp1-universal-receiver-delegate-vault.md
+++ b/docs/standards/smart-contracts/lsp1-universal-receiver-delegate-vault.md
@@ -16,7 +16,7 @@ It writes the **[LSP7-DigitalAsset](../nft-2.0/02-LSP7-Digital-Asset.md)** and *
 
 ## Functions
 
-### Constructor
+### constructor
 
 ```solidity
   constructor()


### PR DESCRIPTION
Mentioned by @Hugoo,  changing **constructor** method to lower case so it looks consistent in the right sidebar.