### PR TITLE
docs(lsp6)!: update LSP6 interface ID + add docs for `account()` function

### DIFF
--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -20,7 +20,7 @@ The **supportsInterface** function from **[ERC165 Standard](https://eips.ethereu
 | **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |
 | **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.                   |
 | **LSP0ERC725Account**             | `0x481e0fe8` | Account that represent an identity on-chain                           |
-| **LSP6KeyManager**                | `0x6f4df48b` | Controller for the ERC725Account.                                     |
+| **LSP6KeyManager**                | `0x32e6d0ab` | Controller for the ERC725Account.                                     |
 | **LSP1UniversalReceiverDelegate** | `0xc2d7bcc1` | Universal Receiver delegated to an other smart contract.              |
 | **LSP7DigitalAsset**              | `0xe33f65c3` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
 | **LSP8IdentifiableDigitalAsset**  | `0x49399145` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -38,6 +38,26 @@ Link the Key Manager to the address of an **LSP0ERC725Account** contract and reg
 | :-------- | :------ | :----------------------------------------------------------- |
 | `account` | address | The address of the **LSP0ER725Account** contract to control. |
 
+### account
+
+```solidity
+function account() external view returns (address)
+```
+
+Returns the address of the account linked to this KeyManager
+
+This can be a contract that implements:
+
+- [ERC725X](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725x) only.
+- [ERC725Y](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725y) only.
+- any ERC725 based contract (implementing both ERC725X and ERC725Y), like a [ERC725Account](../smart-contracts/lsp0-erc725-account.md).
+
+#### Returns
+
+| Name      | Type      | Description                       |
+| --------- | --------- | --------------------------------- |
+| `account` | `address` | the address of the linked account |
+
 ### execute
 
 ```solidity


### PR DESCRIPTION
# What does this PR introduce?

> **NB:** this PR is in draft until a new release version of `@lukso/lsp-smart-contracts

This docs PR introduces changes implemented in:
- lukso-network/lsp-smart-contracts#131
- lukso-network/LIPs#71


- [x] add standard API docs for new `account()` function in LSP6.
- [x] update LSP6 interface ID to reflect those changes.
    - **before**: `0x6f4df48b`
    - **after**: `0x32e6d0ab`