### PR TITLE
docs: add security notice in LSP6 + LSP3Profile JSON example

### DIFF
--- a/docs/standards/universal-profile/03-lsp3-universal-profile-metadata.md
+++ b/docs/standards/universal-profile/03-lsp3-universal-profile-metadata.md
@@ -49,6 +49,55 @@ The value attached to this key is a [JSONURL encoded value](../../standards/gene
 
 Inside the JSON file, the keys `profileImage` and `backgroundImage` can accept an array of images, each defining an image with different dimensions (width + height). This is useful for client interfaces to download and serve the images with the most suitable dimensions instead of re-scale them.
 
+<details>
+    <summary>Example of JSON File linked to <code>LSP3Profile</code> key</summary>
+
+```json
+{
+  "LSP3Profile": {
+    "name": "frozeman",
+    "description": "The inventor of ERC725 and ERC20...",
+    "links": [
+      { "title": "Twitter", "url": "https://twitter.com/feindura" },
+      { "title": "lukso.network", "url": "https://lukso.network" }
+    ],
+    "tags": ["brand", "public profile"],
+    "avatar": [
+      {
+        "hashFunction": "keccak256(bytes)",
+        "hash": "0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55",
+        "url": "ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N",
+        "fileType": "fbx"
+      }
+    ],
+    "profileImage": [
+      {
+        "address": 0x1231c7436a77a009a97e48e4e10c92e89fd95fe15, // the address of an LSP7 or LSP8
+        "tokenId": 0xdde1c7436a77a009a97e48e4e10c92e89fd95fe1556fc5c62ecef57cea51aa37 // (optional) if token contract is an LSP7
+      }
+    ],
+    "backgroundImage": [
+      {
+        "width": 1800,
+        "height": 1013,
+        "hashFunction": "keccak256(bytes)",
+        "hash": "0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55",
+        "url": "ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N"
+      },
+      {
+        "width": 1024,
+        "height": 576,
+        "hashFunction": "keccak256(bytes)",
+        "hash": "0xfce1c7436a77a009a97e48e4e10c92e89fd95fe1556fc5c62ecef57cea51aa37",
+        "url": "ifps://QmZc9uMJxyUeUpuowJ7AD6MKoNTaWdVNcBj72iisRyM9Su"
+      }
+    ]
+  }
+}
+```
+
+</details>
+
 ### LSP3IssuedAssets
 
 **Universal Profiles** can create digital assets, such as tokens and NFTs. Every assets (tokens and NFTs) created should be registered in the `LSP3IssuedAssets[]` Array.

--- a/docs/standards/universal-profile/04-lsp6-key-manager.md
+++ b/docs/standards/universal-profile/04-lsp6-key-manager.md
@@ -67,6 +67,16 @@ See the section **[Permissions Values](#permission-values)** to know **what each
 
 :::
 
+:::danger
+
+**Granting permissions to the linked ERC725Account itself is dangerous! **
+
+A caller can craft a payload via `ERC725X.execute(...)` to be sent back to the KeyManager, leading to re-entrancy.
+
+Such transaction flow can lead an initial caller to use more permissions than it is originally allowed, by using the permissions granted to the linked ERC725Account's address for itself.
+
+:::
+
 An address can hold one (or more) permissions, enabling it to perform multiple _"actions"_ on an ERC725Account. Such _"actions"_ include **setting data** on the ERC725Account, **calling other contracts**, **transferring native tokens** and more.
 
 To grant permission(s) to an `<address>`, set the following key-value pair below in the [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) contract storage.


### PR DESCRIPTION
# What does this PR introduce?

- [x] add security notice in LSP6 Standard page, warning about re-entrancy issue if the account linked to the KeyManager is granted permissions.
- [x] add example of an LSP3Profile JSON file in LSP3 Standard page in a colspan.

![image](https://user-images.githubusercontent.com/31145285/161042866-91c402a8-de11-44b0-9487-31024777dd06.png)

![image](https://user-images.githubusercontent.com/31145285/161042913-0901fac5-99d6-4b5b-8d1e-c9fd63dc581c.png)
