### PR TITLE
docs: Improve Standard Detection page + outputs in guides

### DIFF
--- a/docs/guides/universal-profile/01-create-profile.md
+++ b/docs/guides/universal-profile/01-create-profile.md
@@ -112,13 +112,14 @@ const web3 = new Web3();
 
 const myEOA = web3.eth.accounts.create();
 console.log(myEOA);
-// output: {
-//     address: "0x...",
-//     privateKey: "0x...",
-//     signTransaction: function(tx){...},
-//     sign: function(data){...},
-//     encrypt: function(password){...}
-// }
+
+> {
+    address: "0x...",
+    privateKey: "0x...",
+    signTransaction: function(tx){...},
+    sign: function(data){...},
+    encrypt: function(password){...}
+}
 ```
 
 Run the script above with Node.js to generate and display your EOA private key + address.
@@ -182,13 +183,14 @@ const web3 = new Web3();
 
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 const myEOA = web3.eth.accounts.privateKeyToAccount(PRIVATE_KEY);
-// {
-//     address: "0x...",
-//     privateKey: "0x...",
-//     signTransaction: function(tx){...},
-//     sign: function(data){...},
-//     encrypt: function(password){...}
-// }
+
+> {
+    address: "0x...",
+    privateKey: "0x...",
+    signTransaction: function(tx){...},
+    sign: function(data){...},
+    encrypt: function(password){...}
+}
 ```
 
 :::danger Never expose your private key!
@@ -226,20 +228,21 @@ const lspFactory = new LSPFactory(
     deployKey: PRIVATE_KEY, // or myEOA.privateKey
   },
 );
-// LSPFactory {
-//   options: {
-//     ...
-//   },
-//   DigitalAsset: DigitalAsset {
-//       ...
-//   },
-//   LSP3UniversalProfile: LSP3UniversalProfile {
-//       ...
-//   },
-//   ProxyDeployer: ProxyDeployer {
-//       ...
-//   }
-// }
+
+> LSPFactory {
+  options: {
+    ...
+  },
+  DigitalAsset: DigitalAsset {
+      ...
+  },
+  LSP3UniversalProfile: LSP3UniversalProfile {
+      ...
+  },
+  ProxyDeployer: ProxyDeployer {
+      ...
+  }
+}
 ```
 
 ### 3.3 - Deploy our Universal Profile
@@ -284,41 +287,42 @@ async function createUniversalProfile() {
 }
 
 createUniversalProfile();
-// {
-//   ERC725Account: {
-//     address: '0x...',
-//     receipt: {
-//       to: null,
-//       from: '0x...',
-//       contractAddress: '0x...',
-//       transactionIndex: 0,
-//       gasUsed: [BigNumber],
-//       logsBloom: '0x...',
-//       blockHash: '0x...',
-//       transactionHash: '0x...',
-//       logs: [],
-//       blockNumber: ...,
-//       confirmations: 1,
-//       cumulativeGasUsed: [BigNumber],
-//       status: 1,
-//       type: 0,
-//       byzantium: true,
-//       events: []
-//     }
-//   },
-//   KeyManager: {
-//     address: '0x646e989A0840CE4c3bac39d535Af736db2371107',
-//     receipt: {
-//       ...
-//     }
-//   },
-//   UniversalReceiverDelegate: {
-//     address: '0xc2f51A2891E7c78541a2CADEff9146F1E0E13E2a',
-//     receipt: {
-//       ...
-//     }
-//   }
-// }
+
+> {
+  ERC725Account: {
+    address: '0x...',
+    receipt: {
+      to: null,
+      from: '0x...',
+      contractAddress: '0x...',
+      transactionIndex: 0,
+      gasUsed: [BigNumber],
+      logsBloom: '0x...',
+      blockHash: '0x...',
+      transactionHash: '0x...',
+      logs: [],
+      blockNumber: ...,
+      confirmations: 1,
+      cumulativeGasUsed: [BigNumber],
+      status: 1,
+      type: 0,
+      byzantium: true,
+      events: []
+    }
+  },
+  KeyManager: {
+    address: '0x646e989A0840CE4c3bac39d535Af736db2371107',
+    receipt: {
+      ...
+    }
+  },
+  UniversalReceiverDelegate: {
+    address: '0xc2f51A2891E7c78541a2CADEff9146F1E0E13E2a',
+    receipt: {
+      ...
+    }
+  }
+}
 ```
 
 :::info Learn more
@@ -344,6 +348,8 @@ async function createUniversalProfile() {
 }
 
 createUniversalProfile();
+
+> my Universal Profile address: 0xFD296cCDB97C605bfdE514e9810eA05f421DEBc2
 ```
 
 We can now visualize our UP on the [universalprofile.cloud](https://universalprofile.cloud) website, by adding the address of the deployed UP in the the url, after the `/` (slash), as follow:
@@ -378,13 +384,14 @@ const web3 = new Web3();
 
 const myEOA = web3.eth.accounts.create();
 console.log(myEOA);
-// output: {
-//     address: "0x...",
-//     privateKey: "0x...",
-//     signTransaction: function(tx){...},
-//     sign: function(data){...},
-//     encrypt: function(password){...}
-// }
+
+> output: {
+    address: "0x...",
+    privateKey: "0x...",
+    signTransaction: function(tx){...},
+    sign: function(data){...},
+    encrypt: function(password){...}
+}
 ```
 
 ```javascript title="main.js"
@@ -435,4 +442,6 @@ async function createUniversalProfile() {
 }
 
 createUniversalProfile();
+
+> my Universal Profile address: 0xFD296cCDB97C605bfdE514e9810eA05f421DEBc2
 ```

--- a/docs/guides/universal-profile/02-edit-profile.md
+++ b/docs/guides/universal-profile/02-edit-profile.md
@@ -177,19 +177,21 @@ async function uploadMetadataToIPFS() {
   const uploadResult = await LSP3UniversalProfile.uploadProfileData(
     jsonFile.LSP3Profile,
   );
-  // {
-  //   profile: {
-  //     LSP3Profile: {
-  //       name: '...',
-  //       description: '...',
-  //       links: [Array],
-  //       tags: [Array],
-  //       profileImage: [Array],
-  //       backgroundImage: [Array]
-  //     }
-  //   },
-  //   url: 'ipfs://Q...'
-  // }
+
+  > {
+    profile: {
+      LSP3Profile: {
+        name: '...',
+        description: '...',
+        links: [Array],
+        tags: [Array],
+        profileImage: [Array],
+        backgroundImage: [Array]
+      }
+    },
+    url: 'ipfs://Q...'
+  }
+
   const profileMetadataIPFSUrl = uploadResult.url;
   return profileMetadataIPFSUrl;
 }
@@ -236,14 +238,15 @@ const schema = [
 const erc725 = new ERC725(schema, profileAddress, web3.currentProvider, {
   ipfsGateway: 'https://ipfs.lukso.network/ipfs/',
 });
-// ERC725 {
-//   options: {
-//     schema: [ [Object] ],
-//     address: '0x...',
-//     provider: Web3ProviderWrapper { type: 'WEB3', provider: [HttpProvider] },
-//     config: { ipfsGateway: 'https://ipfs.lukso.network/ipfs/' }
-//   }
-// }
+
+> ERC725 {
+  options: {
+    schema: [ [Object] ],
+    address: '0x...',
+    provider: Web3ProviderWrapper { type: 'WEB3', provider: [HttpProvider] },
+    config: { ipfsGateway: 'https://ipfs.lukso.network/ipfs/' }
+  }
+}
 ```
 
 ### 3.2 - Encode the LSP3Profile data
@@ -278,12 +281,13 @@ const encodedData = erc725.encodeData({
     url: profileMetadataIPFSUrl, // obtained in Step 2
   },
 });
-// {
-//   LSP3Profile: {
-//     key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
-//     value: '0x...',
-//   }
-// }
+
+> {
+  LSP3Profile: {
+    key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
+    value: '0x...',
+  }
+}
 ```
 
 ## Step 4 - Edit our Universal Profile
@@ -302,13 +306,14 @@ const web3 = new Web3('https://rpc.l14.lukso.network');
 
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 const myEOA = web3.eth.accounts.privateKeyToAccount(PRIVATE_KEY);
-// {
-//     address: "0x...",
-//     privateKey: "0x...",
-//     signTransaction: function(tx){...},
-//     sign: function(data){...},
-//     encrypt: function(password){...}
-// }
+
+> {
+    address: "0x...",
+    privateKey: "0x...",
+    signTransaction: function(tx){...},
+    sign: function(data){...},
+    encrypt: function(password){...}
+}
 ```
 
 ### 4.2 - Create instances of our Contracts

--- a/docs/standards/standard-detection.md
+++ b/docs/standards/standard-detection.md
@@ -41,9 +41,18 @@ Calling this function will return **TRUE** if the contract implements this speci
 
 ### Example
 
-A **UniversalProfile** is a contract based on **[LSP0 - ERC725Account](./universal-profile/01-lsp0-erc725account.md)** (LSP0). This means that the contract **SHOULD** implement the functions defined in the [LSP0 - ERC725Account interface](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#interface-cheat-sheet): `getData(...)`, `setData(...)`, `execute(...)`, `universalReceiver(...)`, `isValidSignature(...)` .
+A **UniversalProfile** is a contract based on **[ERC725Account](./universal-profile/01-lsp0-erc725account.md)** (LSP0). This means that the contract **SHOULD** implement the functions defined in the [ERC725Account interface](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#interface-cheat-sheet).
 
 ```javascript
+const UniversalProfile = require("@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json");
+const Web3 = require("web3");
+
+// Connect to the LUKSO L14 network
+const web3 = new Web3("https://rpc.l14.lukso.network");
+
+// Create an instance of the Universal Profile
+const myUPContract = new web3.eth.Contract(UniversalProfile.abi, "<contract-address>");
+
 const ERC725AccountInterfaceId = '0x63cb749b'
 await myUPContract.methods.supportsInterface(ERC725AccountInterfaceId).call()
 > TRUE or FALSE
@@ -76,6 +85,18 @@ Calling this function will return a specific `bytes4` value (defined in the Meta
 An **LSP7DigitalAsset** is a contract that contains ERC725Y keys defined in **[LSP4 - Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)**. This means that the contract **SHOULD** have the following ERC725Y keys set by default: `LSP4TokenName`, `LSP4TokenSymbol`, `LSP4Metadata`, `LSP4CreatorsMap:<address>` and `LSP4Creators[]`.
 
 ```javascript
+const LSP7DigitalAsset = require('@lukso/lsp-smart-contracts/artifacts/LSP7DigitalAsset.json');
+const Web3 = require('web3');
+
+// Connect to the LUKSO L14 network
+const web3 = new Web3('https://rpc.l14.lukso.network');
+
+// Create an instance of the LSP7 Token
+const myTokenContract = new web3.eth.Contract(
+  LSP7DigitalAsset.abi,
+  '<contract-address>',
+);
+
 const SupportedStandards_LSP4DigitalAsset =
   '0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624';
 (await myTokenContract.methods

--- a/docs/standards/standard-detection.md
+++ b/docs/standards/standard-detection.md
@@ -1,13 +1,13 @@
 ---
-title: 'Standard Detection'
+title: 'Standards Detection'
 sidebar_position: 2
 ---
 
-# Standard Detection
+# Standards Detection
 
 :::caution
 
-The **InterfaceId** and the **SupportedStandards:XYZ** key is not the most secure way to check for a standard, as they could be set manually.
+The **`interfaceId`** and the **`SupportedStandards:{StandardName}`** key is not the most secure way to check for a standard, as they could be set manually.
 
 :::
 
@@ -17,15 +17,68 @@ There are 2 types of standards at **LUKSO**:
 
 - **Metadata Standards**: Where we standardize a set of ERC725Y keys. i.e: [LSP3-UniversalProfile-Metadata](./universal-profile/03-lsp3-universal-profile-metadata.md), [LSP4-DigitalAsset-Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md), [LSP10ReceivedVaults](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-10-ReceivedVaults.md), etc ..
 
-## Difference between InterfaceId VS SupportedStandard Key
+![Interface and metadata standards](../../static/img/standard-detection.jpeg)
 
+These 2 types of standards are fundamental for interacting with smart contracts on the LUKSO blockchain.
 
-Checking the **InterfaceId** for a contract using [ERC165 standard](https://eips.ethereum.org/EIPS/eip-165) is equal for checking if the contract is implementing a set of functions. As for checking for the **SupportedStandards:XYZ** ERC725Y key, it's equal for checking if the contract is implementing **XYZ** related ERC725Y Keys.
+**Interface Standard** enables us to know which functions (and their parameters) can be called on a smart contract. On the other hand, **Metadata Standard** gives information about the data set by default on the contract, and which keys can be queried to retrieve such data.
+
+## Interface Detection
+
+:::success Tip
+
+For a full list of `interfaceId`s, see the section **[Contracts Implementation > Interface Ids](./smart-contracts/interface-ids)**
+
+:::
+
+> This covers how to detect if a contract implements a specific interface.
+
+We can verify if a contract implements a specific set of functions (= an **interface**) using an [`interfaceId`](./smart-contracts/interface-ids).
+
+This can be done using the function `supportsInterface(interfaceId)`, passing the `bytes4` `interfaceId` as a parameter.
+
+Calling this function will return **TRUE** if the contract implements this specific `interfaceId`, **FALSE** otherwise.
 
 ### Example
 
-![Interface and metadata standards](../../static/img/standard-detection.jpeg)
+A **UniversalProfile** is a contract based on **[LSP0 - ERC725Account](./universal-profile/01-lsp0-erc725account.md)** (LSP0). This means that the contract **SHOULD** implement the functions defined in the [LSP0 - ERC725Account interface](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#interface-cheat-sheet): `getData(...)`, `setData(...)`, `execute(...)`, `universalReceiver(...)`, `isValidSignature(...)` .
 
+```javascript
+const ERC725AccountInterfaceId = '0x63cb749b'
+await myUPContract.methods.supportsInterface(ERC725AccountInterfaceId).call()
+> TRUE or FALSE
+```
 
-**UniversalProfile** contract supports **[ERC725Account InterfaceId](./smart-contracts/interface-ids)**, this means that the contract **SHOULD** implement functions like `getData`, `setData`, `execute`, `universalReceiver`, `isValidSignature` .    
-Also it implements the **[SupportedStandards:LSP3UniversalProfile](./universal-profile/lsp3-universal-profile-metadata#supportedstandardslsp3universalprofile)** key, this means that the contract **SHOULD** implement ERC725Y keys like `LSP1UniversalReceiver`, `LSP3IssuedAssets`, `LSP5ReceivedAssets`, etc ..
+:::info
+
+See [ERC165 - Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165) for more infos.
+
+:::
+
+## Metadata Detection
+
+:::success Tip
+
+All `SupportedStandards:{StandardName}` keys can be found under each ERC725Y JSON Schema on **[erc725.js](https://github.com/ERC725Alliance/erc725.js/tree/develop/src/schemas)**.
+
+:::
+
+> This covers how to detect if a contract contains a specific set of ERC725Y in its storage.
+
+We can verify if a contract contains a certain set of ERC725 keys (= **metadata**) by checking value stored under the key `SupportedStandards:{StandardName}` in the contract storage.
+
+This can be done by calling the function `getData([SupportedStandards:{StandardName}])`, passing as a parameter the `bytes32` key of the Metadata Standard.
+
+Calling this function will return a specific `bytes4` value (defined in the Metadata Standard) if the contract has some metadata keys set by default. Otherwise, it will return an empty value.
+
+### Example
+
+An **LSP7DigitalAsset** is a contract that contains ERC725Y keys defined in **[LSP4 - Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)**. This means that the contract **SHOULD** have the following ERC725Y keys set by default: `LSP4TokenName`, `LSP4TokenSymbol`, `LSP4Metadata`, `LSP4CreatorsMap:<address>` and `LSP4Creators[]`.
+
+```javascript
+const SupportedStandards_LSP4DigitalAsset =
+  '0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624';
+(await myTokenContract.methods
+  .getData([SupportedStandards_LSP4DigitalAsset])
+  .call()) > 0xa4d96624; // valid result according to LSP4
+```

--- a/docs/standards/standard-detection.md
+++ b/docs/standards/standard-detection.md
@@ -41,7 +41,7 @@ Calling this function will return **TRUE** if the contract implements this speci
 
 ### Example
 
-A **UniversalProfile** is a contract based on **[ERC725Account](./universal-profile/01-lsp0-erc725account.md)** (LSP0). This means that the contract **SHOULD** implement the functions defined in the [ERC725Account interface](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#interface-cheat-sheet).
+A **[UniversalProfile](./universal-profile/03-lsp3-universal-profile-metadata.md)** is a contract based on **[ERC725Account](./universal-profile/01-lsp0-erc725account.md)** (LSP0). This means that the contract **SHOULD** implement the functions defined in the [ERC725Account interface](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#interface-cheat-sheet).
 
 ```javascript
 const UniversalProfile = require("@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json");
@@ -82,7 +82,7 @@ Calling this function will return a specific `bytes4` value (defined in the Meta
 
 ### Example
 
-An **LSP7DigitalAsset** is a contract that contains ERC725Y keys defined in **[LSP4 - Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)**. This means that the contract **SHOULD** have the following ERC725Y keys set by default: `LSP4TokenName`, `LSP4TokenSymbol`, `LSP4Metadata`, `LSP4CreatorsMap:<address>` and `LSP4Creators[]`.
+An **[LSP7DigitalAsset](./nft-2.0/02-LSP7-Digital-Asset.md)** is a contract that contains ERC725Y keys defined in **[LSP4 - Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)**. This means that the contract **SHOULD** have the following ERC725Y keys set by default: `LSP4TokenName`, `LSP4TokenSymbol`, `LSP4Metadata`, `LSP4CreatorsMap:<address>` and `LSP4Creators[]`.
 
 ```javascript
 const LSP7DigitalAsset = require('@lukso/lsp-smart-contracts/artifacts/LSP7DigitalAsset.json');


### PR DESCRIPTION
# What does this PR introduce?

- [x] removed comments from code snippets in guides to show outputs. Use caret `>` instead (see screenshot below).
- [x] added content + code examples for checking `interfaceId` and `SupportedStandard:{StandardName}`

![Screenshot 2022-02-01 at 14 31 23](https://user-images.githubusercontent.com/31145285/151987467-4a6ad3a6-d073-4cc9-af16-bb20bf7447b9.png)