### PR TITLE
docs: update guides + standards detection page based erc725 v3.0.0 (`getData(...)` + `setData(...)` function overloading).

### DIFF
--- a/docs/guides/fetch-data/02-read-asset-data.md
+++ b/docs/guides/fetch-data/02-read-asset-data.md
@@ -172,13 +172,15 @@ Now that we have retrieved all the owned assets, we need to check which interfac
 
 UniversalProfile contracts on the _universalprofile.cloud_ website of the LUKSO L14 Network have been deployed using different `ERC725Y` interfaces. We have to know which interface to use, to assure the right interaction and bypass errors.
 
+<!-- @todo find a way to describe the different type of interfaces here -->
+
 <Tabs>
   
   <TabItem value="Current Standads" label="Current Standards">
 
 :::info
 
-The `ERC725Y` interface function `getData(...)` accepts an array of keys: `getData(keys[])` to fetch multiple values at once.
+The `ERC725Y` interface function `getData(...)` accepts either one key an array of keys: `getData(keys[])` to fetch multiple values at once.
 
 :::
 

--- a/docs/guides/key-manager/01-give-permissions.md
+++ b/docs/guides/key-manager/01-give-permissions.md
@@ -73,20 +73,18 @@ let bobPermissions = PERMISSIONS.SETDATA;
 
 // give the permission SETDATA to Bob
 async function setBobPermission() {
-  let payload = await universalProfile.methods
-    .setData(
-      [
-        ADDRESSES.PERMISSIONS + bobAddress.substr(2), // allow Bob to setData on your UP
-        PERMISSIONS_ARRAY, // length of AddressPermissions[]
-        PERMISSIONS_ARRAY.slice(0, 34) + '00000000000000000000000000000001', // add Bob's address into the list of permissions
-      ],
-      [
-        bobPermissions,
-        3, // 3 because UP owner + Universal Receiver Delegate permission have already been set by lsp-factory
-        bobAddress,
-      ],
-    )
-    .encodeABI();
+  let payload = await universalProfile.methods['setData(bytes32[],bytes[])'](
+    [
+      ADDRESSES.PERMISSIONS + bobAddress.substr(2), // allow Bob to setData on your UP
+      PERMISSIONS_ARRAY, // length of AddressPermissions[]
+      PERMISSIONS_ARRAY.slice(0, 34) + '00000000000000000000000000000001', // add Bob's address into the list of permissions
+    ],
+    [
+      bobPermissions,
+      3, // 3 because UP owner + Universal Receiver Delegate permission have already been set by lsp-factory
+      bobAddress,
+    ],
+  ).encodeABI();
 
   keyManager
     .execute(payload)
@@ -120,18 +118,21 @@ let bobPermissions = ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32);
 
 // give the permission SETDATA to Bob
 async function setBobPermission() {
-  let payload = universalProfile.interface.encodeFunctionData('setData', [
+  let payload = universalProfile.interface.encodeFunctionData(
+    'setData(bytes32[],bytes[])',
     [
-      ADDRESSES.PERMISSIONS + bobAddress.substr(2),
-      PERMISSIONS_ARRAY, // length of AddressPermissions[]
-      PERMISSIONS_ARRAY.slice(0, 34) + '00000000000000000000000000000001', // add Bob's address into the list of
+      [
+        ADDRESSES.PERMISSIONS + bobAddress.substr(2),
+        PERMISSIONS_ARRAY, // length of AddressPermissions[]
+        PERMISSIONS_ARRAY.slice(0, 34) + '00000000000000000000000000000001', // add Bob's address into the list of
+      ],
+      [
+        bobPermissions,
+        3, // 3 because UP owner + Universal Receiver Delegate permission have already been set by lsp-factory
+        bobAddress,
+      ],
     ],
-    [
-      bobPermissions,
-      3, // 3 because UP owner + Universal Receiver Delegate permission have already been set by lsp-factory
-      bobAddress,
-    ],
-  ]);
+  );
 
   await keyManager.connect(myEOA).execute(payload);
 }

--- a/docs/guides/universal-profile/browser-extension/03-interact-with-dapp.md
+++ b/docs/guides/universal-profile/browser-extension/03-interact-with-dapp.md
@@ -179,7 +179,7 @@ const contract = new web3.eth.Contract(
 
 ```js
 await contract.methods
-  .setData([key], [value])
+  ["setData(bytes32,bytes)"](key, value)
   .send({
       from: UP_ADDRESS,
   })

--- a/docs/guides/universal-profile/create-profile.md
+++ b/docs/guides/universal-profile/create-profile.md
@@ -34,8 +34,9 @@ With the **Ownable** design pattern, a contract can be designed with _functional
 
 In the context of Universal Profile, _reading data from the contract storage can be done by anyone_. But **only the owner can**:
 
-- `setData` = add, edit or remove data from the [ERC725Y](../../standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store) storage.
-- `execute` = calling other contracts, doing LYX transfers, create other contracts (see [ERC725X](../../standards/universal-profile/lsp0-erc725account#erc725x---generic-executor) executor)
+- `setData(...)` = add, edit or remove data from the [ERC725Y](../../standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store) storage.
+- `execute(...)` = transferring LYX to addresses, calling other contracts, or create and deploy new contracts (see [ERC725X](../../standards/universal-profile/lsp0-erc725account#erc725x---generic-executor) executor)
+- `transferOwnership(...)` = make an address be the new owner of the Universal Profile.
 
 In this guide, our Universal Profile's owner will be a contract called a **Key Manager**. The [Key Manager](../../standards/smart-contracts/lsp6-key-manager.md) is a smart contract that enables to give specific permissions (_eg: _ transferring LYX on behalf of the Universal Profile) to `address`es, so that they can interact on the Universal Profile.
 

--- a/docs/guides/universal-profile/edit-profile.md
+++ b/docs/guides/universal-profile/edit-profile.md
@@ -176,7 +176,7 @@ const jsonFile = require('./UniversalProfileMetadata.json');
 async function uploadMetadataToIPFS() {
   const uploadResult = await LSP3UniversalProfile.uploadProfileData(jsonFile.LSP3Profile);
 
-    /*
+  /*
     uploadResult = {
         profile: {
             LSP3Profile: {
@@ -355,6 +355,8 @@ const myKM = new web3.eth.Contract(KeyManager.abi, keyManagerAddress);
 The final step is to edit our `LSP3Profile` key on our Universal Profile with the new value obtained in **Step 3.2**. We can easily access both the key and value from the encoded data obtained with erc725.js.
 
 Since our Universal Profile is owned by a Key Manager, the call will have to go through the Key Manager first. We then need to **encoded the setData payload** and pass it to our Universal Profile to perform this last step.
+
+<!-- @todo to be modified if we introduce setData(bytes32,bytes) as a 4th selector in the KeyManager -->
 
 ```javascript title="main.js"
 // encode the setData payload

--- a/docs/standards/standard-detection.md
+++ b/docs/standards/standard-detection.md
@@ -72,7 +72,7 @@ The **[erc725.js](https://github.com/ERC725Alliance/erc725.js/tree/develop/src/s
 
 > This section covers how to detect if a contract contains a specific set of ERC725Y in its storage.
 
-We can verify if a contract contains a specific set of ERC725 keys (= **metadata**) by checking the value stored under the key `SupportedStandards:{StandardName}` in the contract storage, via the function `getData([SupportedStandards:{StandardName}])`.
+We can verify if a contract contains a specific set of ERC725 keys (= **metadata**) by checking the value stored under the key `SupportedStandards:{StandardName}` in the contract storage, via the function `getData(SupportedStandards:{StandardName})`.
 
 Calling this function will return a specific bytes4 value (defined in the Metadata Standard) if the contract has some metadata keys set by default. Otherwise, it will return an empty value.
 
@@ -91,6 +91,6 @@ const web3 = new Web3('https://rpc.l14.lukso.network');
 const myTokenContract = new web3.eth.Contract(LSP7DigitalAsset.abi, '<contract-address>');
 
 const SupportedStandards_LSP4 = '0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624';
-await myTokenContract.methods.getData([SupportedStandards_LSP4DigitalAsset]).call();
+await myTokenContract.methods.getData(SupportedStandards_LSP4DigitalAsset).call();
 > 0xa4d96624; // valid result according to LSP4
 ```


### PR DESCRIPTION
# What does this PR introduces?


- [x] use `getData(bytes32)` in Standard detection code snippets.
- [x] use function overloading in browser extension guide
- [x] use function overloading in guide to grant permissions to addresses
- [ ] use function overloading in guides for creating + editing a Universal Profile

## Improvements

- added additional bullet point in guide for creating a Universal Profile, about `transferOwnership(...)`