### PR TITLE
Edit `executeRelayCall(..)` function in LSP6

### DIFF
--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -20,7 +20,7 @@ _Interface IDs are not the most secure way to ensure that a contract implements 
 | **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |
 | **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.                   |
 | **LSP0ERC725Account**             | `0x481e0fe8` | Account that represent an identity on-chain                           |
-| **LSP6KeyManager**                | `0x32e6d0ab` | Controller for the ERC725Account.                                     |
+| **LSP6KeyManager**                | `0xc403d48f` | Controller for the ERC725Account.                                     |
 | **LSP1UniversalReceiverDelegate** | `0xc2d7bcc1` | Universal Receiver delegated to an other smart contract.              |
 | **LSP7DigitalAsset**              | `0xe33f65c3` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
 | **LSP8IdentifiableDigitalAsset**  | `0x49399145` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -67,7 +67,7 @@ This can be a contract that implements:
 ### execute
 
 ```solidity
-function execute(bytes memory data) public payable returns (bytes memory result)
+function execute(bytes memory _calldata) public payable returns (bytes memory result)
 ```
 
 Executes a payload on the **LSP0ERC725Account** contract.
@@ -78,9 +78,9 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 #### Parameters:
 
-| Name   | Type  | Description                 |
-| :----- | :---- | :-------------------------- |
-| `data` | bytes | The payload to be executed. |
+| Name        | Type  | Description                 |
+| :---------- | :---- | :-------------------------- |
+| `_calldata` | bytes | The payload to be executed. |
 
 #### Return Values:
 
@@ -120,9 +120,9 @@ More info about **channel** can be found here: **[What are multi-channel nonces]
 
 ```solidity
 function executeRelayCall(
+    bytes memory signature,
     uint256 nonce,
-    bytes memory data,
-    bytes memory signature
+    bytes memory _calldata
 ) public
 ```
 
@@ -134,9 +134,9 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 | Name        | Type    | Description                                       |
 | :---------- | :------ | :------------------------------------------------ |
+| `signature` | bytes   | The bytes65 ethereum signature.                   |
 | `nonce`     | uint256 | The nonce of the address that signed the message. |
-| `data`      | bytes   | The payload to be executed.                       |
-| `signature` | bytes   | The bytes32 ethereum signature.                   |
+| `_calldata` | bytes   | The payload to be executed.                       |
 
 ### isValidSignature
 

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -120,7 +120,6 @@ More info about **channel** can be found here: **[What are multi-channel nonces]
 
 ```solidity
 function executeRelayCall(
-    address signedFor,
     uint256 nonce,
     bytes memory data,
     bytes memory signature
@@ -135,7 +134,6 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 | Name        | Type    | Description                                       |
 | :---------- | :------ | :------------------------------------------------ |
-| `signedFor` | address | The KeyManager contract address.                  |
 | `nonce`     | uint256 | The nonce of the address that signed the message. |
 | `data`      | bytes   | The payload to be executed.                       |
 | `signature` | bytes   | The bytes32 ethereum signature.                   |


### PR DESCRIPTION
## What does this PR introduce?
- Change to LSP6 InterfaceId to `0xc403d48f `.
- Re-order `executeRelayCall(..)` params
- Remove `signedFor` param from `executeRelayCall(..)`.

NB: To not merge till lsp-smart-contract is released.