### PR TITLE
add notice about value transfer with staticcall and delegatecall

### DIFF
--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -114,6 +114,8 @@ _Triggers the **[ContractCreated](#contractcreated)** event when a smart contrac
 
 :::note
 The `execute(...)` function can only be called by the current owner of the contract.
+
+The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
 :::
 
 #### Parameters:
@@ -122,7 +124,7 @@ The `execute(...)` function can only be called by the current owner of the contr
 | :-------------- | :------ | :----------------------------------------------------------------------------------------------------------------------- |
 | `operationType` | uint256 | The type of operation that needs to be executed.                                                                         |
 | `to`            | address | The address to interact with. The address `to` will be unused if a contract is created (operations 1 & 2).               |
-| `value`         | uint256 | The desired value to transfer with the transaction.                                                                      |
+| `value`         | uint256 | The amount of native tokens to transfer with the transaction (in Wei).                                                                      |
 | `data`          | bytes   | The calldata (ABI-encoded payload of a function to run on an other contract), or the bytecode of the contract to deploy. |
 
 #### Return Values:

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -113,16 +113,18 @@ _Triggers the **[ContractCreated](#contractcreated)** event when a smart contrac
 
 :::note
 The `execute(...)` function can only be called by the current owner of the vault.
+
+The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
 :::
 
 #### Parameters:
 
 | Name            | Type    | Description                                                                                   |
 | :-------------- | :------ | :-------------------------------------------------------------------------------------------- |
-| `operationType` | uint256 | The operation to execute.                                                                     |
+| `operationType` | uint256 | The type of operation that needs to be executed.                                                                     |
 | `to`            | address | The address to interact with. `to` will be unused if a contract is created (operation 1 & 2). |
-| `value`         | uint256 | The desired value to transfer.                                                                |
-| `data`          | bytes   | The calldata (= abi-encoded function to execute) , or the bytecode of the contract to deploy. |
+| `value`         | uint256 | The amount of native tokens to transfer with the transaction (in Wei).                                                                |
+| `data`          | bytes   | The calldata (ABI-encoded payload of a function to run on an other contract), or the bytecode of the contract to deploy. |
 
 #### Return Values:
 

--- a/docs/standards/universal-profile/lsp0-erc725account.md
+++ b/docs/standards/universal-profile/lsp0-erc725account.md
@@ -52,8 +52,8 @@ The following types of calls (= operation types) are available:
 |        0         |          [`CALL`](https://www.evm.codes/#f1)          | call another smart contract                                                                                                             |
 |        1         |         [`CREATE`](https://www.evm.codes/#f0)         | create a new smart contract with the associated bytecode passed as `_data`                                                              |
 |        2         |  [`CREATE2`](https://eips.ethereum.org/EIPS/eip-1014)  | create a new smart contract with a **salt **(for pre-computed contract addresses)                                                       |
-|        3         | [`DELEGATECALL`](https://eips.ethereum.org/EIPS/eip-7) | run the function from another contract, but use and update the storage of the current contract (= persist `msg.sender` and `msg.value`) |
-|        4         | [`STATICCALL`](https://eips.ethereum.org/EIPS/eip-214) | call another smart contract while disallowing any modification to the state during the call                                             |
+|        3        | [`STATICCALL`](https://eips.ethereum.org/EIPS/eip-214) | call another smart contract while disallowing any modification to the state during the call                                             |
+|        4         | [`DELEGATECALL`](https://eips.ethereum.org/EIPS/eip-7) | run the function from another contract, but use and update the storage of the current contract (= persist `msg.sender` and `msg.value`) |
 
 # ![ERC725X operation type CALL](/img/standards/erc725x-operation-type-call.jpeg)
 


### PR DESCRIPTION
# What does this PR introduce?

Add the following notes in the docs following https://github.com/ERC725Alliance/ERC725/pull/108 and 0.3.2 release of ERC725 base contracts.

- [x] add notice about value transfer not being allowed with `staticcall` and `delegatecall`
- [x] replace `value` -> `amount of native tokens`
- specify **Wei** as unit for amount transferred

## Fix

- order of table for ERC725X in LSP0 (STATICCALL = 3, not 4. Same for DELEGATECALL)