### PR TITLE
Update fetch profile data guide

### DIFF
--- a/docs/guides/fetch-data/read-profile-data.md
+++ b/docs/guides/fetch-data/read-profile-data.md
@@ -189,7 +189,7 @@ To only get one specific part of information from the Universal Profile, you can
 In our case, to only read the profile's information, we can use `fetchData('LSP3Profile')`. Otherwise, you could just search trough the full JSON array from step before to extract the desired element.
 
 ```javascript title="read_profile.js"
-//...
+// ...
 
 /*
  * Specifically try fetching the @param's 
@@ -221,7 +221,7 @@ You can instantiate variables for the information you would like to process. All
     <summary>Fetch the profile's metadata</summary>
 
 ```javascript title="read_profile.js"
-//...
+// ...
 
 // Fetchable metadata information
 let name;

--- a/docs/guides/fetch-data/read-profile-data.md
+++ b/docs/guides/fetch-data/read-profile-data.md
@@ -5,10 +5,7 @@ sidebar_position: 1
 
 # Read Universal Profile Data
 
-In this guide, we will learn how to:
-
-- check the validity of the blockchain address.
-- read data from a [Universal Profile](../../standards/universal-profile/introduction.md).
+In this guide, we will learn how to read data from a [Universal Profile](../../standards/universal-profile/introduction.md).
 
 <div style={{textAlign: 'center', color: 'grey'}}>
   <img
@@ -25,6 +22,7 @@ We will use:
 - [erc725.js](../../tools/erc725js/getting-started/) library to check the interface of a profile.
 - [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) to enable you to use `fetch()` in Node.js code.
 
+
 ## Setup
 
 Open a terminal in the project's folder of your choice and install all required libraries.
@@ -32,51 +30,21 @@ Open a terminal in the project's folder of your choice and install all required 
 ```shell
 npm install web3 @erc725/erc725.js isomorphic-fetch
 ```
-
-## Step 1 - Check for valid Blockchain Address
+## Step 1 - Call the Universal Profile
 
 :::success Recommendation
 Complete "ready to use" JSON and JS files are available at the end in the [**Final Code**](#final-code) section.
 :::
 
-Within an application, the Universal Profile address is commonly used as input. We want to make sure that the address is valid in the first place. We can do a checkup by converting the value into a checksum address using the `web3.js` library.
-
-To make the guide more understandable, we use a sample profile address. You will most likely change this static variable with a dynamic value from your app's input field or fetching process.
-
-```javascript title="read_profile.js"
-// Import and Network Setup
-const Web3 = require('web3');
-const web3 = new Web3('https://rpc.l14.lukso.network');
-
-// Our static Universal Profile address
-const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
-
-/*
- * Check if input is a valid blockchain address
- *
- * @param address input
- * @return boolean result
- */
-function isValidAddress(address) {
-  const formattedAddress = web3.utils.toChecksumAddress(address);
-  return web3.utils.checkAddressChecksum(formattedAddress);
-}
-
-console.log(isValidAddress(SAMPLE_PROFILE_ADDRESS));
-// true
-```
-
-If the function `isValidAddress(...)` gives us back `true`, the address is valid and can be used.`
-
-## Step 2 - Call the Universal Profile
-
 To inspect the address and check if it has an ERC725 contract, we can call its interface through the `erc725.js` library. The instance of the contract will need the following information:
 
-- [LSP2 - ERC725Y JSON Schema](../../standards/generic-standards/lsp2-json-schema/) describes the data in the contract storage, and which keys to use to retrieve it.
+- [LSP3 - Universal Profile Metadata](../../standards/universal-profile/lsp3-universal-profile-metadata) describes the data in the Universal Profile contract storage, and which keys to use to retrieve it. We can import the schema directly from the [erc725.js](../../tools/erc725js/getting-started/) library.
 
-  - `SupportedStandards` will fetch the interface using a Metadata Standard with a key. In our case we use `SupportedStandards:LSP3UniversalProfile` to check if the contract is an Universal Profile.
-  - `LSP3Profile` fetches the data of the Universal Profile.
-  - `LSP1UniversalReceiverDelegate` will fetch received assets.
+  - `SupportedStandards` shows the interface using a Metadata Standard with a key. In our case we use `SupportedStandards:LSP3UniversalProfile` from to check if the contract is an Universal Profile.
+  - `LSP3Profile` shows the data of the Universal Profile.
+  - `LSP12IssuedAssets[]` shows assets the Universal Profile issued.
+  - `LSP5ReceivedAssets[]` shows assets the Universal Profile received.
+  - `LSP1UniversalReceiverDelegate` will point to the [Universal Receiver](../../standards/generic-standards/lsp1-universal-receiver/) of the Universal Profile.
 
 - `address`: the address of the contract
 - `provider`: a [provider](../../tools/erc725js/providers) object. Usually used with the RPC endpoint URL
@@ -84,57 +52,31 @@ To inspect the address and check if it has an ERC725 contract, we can call its i
 
 Besides the schema, we also use `isomorphic-fetch` to fetch the HTTP response from the profile while using `node` for execution. You may not need this library if you use browser environments like `ReactJS` or `VueJS`.
 
-After importing the ERC725 object and the fetch functionality, we can declare all data needed to instantiate the ERC725 contract instance. While fetching, we can use the function from the previous step to handle errors that might occur.
+After importing the ERC725 object, we can declare all data needed to instantiate the Universal Profile as ERC725 contract instance.
 
-<details>
-    <summary>ERC725 JSON Schema</summary>
+:::info
+After initializing the ERC725 profile, we can choose between calling the `getData()` or `fetchData()` function on it.
+- `getData()` will give the basic profile information with keys, names, and the values, including its hash and URL.
+- `fetchData()` will also fetch the linked data from the storage URLs and include it within the response. 
 
-```json title="erc725schema.json"
-[
-  {
-    "name": "SupportedStandards:ERC725Account",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
-    "keyType": "Mapping",
-    "valueContent": "0xafdeb5d6",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP3Profile",
-    "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
-    "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP1UniversalReceiverDelegate",
-    "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
-    "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address"
-  }
-]
-```
-
-</details>
+We will use the convenient `fetchData()` function since we only need one command to return the complete profile information list without separately grazing the storage files afterward.  
+:::
 
 ```javascript title="read_profile.js"
-// ...
-// Import and Setup
+// Import and Network Setup
+const Web3 = require('web3');
 const { ERC725 } = require('@erc725/erc725.js');
 require('isomorphic-fetch');
 
-// Parameters for ERC725 Instance
-const erc725schema = require('./erc725schema.json');
-
+// Our static variables
+const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
 const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
+const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
 
-const IPFS_GATEWAY = 'https://ipfs.lukso.network/ipfs/';
-
+// Parameters for ERC725 Instance
+const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
-
-const config = {
-  ipfsGateway: IPFS_GATEWAY,
-};
+const config = { ipfsGateway: IPFS_GATEWAY };
 
 /*
  * Try fetching the @param's Universal Provile data
@@ -143,15 +85,11 @@ const config = {
  * @return string JSON or custom error
  */
 async function getProfile(address) {
-  if (isValidAddress(address)) {
-    try {
-      const erc725 = new ERC725(erc725schema, address, provider, config);
-      return await erc725.fetchData();
-    } catch (error) {
+  try {
+    const profile = new ERC725(erc725schema, address, provider, config);
+    return await profile.fetchData();
+  } catch (error) {
       return console.log('This is not an ERC725 Contract');
-    }
-  } else {
-    return console.log('This is not an blockchain address');
   }
 }
 
@@ -167,101 +105,167 @@ If everything went fine, we now have the profile's [LSP3 - Universal Profile Met
     <summary>Show JSON response</summary>
 
 ```json
-{
-  "SupportedStandards:ERC725Account": "0xafdeb5d6",
-  "LSP3Profile": {
-    "LSP3Profile": {
-      "name": "...",
-      "links": [
-        {
-          "title": "... ",
-          "url": "..."
-        },
-        ...
-      ],
-      "description": "...",
-      "profileImage": [
-        {
-          "width": 1512,
-          "height": 1998,
-          "hashFunction": "keccak256(bytes)",
-          "hash": "0x...",
-          "url": "..."
-        },
-        ...
-      ],
-      "backgroundImage": [
-        {
-          "width": 1512,
-          "height": 1998,
-          "hashFunction": "keccak256(bytes)",
-          "hash": "0x...",
-          "url": "..."
-        },
-        ...
-      ],
-      "tags": ["sample profile"]
+[
+  {
+    "key": "...",
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "value": null
+  },
+  {
+    "key": "...",
+    "name": "LSP3Profile",
+    "value": {
+      "LSP3Profile": {
+        "name": "...",
+        "links": [
+          {
+            "title": "...",
+            "url": "..."
+          },
+          ...
+        ],
+        "description": "...",
+        "profileImage": [
+          {
+            "width": 1512,
+            "height": 1998,
+            "hashFunction": "keccak256(bytes)",
+            "hash": "0x...",
+            "url": "ipfs://..."
+          },
+          ...
+        ],
+        "backgroundImage": [
+          {
+            "width": 1512,
+            "height": 1998,
+            "hashFunction": "keccak256(bytes)",
+            "hash": "0x...",
+            "url": "ipfs://..."
+          },
+          ...
+        ],
+        "tags": [
+          "...",
+          ...
+        ]
+      }
     }
   },
-  "LSP1UniversalReceiverDelegate": "0x..."
-}
+  {
+    "key": "0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd",
+    "name": "LSP12IssuedAssets[]",
+    "value": []
+  },
+  {
+    "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
+    "name": "LSP5ReceivedAssets[]",
+    "value": []
+  },
+  {
+    "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
+    "name": "LSP1UniversalReceiverDelegate",
+    "value": "0x..."
+  }
+]
 ```
 
 </details>
 
+## Step 2 - Get the specific Profile Information
+
+With the JSON response, we can fetch all sorts of data including:
+
+- `SupportedStandards:LSP3UniversalProfile`: Check if the smart contract is an LSP3 Universal Profile
+- `LSP3Profile`: The data of the Universal Profile (name, description, tags, links, pictures)
+- `LSP12IssuedAssets[]`: Assets the Universal Profile issued
+- `LSP5ReceivedAssets[]`: Assets the Universal Profile received
+- `LSP1UniversalReceiverDelegate`: The Universal Receiver that belongs to the Universal Profile
+
+:::info
+To only get one specific part of information from the Universal Profile, you can define a specific name within the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. 
+:::
+
+In our case, to only read the profile's information, we can use `fetchData('LSP3Profile')`. Otherwise, you could just search trough the full JSON array from step before to extract the desired element.
+
+```javascript title="read_profile.js"
+//...
+
+/*
+ * Specifically try fetching the @param's 
+ * Universal Profile Metadata
+ *
+ * @param address of Universal Profile
+ * @return string JSON or custom error
+ */
+async function getProfileData(address) {
+  try {
+    const profile = new ERC725(erc725schema, address, provider, config);
+    return await profile.fetchData('LSP3Profile');
+  } catch (error) {
+      return console.log('This is not an ERC725 Contract');
+  }
+}
+
+// Debug
+getProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+  console.log(JSON.stringify(profileData, undefined, 2)),
+);
+```
+
 ## Step 3 - Read the Dataset
 
-With the JSON response, we can fetch all sorts of data:
-
-- Profile metadata
-- Pictures and their properties
-- Receiver address containing asset data
-
-Just instantiate variables for the information you would like to process. All demo fetch functions provided with this guide will come with console logs to directly see results in your terminal.
+You can instantiate variables for the information you would like to process. All demo functions provided with this guide will come with console logs to directly see results in your terminal.
 
 <details>
     <summary>Fetch the profile's metadata</summary>
 
 ```javascript title="read_profile.js"
-// ...
+//...
+
 // Fetchable metadata information
 let name;
 let description;
-
 let links = [];
 let firstLinkTitle;
 let firstLinkURL;
-
 let tags = [];
 let firstTag;
 
 /*
- * Fetch metadata information from the JSON dataset of
- * an Universal Profile
+ * Fetch the Universal Profile and extract the
+ * metadata information from its JSON dataset
  */
-async function fetchProfileData() {
-  profileData = await getProfile(SAMPLE_PROFILE_ADDRESS);
-  name = profileData.LSP3Profile.LSP3Profile.name;
-  description = profileData.LSP3Profile.LSP3Profile.description;
-
-  links = profileData.LSP3Profile.LSP3Profile.links;
-  firstLinkTitle = links[0].title;
-  firstLinkURL = links[0].url;
-
-  tags = profileData.LSP3Profile.LSP3Profile.tags;
-  firstTag = tags[0];
-
-  console.log('Name ' + name);
-  console.log('Description: ' + description + '\n');
-  console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
-  console.log('Title of first Link: ' + firstLinkTitle);
-  console.log('URL of first Link: ' + firstLinkURL + '\n');
-  console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
-  console.log('First tag: ' + firstTag + '\n');
+async function fetchProfileMetadata() {
+  try{
+    profileMetadata = await getProfileData(SAMPLE_PROFILE_ADDRESS);
+    
+    name = profileMetadata.value.LSP3Profile.name;
+    
+    description = profileMetadata.value.LSP3Profile.description;
+  
+    links = profileMetadata.value.LSP3Profile.links;
+    firstLinkTitle = links[0].title;
+    firstLinkURL = links[0].url;
+  
+    tags = profileMetadata.value.LSP3Profile.tags;
+    firstTag = tags[0];
+  
+    console.log('Name: ' + name + '\n');
+    console.log('Description: ' + description + '\n');
+    console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
+    console.log('Title of first Link: ' + firstLinkTitle);
+    console.log('URL of first Link: ' + firstLinkURL + '\n');
+    console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
+    console.log('First tag: ' + firstTag + '\n');
+    
+  } catch(e){
+    console.log('Error reading profile');
+  }
 }
 
 // Debug
-fetchProfileData();
+fetchProfileMetadata();
 ```
 
 </details>
@@ -271,39 +275,37 @@ fetchProfileData();
 
 ```javascript title="read_profile.js"
 // ...
+
 // Fetchable picture information
-let baseURL = 'https://ipfs.lukso.network/ipfs/';
-
 let backgroundImageLinks = [];
-let fullSizeBackgroundImg;
-
 let profileImageLinks = [];
+let fullSizeBackgroundImg;
 let fullSizeProfileImg;
 
 /*
- * Fetch picture information from the JSON dataset of
- * a Universal Profile
+ * Fetch the Universal Profile and extract the 
+ * picture information from its JSON dataset
  *
  * @return string Error
  */
-async function fetchPictureData() {
-  pictureData = await getProfile(SAMPLE_PROFILE_ADDRESS);
+async function fetchProfilePictures() {
+  pictureData = await getProfileData(SAMPLE_PROFILE_ADDRESS);
   let backgroundImagesIPFS =
-    pictureData.LSP3Profile.LSP3Profile.backgroundImage;
-  let profileImagesIPFS = pictureData.LSP3Profile.LSP3Profile.profileImage;
+    pictureData.value.LSP3Profile.backgroundImage;
+  let profileImagesIPFS = pictureData.value.LSP3Profile.profileImage;
 
   try {
     for (let i in backgroundImagesIPFS) {
       backgroundImageLinks.push([
         i,
-        baseURL + backgroundImagesIPFS[i].url.substring(7),
+        IPFS_GATEWAY + backgroundImagesIPFS[i].url.substring(7),
       ]);
     }
 
     for (let i in profileImagesIPFS) {
       profileImageLinks.push([
         i,
-        baseURL + profileImagesIPFS[i].url.substring(7),
+        IPFS_GATEWAY + profileImagesIPFS[i].url.substring(7),
       ]);
     }
 
@@ -329,28 +331,8 @@ async function fetchPictureData() {
   }
 }
 
-fetchPictureData();
-```
-
-</details>
-
-<details>
-    <summary>Fetch the profile's universal receiver</summary>
-
-```javascript title="read_profile.js"
-// ...
-/*
- * Fetch the address of the Universal Receiver from
- * the JSON dataset of an Universal Profile
- *
- * @return address of Universal Reveicer Delegate
- */
-async function fetchReceiverData() {
-  receiverData = await getProfile(SAMPLE_PROFILE_ADDRESS);
-  return receiverData.LSP1UniversalReceiverDelegate;
-}
-
-fetchReceiverData().then((receiverAddress) => console.log(receiverAddress));
+// Debug
+fetchProfilePictures();
 ```
 
 </details>
@@ -359,89 +341,36 @@ fetchReceiverData().then((receiverAddress) => console.log(receiverAddress));
 
 Below is the complete code snippet of this guide, with all the steps compiled together.
 
-<details>
-    <summary>ERC725 JSON Schema</summary>
-
-```json title="erc725schema.json"
-[
-  {
-    "name": "SupportedStandards:ERC725Account",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
-    "keyType": "Mapping",
-    "valueContent": "0xafdeb5d6",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP3Profile",
-    "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
-    "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP1UniversalReceiverDelegate",
-    "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
-    "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address"
-  }
-]
-```
-
-</details>
-
 ```javascript title="read_profile.js"
-// Import and Setup
+// Import and Network Setup
 const Web3 = require('web3');
 const { ERC725 } = require('@erc725/erc725.js');
 require('isomorphic-fetch');
-// Parameters for ERC725 Instance
-const erc725schema = require('./erc725schema.json');
 
-// Our static Universal Profile address
+// Our static variables
 const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
-
 const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
+const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
 
-const web3 = new Web3(RPC_ENDPOINT);
+// Parameters for ERC725 Instance
+const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
-
-const IPFS_GATEWAY = 'https://ipfs.lukso.network/ipfs/';
-
-const config = {
-  ipfsGateway: IPFS_GATEWAY,
-};
+const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Fetchable metadata information
 let name;
 let description;
-
 let links = [];
 let firstLinkTitle;
 let firstLinkURL;
-
 let tags = [];
 let firstTag;
 
 // Fetchable picture information
-let baseURL = IPFS_GATEWAY;
-
 let backgroundImageLinks = [];
-let fullSizeBackgroundImg;
-
 let profileImageLinks = [];
+let fullSizeBackgroundImg;
 let fullSizeProfileImg;
-
-/*
- * Check if input is a valid blockchain address
- *
- * @param address input
- * @return boolean result
- */
-function isValidAddress(address) {
-  let formattedAddress = web3.utils.toChecksumAddress(address);
-  return web3.utils.checkAddressChecksum(formattedAddress);
-}
 
 /*
  * Try fetching the @param's Universal Provile data
@@ -450,67 +379,86 @@ function isValidAddress(address) {
  * @return string JSON or custom error
  */
 async function getProfile(address) {
-  if (isValidAddress(address)) {
-    try {
-      const erc725 = new ERC725(erc725schema, address, provider, config);
-      return await erc725.fetchData();
-    } catch (error) {
+  try {
+    const profile = new ERC725(erc725schema, address, provider, config);
+    return await profile.fetchData();
+  } catch (error) {
       return console.log('This is not an ERC725 Contract');
-    }
-  } else {
-    return console.log('This is not an blockchain address');
   }
 }
 
 /*
- * Fetch metadata information from the JSON dataset of
- * an Universal Profile
+ * Specifically try fetching the @param's 
+ * Universal Profile Metadata
+ *
+ * @param address of Universal Profile
+ * @return string JSON or custom error
  */
-async function fetchProfileData() {
-  profileData = await getProfile(SAMPLE_PROFILE_ADDRESS);
-  name = profileData.LSP3Profile.LSP3Profile.name;
-  description = profileData.LSP3Profile.LSP3Profile.description;
-
-  links = profileData.LSP3Profile.LSP3Profile.links;
-  firstLinkTitle = links[0].title;
-  firstLinkURL = links[0].url;
-
-  tags = profileData.LSP3Profile.LSP3Profile.tags;
-  firstTag = tags[0];
-
-  console.log('Name ' + name);
-  console.log('Description: ' + description + '\n');
-  console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
-  console.log('Title of first Link: ' + firstLinkTitle);
-  console.log('URL of first Link: ' + firstLinkURL + '\n');
-  console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
-  console.log('First tag: ' + firstTag + '\n');
+async function getProfileData(address) {
+  try {
+    const profile = new ERC725(erc725schema, address, provider, config);
+    return await profile.fetchData('LSP3Profile');
+  } catch (error) {
+      return console.log('This is not an ERC725 Contract');
+  }
 }
 
 /*
- * Fetch picture information from the JSON dataset of
- * a Universal Profile
+ * Fetch the Universal Profile and extract metadata 
+ * information from it's JSON dataset
+ */
+async function fetchProfileMetadata() {
+  try{
+    profileMetadata = await getProfileData(SAMPLE_PROFILE_ADDRESS);
+    
+    name = profileMetadata.value.LSP3Profile.name;
+    
+    description = profileMetadata.value.LSP3Profile.description;
+  
+    links = profileMetadata.value.LSP3Profile.links;
+    firstLinkTitle = links[0].title;
+    firstLinkURL = links[0].url;
+  
+    tags = profileMetadata.value.LSP3Profile.tags;
+    firstTag = tags[0];
+  
+    console.log('Name: ' + name + '\n');
+    console.log('Description: ' + description + '\n');
+    console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
+    console.log('Title of first Link: ' + firstLinkTitle);
+    console.log('URL of first Link: ' + firstLinkURL + '\n');
+    console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
+    console.log('First tag: ' + firstTag + '\n');
+    
+  } catch(e){
+    console.log('Error reading profile');
+  }
+}
+
+/*
+ * Fetch the Universal Profile and extract the 
+ * picture information from its JSON dataset
  *
  * @return string Error
  */
-async function fetchPictureData() {
-  pictureData = await getProfile(SAMPLE_PROFILE_ADDRESS);
+async function fetchProfilePictures() {
+  pictureData = await getProfileData(SAMPLE_PROFILE_ADDRESS);
   let backgroundImagesIPFS =
-    pictureData.LSP3Profile.LSP3Profile.backgroundImage;
-  let profileImagesIPFS = pictureData.LSP3Profile.LSP3Profile.profileImage;
+    pictureData.value.LSP3Profile.backgroundImage;
+  let profileImagesIPFS = pictureData.value.LSP3Profile.profileImage;
 
   try {
     for (let i in backgroundImagesIPFS) {
       backgroundImageLinks.push([
         i,
-        baseURL + backgroundImagesIPFS[i].url.substring(7),
+        IPFS_GATEWAY + backgroundImagesIPFS[i].url.substring(7),
       ]);
     }
 
     for (let i in profileImagesIPFS) {
       profileImageLinks.push([
         i,
-        baseURL + profileImagesIPFS[i].url.substring(7),
+        IPFS_GATEWAY + profileImagesIPFS[i].url.substring(7),
       ]);
     }
 
@@ -536,27 +484,19 @@ async function fetchPictureData() {
   }
 }
 
-/*
- * Fetch the address of the Universal Receiver from
- * the JSON dataset of an Universal Profile
- *
- * @return address of Universal Reveicer Delegate
- */
-async function fetchReceiverData() {
-  receiverData = await getProfile(SAMPLE_PROFILE_ADDRESS);
-  return receiverData.LSP1UniversalReceiverDelegate;
-}
+
 
 // Step 1
-console.log(isValidAddress(SAMPLE_PROFILE_ADDRESS));
-
-// Step 2
 getProfile(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
+// Step 2
+getProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+  console.log(JSON.stringify(profileData, undefined, 2)),
+);
+
 // Step 3
-fetchProfileData();
-fetchPictureData();
-fetchReceiverData().then((receiverAddress) => console.log(receiverAddress));
+fetchProfileMetadata();
+fetchProfilePictures();
 ```

--- a/docs/guides/fetch-data/read-profile-data.md
+++ b/docs/guides/fetch-data/read-profile-data.md
@@ -38,7 +38,7 @@ Complete "ready to use" JSON and JS files are available at the end in the [**Fin
 
 To inspect the address and check if it has an ERC725 contract, we can call its interface through the `erc725.js` library. The instance of the contract will need the following information:
 
-- [LSP3 - Universal Profile Metadata](../../standards/universal-profile/lsp3-universal-profile-metadata) describes the data in the Universal Profile contract storage, and which keys to use to retrieve it. We can import the schema directly from the [erc725.js](../../tools/erc725js/getting-started/) library.
+- [LSP3 - Universal Profile Metadata](../../standards/universal-profile/lsp3-universal-profile-metadata) describes the data in the Universal Profile contract storage, and which keys to use to retrieve it. We can import the schema directly from the [erc725.js](../../tools/erc725js/schemas#standard-lsp-schemas) library.
 
   - `SupportedStandards` shows the interface using a Metadata Standard with a key. In our case we use `SupportedStandards:LSP3UniversalProfile` from to check if the contract is an Universal Profile.
   - `LSP3Profile` shows the data of the Universal Profile.
@@ -71,7 +71,7 @@ require('isomorphic-fetch');
 // Our static variables
 const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
 const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
-const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Parameters for ERC725 Instance
 const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
@@ -79,12 +79,12 @@ const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 /*
- * Try fetching the @param's Universal Provile data
+ * Try fetching the @param's Universal Provile
  *
  * @param address of Universal Profile
  * @return string JSON or custom error
  */
-async function getProfile(address) {
+async function fetchProfile(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
     return await profile.fetchData();
@@ -94,7 +94,7 @@ async function getProfile(address) {
 }
 
 // Debug
-getProfile(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+fetchProfile(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 ```
@@ -192,13 +192,13 @@ In our case, to only read the profile's information, we can use `fetchData('LSP3
 // ...
 
 /*
- * Specifically try fetching the @param's 
- * Universal Profile Metadata
+ * Fetch the @param's Universal Profile's 
+ * LSP3 data
  *
  * @param address of Universal Profile
  * @return string JSON or custom error
  */
-async function getProfileData(address) {
+async function fetchProfileData(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
     return await profile.fetchData('LSP3Profile');
@@ -208,134 +208,10 @@ async function getProfileData(address) {
 }
 
 // Debug
-getProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+fetchProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 ```
-
-## Step 3 - Read the Dataset
-
-You can instantiate variables for the information you would like to process. All demo functions provided with this guide will come with console logs to directly see results in your terminal.
-
-<details>
-    <summary>Fetch the profile's metadata</summary>
-
-```javascript title="read_profile.js"
-// ...
-
-// Fetchable metadata information
-let name;
-let description;
-let links = [];
-let firstLinkTitle;
-let firstLinkURL;
-let tags = [];
-let firstTag;
-
-/*
- * Fetch the Universal Profile and extract the
- * metadata information from its JSON dataset
- */
-async function fetchProfileMetadata() {
-  try{
-    profileMetadata = await getProfileData(SAMPLE_PROFILE_ADDRESS);
-    
-    name = profileMetadata.value.LSP3Profile.name;
-    
-    description = profileMetadata.value.LSP3Profile.description;
-  
-    links = profileMetadata.value.LSP3Profile.links;
-    firstLinkTitle = links[0].title;
-    firstLinkURL = links[0].url;
-  
-    tags = profileMetadata.value.LSP3Profile.tags;
-    firstTag = tags[0];
-  
-    console.log('Name: ' + name + '\n');
-    console.log('Description: ' + description + '\n');
-    console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
-    console.log('Title of first Link: ' + firstLinkTitle);
-    console.log('URL of first Link: ' + firstLinkURL + '\n');
-    console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
-    console.log('First tag: ' + firstTag + '\n');
-    
-  } catch(e){
-    console.log('Error reading profile');
-  }
-}
-
-// Debug
-fetchProfileMetadata();
-```
-
-</details>
-
-<details>
-    <summary>Fetch the profile's picture properties</summary>
-
-```javascript title="read_profile.js"
-// ...
-
-// Fetchable picture information
-let backgroundImageLinks = [];
-let profileImageLinks = [];
-let fullSizeBackgroundImg;
-let fullSizeProfileImg;
-
-/*
- * Fetch the Universal Profile and extract the 
- * picture information from its JSON dataset
- *
- * @return string Error
- */
-async function fetchProfilePictures() {
-  pictureData = await getProfileData(SAMPLE_PROFILE_ADDRESS);
-  let backgroundImagesIPFS =
-    pictureData.value.LSP3Profile.backgroundImage;
-  let profileImagesIPFS = pictureData.value.LSP3Profile.profileImage;
-
-  try {
-    for (let i in backgroundImagesIPFS) {
-      backgroundImageLinks.push([
-        i,
-        IPFS_GATEWAY + backgroundImagesIPFS[i].url.substring(7),
-      ]);
-    }
-
-    for (let i in profileImagesIPFS) {
-      profileImageLinks.push([
-        i,
-        IPFS_GATEWAY + profileImagesIPFS[i].url.substring(7),
-      ]);
-    }
-
-    fullSizeBackgroundImg = backgroundImageLinks[0][1];
-    fullSizeProfileImg = profileImageLinks[0][1];
-
-    console.log('Fullsize Background Image: ' + fullSizeBackgroundImg + '\n');
-    console.log('Fullsize Background Image: ' + fullSizeProfileImg + '\n');
-
-    console.log(
-      'Background Image Links: ' +
-        JSON.stringify(backgroundImageLinks, undefined, 2) +
-        '\n',
-    );
-
-    console.log(
-      'Background Image Links: ' +
-        JSON.stringify(profileImageLinks, undefined, 2) +
-        '\n',
-    );
-  } catch (error) {
-    return console.log('Could not fetch images');
-  }
-}
-
-// Debug
-fetchProfilePictures();
-```
-
-</details>
 
 ## Final Code
 
@@ -350,27 +226,12 @@ require('isomorphic-fetch');
 // Our static variables
 const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
 const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
-const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Parameters for ERC725 Instance
 const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
-
-// Fetchable metadata information
-let name;
-let description;
-let links = [];
-let firstLinkTitle;
-let firstLinkURL;
-let tags = [];
-let firstTag;
-
-// Fetchable picture information
-let backgroundImageLinks = [];
-let profileImageLinks = [];
-let fullSizeBackgroundImg;
-let fullSizeProfileImg;
 
 /*
  * Try fetching the @param's Universal Provile data
@@ -378,7 +239,7 @@ let fullSizeProfileImg;
  * @param address of Universal Profile
  * @return string JSON or custom error
  */
-async function getProfile(address) {
+async function fetchProfile(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
     return await profile.fetchData();
@@ -388,13 +249,13 @@ async function getProfile(address) {
 }
 
 /*
- * Specifically try fetching the @param's 
- * Universal Profile Metadata
+ * Fetch the @param's Universal Profile's 
+ * LSP3 data
  *
  * @param address of Universal Profile
  * @return string JSON or custom error
  */
-async function getProfileData(address) {
+async function fetchProfileData(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
     return await profile.fetchData('LSP3Profile');
@@ -403,100 +264,14 @@ async function getProfileData(address) {
   }
 }
 
-/*
- * Fetch the Universal Profile and extract metadata 
- * information from it's JSON dataset
- */
-async function fetchProfileMetadata() {
-  try{
-    profileMetadata = await getProfileData(SAMPLE_PROFILE_ADDRESS);
-    
-    name = profileMetadata.value.LSP3Profile.name;
-    
-    description = profileMetadata.value.LSP3Profile.description;
-  
-    links = profileMetadata.value.LSP3Profile.links;
-    firstLinkTitle = links[0].title;
-    firstLinkURL = links[0].url;
-  
-    tags = profileMetadata.value.LSP3Profile.tags;
-    firstTag = tags[0];
-  
-    console.log('Name: ' + name + '\n');
-    console.log('Description: ' + description + '\n');
-    console.log('Links: ' + JSON.stringify(links, undefined, 2) + '\n');
-    console.log('Title of first Link: ' + firstLinkTitle);
-    console.log('URL of first Link: ' + firstLinkURL + '\n');
-    console.log('Tags: ' + JSON.stringify(tags, undefined, 2) + '\n');
-    console.log('First tag: ' + firstTag + '\n');
-    
-  } catch(e){
-    console.log('Error reading profile');
-  }
-}
-
-/*
- * Fetch the Universal Profile and extract the 
- * picture information from its JSON dataset
- *
- * @return string Error
- */
-async function fetchProfilePictures() {
-  pictureData = await getProfileData(SAMPLE_PROFILE_ADDRESS);
-  let backgroundImagesIPFS =
-    pictureData.value.LSP3Profile.backgroundImage;
-  let profileImagesIPFS = pictureData.value.LSP3Profile.profileImage;
-
-  try {
-    for (let i in backgroundImagesIPFS) {
-      backgroundImageLinks.push([
-        i,
-        IPFS_GATEWAY + backgroundImagesIPFS[i].url.substring(7),
-      ]);
-    }
-
-    for (let i in profileImagesIPFS) {
-      profileImageLinks.push([
-        i,
-        IPFS_GATEWAY + profileImagesIPFS[i].url.substring(7),
-      ]);
-    }
-
-    fullSizeBackgroundImg = backgroundImageLinks[0][1];
-    fullSizeProfileImg = profileImageLinks[0][1];
-
-    console.log('Fullsize Background Image: ' + fullSizeBackgroundImg + '\n');
-    console.log('Fullsize Background Image: ' + fullSizeProfileImg + '\n');
-
-    console.log(
-      'Background Image Links: ' +
-        JSON.stringify(backgroundImageLinks, undefined, 2) +
-        '\n',
-    );
-
-    console.log(
-      'Background Image Links: ' +
-        JSON.stringify(profileImageLinks, undefined, 2) +
-        '\n',
-    );
-  } catch (error) {
-    return console.log('Could not fetch images');
-  }
-}
-
-
-
 // Step 1
-getProfile(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+fetchProfile(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
 // Step 2
-getProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
+fetchProfileData(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
-// Step 3
-fetchProfileMetadata();
-fetchProfilePictures();
 ```

--- a/docs/guides/fetch-data/read-profile-data.md
+++ b/docs/guides/fetch-data/read-profile-data.md
@@ -172,7 +172,7 @@ If everything went fine, we now have the profile's [LSP3 - Universal Profile Met
 
 </details>
 
-## Step 2 - Get the specific Profile Information
+## Step 2 - Get Specific Information
 
 With the JSON response, we can fetch all sorts of data including:
 


### PR DESCRIPTION
This PR updates the fetch data guide to the newest `erc725.js` behaviour.

- updated notes for fetchData and getData
- updated code snippets
- removed address check
- removed get Receiver Address (not needed for assets anymore)
- removed custom ABI schemes