### PR TITLE
build: add meta image for social links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,7 @@ module.exports = {
   projectName: 'docs', // Usually your repo name.
   plugins: ['docusaurus-plugin-sass', 'plugin-image-zoom'],
   themeConfig: {
+    image: 'img/logo.png',
     navbar: {
       title: 'LUKSO',
       logo: {


### PR DESCRIPTION
# What does this PR introduce?

add LUKSO logo as a meta image, so that it appears nicely when sharing link to the docs on social medias like Twitter or Medium.

_example from blog.soliditylang.com_ when sharing on Medium.

![image](https://user-images.githubusercontent.com/31145285/165064894-6920cf32-a8ba-4536-b797-cfa6c9829ec1.png)
