### PR TITLE
Remove spare zero from L16 chainID

### DIFF
--- a/docs/networks/l16-testnet.md
+++ b/docs/networks/l16-testnet.md
@@ -140,12 +140,12 @@ You do not have to install Docker Compose separately
 
 ## Setting up Metamask
 
-| Setting                      | Value                                                |
-| ---------------------------- | ---------------------------------------------------- |
+| Setting                      | Value                                           |
+| ---------------------------- | ----------------------------------------------- |
 | Network Name                 | L16                                             |
 | New RPC URL                  | https://rpc.l16.lukso.network                   |
-| Chain ID                     | 2828 (0x0B0C)                                 |
-| Currency Symbol              | LYXt                                                 |
+| Chain ID                     | 2828 (0xB0C)                                    |
+| Currency Symbol              | LYXt                                            |
 | Execution Block Explorer URL | <https://explorer.execution.l16.lukso.network>  |
 
 


### PR DESCRIPTION
Old hex with the spare zero caused problems importing the chain using MetaMasks `wallet_addEthereumChain` function. Its not needed in custom imports as well, as chainID field is converted anyways.