### PR TITLE
Improve fetch digital asset guide

### DIFF
--- a/docs/guides/digital-assets/read-asset-data.md
+++ b/docs/guides/digital-assets/read-asset-data.md
@@ -8,10 +8,6 @@ import TabItem from '@theme/TabItem';
 
 # Read Asset Data
 
-:::success Recommendation
-Complete _"ready to use"_ JSON and JS files are available at the end in the [**Final Code**](#final-code) section.
-:::
-
 In this guide, we will learn how to:
 
 - Get all assets owned by a Universal Profile.
@@ -29,7 +25,7 @@ In this guide, we will learn how to:
 We will use:
 
 - [web3.js](https://web3js.readthedocs.io/en/v1.7.0/) for utility as well as connecting to the LUKSO L14 or L16 network.
-- [erc725.js](../../tools/erc725js/getting-started/) library to check the interface of a profile.
+- [erc725.js](../../tools/erc725js/getting-started/) library to fetch the asset metadata.
 - [lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts) to integrate the ABIs for the LUKSO Standards.
 
 ## Setup
@@ -45,7 +41,7 @@ npm install web3 @erc725/erc725.js @lukso/lsp-smart-contracts
 <Tabs>
   <TabItem value="Current Standard" label="Current Standard">
 
-In the [**Read Profile Data** guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch all the assets owned by the Universal Profile by fetching using the `LSP5ReceivedAssets[]` key.
+In the [**Read Profile Data** guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch all the assets owned by the Universal Profile by calling `fetchData` and passing the `LSP5ReceivedAssets[]` key.
 
 :::info
 This same method can also be used to fetch all assets a Universal Profile has ever issued by using the `LSP12IssuedAssets[]` key.
@@ -91,6 +87,11 @@ console.log(ownedAssets);
   <TabItem value="Legacy Standard" label="Legacy Standard">
 
 In the [previous guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch the address of the [Universal Receiver](../../standards/generic-standards/lsp1-universal-receiver/) by using `fetchData("LSP1UniversalReceiverDelegate")`.
+
+:::caution
+If using erc725.js in a NodeJS environment you may need to install and import [`isomorphic-fetch`](https://www.npmjs.com/package/isomorphic-fetch) to use the `fetchData()` method.
+
+:::
 
 ```javascript title="read_assets.js"
 // Import and network setup
@@ -176,7 +177,7 @@ console.log(receivedAssets),
 
 ## Step 2 - Fetch the asset metadata
 
-Now we can safely retrieve the metadata for the asset address. The [LSP4](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) metadata is saved under the ERC725Y key-value store of the digital asset. We need to input the correct data key to fetch the associated value. There are multiple [LSP4 keys](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) for different properties.
+Now we can retrieve the metadata for the asset address. The [LSP4](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) metadata is saved under the ERC725Y key-value store of the digital asset. We need to input the correct data key to fetch the associated value. There are multiple [LSP4 keys](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) for different properties.
 
 - `LSP4TokenName`
 - `LSP4TokenSymbol`
@@ -192,15 +193,21 @@ import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 // ...
 
 // Instantiate the asset
-const digitalAsset = new ERC725(
-  LSP4Schema,
-  SAMPLE_ASSET_ADDRESS,
-  provider,
-  config,
-);
+const digitalAsset = new ERC725(LSP4Schema, ownedAssets[0], provider, config);
 
 // Get the encoded data
 const decodedAssetMetadata = await digitalAsset.fetchData('LSP4Metadata');
+```
+
+To get the metadata of all owned assets we can iterate through the `ownedAssets` array.
+
+```javascript
+const ownedAssetsMetadata = await ownedAssets.map(async (ownedAsset) => {
+  const digitalAsset = new ERC725(LSP4Schema, ownedAsset, provider, config);
+
+  return await digitalAsset.fetchData('LSP4Metadata');
+});
+
 ```
 
 ## Final Code
@@ -212,21 +219,14 @@ Below is the complete code snippet of this guide, with all the steps compiled to
   <TabItem value="Current Standards" label="Current Standards">
 
 ```javascript title="read_assets.js"
-// Imports
-import Web3 from "web3";
-import { ERC725 } from "@erc725/erc725.js";
-import "isomorphic-fetch";
-import erc725schema from "@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json";
-import LSP4schema from "@erc725/erc725.js/schemas/LSP4DigitalAsset.json";
-import LSP8 from "@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json";
-import LSP4 from "@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json";
-import { ERC725Y_INTERFACE_IDS } from "@erc725/erc725.js/build/main/src/lib/constants";
+// Import and network setup
+import { ERC725 } from '@erc725/erc725.js';
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
+import Web3 from 'web3';
 
-// Sample addresses
+// Static variables
 const SAMPLE_PROFILE_ADDRESS = '0xa907c1904c22DFd37FF56c1f3c3d795682539196';
-const SAMPLE_ASSET_ADDRESS = '0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353';
-
-// Network and storage
 const RPC_ENDPOINT = 'https://rpc.l16.lukso.network';
 const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
 
@@ -234,222 +234,26 @@ const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
-// Setup Web3
-const web3 = new Web3('https://rpc.l16.lukso.network');
-
-// Data keys for asset properties
-const TokenNameKey = LSP4schema[1].key;
-const TokenSymbolKey = LSP4schema[2].key;
-const MetaDataKey = LSP4schema[3].key;
-const CreatorsKey = LSP4schema[4].key;
-
-/*
- * Fetch the LSP5 data of the Universal Profile
- * to get its ever received assets
- *
- * @param address of the Universal Profile
- * @return address[] of received assets or custom error
- */
-async function fetchReceivedAssets(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData('LSP5ReceivedAssets[]');
-    return result.value;
-  } catch (error) {
-    return console.log('This is not an ERC725 Contract');
-  }
-}
-
-/*
- * Fetch the ever issued assets from
- * the Universal Profile
- *
- * @param address of the Universal Profile
- * @return address[] of the issued assets or custom error
- */
-async function fetchIssuedAssets(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData('LSP12IssuedAssets[]');
-    return result.value;
-  } catch (error) {
-    return console.log('This is not an ERC725 Contract');
-  }
-}
-
-/*
- * Return an array of assets
- * that are owned by the
- * Universal Profile.
- *
- * @param owner of the Universal Profile
- * @return address[] of owned assets
- */
-async function fetchOwnedAssets(owner) {
-  const digitalAssets = await fetchReceivedAssets(owner);
-  const ownedAssets = [];
-
-  for (let i = 0; i < digitalAssets.length; i++) {
-    // Create instance of the asset to check owner balance
-    const LSP8Contract = new web3.eth.Contract(LSP8.abi, digitalAssets[i]);
-
-    const isCurrentOwner = await LSP8Contract.methods.balanceOf(owner).call();
-    if (isCurrentOwner > 0) {
-      ownedAssets[ownedAssets.length] = digitalAssets[i];
-    }
-  }
-  return ownedAssets;
-}
-
-/*
- * Check the ERC725Y interface of an asset
- *
- * @param assetAddress of the smart contract
- * @return boolean isERC725Y
- */
-async function checkErc725YInterfaceId(assetAddress) {
-  // Create an instance of the asset
-  const asset = new web3.eth.Contract(LSP4.abi, assetAddress);
-
-  let isERC725Y = false;
-
-  // Check if the contract has a key-value store
-  try {
-    isERC725Y = await asset.methods
-      .supportsInterface(ERC725Y_INTERFACE_IDS['3.0'])
-      .call();
-  } catch (error) {
-    console.log('Address could not be checked for ERC725Y interface');
-  }
-
-  return isERC725Y;
-}
-
-/*
- * Get the dataset of an asset
- *
- * @param data key of the property to fetch
- * @return string of the encoded data
- */
-async function getAssetData(key, address) {
-  try {
-    // Instantiate the asset
-    const digitalAsset = new web3.eth.Contract(LSP4.abi, address);
-
-    // Get the encoded data
-    return await digitalAsset.methods['getData(bytes32)'](key).call();
-  } catch (error) {
-    return console.error('Data of assets address could not be loaded');
-  }
-}
-
-/*
- * Decode the value from ERC725Y storage
- * based on its data key and phrase
- *
- * @param data key of the asset property to fetch
- * @param encodedData as string
- * @return JSON of the decoded data
- */
-async function decodeAssetData(keyName, encodedData) {
-  try {
-    // Instanciate the asset
-    const digitalAsset = new ERC725(
-      LSP4schema,
-      SAMPLE_ASSET_ADDRESS,
-      provider,
-      config,
-    );
-
-    // Decode the assets data
-    return digitalAsset.decodeData({
-      keyName: keyName,
-      value: encodedData,
-    });
-  } catch (error) {
-    console.log('Data of an asset could not be decoded');
-  }
-}
-
-/*
- * Create a fetchable storage link that
- * was embeded into the decoded asset data
- *
- * @param decodedAssetMetadata as JSON
- * @return string of asset data URL
- */
-async function getMetaDataLink(decodedAssetMetadata) {
-  try {
-    // Generate IPFS link from decoded metadata
-    return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
-  } catch (error) {
-    console.log('URL could not be fetched');
-  }
-}
-
-/*
- * Fetch the asset data from the provided
- * storage link
- *
- * @param dataURL as string
- * @return string with asset data as JSON
- */
-async function fetchAssetData(dataURL) {
-  try {
-    const response = await fetch(dataURL);
-    return await response.json();
-  } catch (error) {
-    console.log('JSON data of IPFS link could not be fetched');
-  }
-}
-
-// Step 1
-fetchReceivedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2)),
+// Fetch the LSP5 data of the Universal Profile to get its owned assets
+const profile = new ERC725(
+  UniversalProfileSchema,
+  SAMPLE_PROFILE_ADDRESS,
+  provider,
+  config,
 );
 
-// Step 2
-fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2)),
-);
+const result = await profile.fetchData('LSP5ReceivedAssets[]');
+const ownedAssets = result.value;
 
-// Step 2
-fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
-  console.log(ownedAssets),
-);
+const ownedAssetsMetadata = await ownedAssets.map(async (ownedAsset) => {
+  // Instantiate the asset
+  const digitalAsset = new ERC725(LSP4Schema, ownedAsset, provider, config);
 
-// Step 4
-checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isERC725Y) =>
-  console.log(isERC725Y),
-);
-
-// Step 5
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData),
-);
-
-// Step 6
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData),
-  );
+  // Get the encoded data
+  return await digitalAsset.fetchData('LSP4Metadata');
 });
 
-// Step 7
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => console.log(dataURL));
-  });
-});
-
-// Step 8
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => {
-      fetchAssetData(dataURL).then((assetJSON) => console.log(assetJSON));
-    });
-  });
-});
+console.log(ownedAssetsMetadata);
 ```
 
   </TabItem>
@@ -479,370 +283,61 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
 
 </details>
 
-<details>
-<summary>ERC725 Legacy Schema</summary>
-
-```json title="erc725_legacy_minimal_schema.json"
-[
-  {
-    "name": "LSP3IssuedAssets[]",
-    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-    "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
-  }
-]
-```
-
-</details>
-
-<details>
-  <summary>LSP4 Legacy ABI</summary>
-
-```json title="lsp4_legacy_minimal_abi.json"
-[
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "outputs": [
-      {
-        "type": "bool",
-        "name": "",
-        "internalType": "bool"
-      }
-    ],
-    "name": "supportsInterface",
-    "inputs": [
-      {
-        "type": "bytes4",
-        "name": "interfaceId",
-        "internalType": "bytes4"
-      }
-    ]
-  }
-]
-```
-
-</details>
-
-<details>
-    <summary>ERC725 Legacy ABI</summary>
-
-```json title="erc725_legacy_minimal_abi.json"
-[
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_keys",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getData",
-    "outputs": [
-      {
-        "internalType": "bytes",
-        "name": "values",
-        "type": "bytes"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  }
-]
-```
-
-</details>
-
 ```javascript title="read_assets.js"
-// Imports
-import Web3 from "web3";
-import { ERC725 } from "@erc725/erc725.js";
-import "isomorphic-fetch";
-import erc725schema from "@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json";
-import LSP8 from "@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json";
-import LSP4schema from "@erc725/erc725.js/schemas/LSP4DigitalAsset.json";
+// Import and network setup
+import { ERC725 } from '@erc725/erc725.js';
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
+import Web3 from 'web3';
+import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json';
 
-// Legacy ABIs and schemas
-import LSP1MinimalABI from "./lsp1_legacy_minimal_abi.json";
-import LSP4MinimalABI from "./lsp4_legacy_minimal_abi.json";
-import ERC725MinimalABI from "./erc725_legacy_minimal_abi.json";
-import ERC725LegacySchema from "./erc725_legacy_minimal_schema.json";
-
-// Sample addresses
-const SAMPLE_ASSET_ADDRESS = '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78';
+// Static variables
 const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
-
-// Network and storage
 const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
 const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
-
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
-// Setup Web3
-const web3 = new Web3('https://rpc.l14.lukso.network');
-
-// Data keys for asset properties
-const TokenNameKey = LSP4schema[1].key;
-const TokenSymbolKey = LSP4schema[2].key;
-const MetaDataKey = LSP4schema[3].key;
-const CreatorsKey = LSP4schema[4].key;
-
-/*
- * Fetch the LSP5 data of the Universal Profile
- * to get its ever received assets
- *
- * @param address of the Universal Profile
- * @return address[] of received assets or custom error
- */
-async function fetchUniversalReceiverAddress(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData('LSP1UniversalReceiverDelegate');
-    return result.value;
-  } catch (error) {
-    return console.log('This is not an ERC725 Contract');
-  }
-}
-
-/*
- * Get all received assets from the
- * Universal Receiver of the
- * Universal Profile.
- *
- * @param address of the Universal Receiver
- * @return address[] of the received assets
- */
-async function fetchReceivedAssets(receiverAddress) {
-  const universalReceiver = new web3.eth.Contract(
-    LSP1MinimalABI,
-    receiverAddress,
-  );
-
-  let rawValues = [];
-
-  try {
-    // Fetch all raw values
-    rawValues = await universalReceiver.methods.getAllRawValues().call();
-  } catch (error) {
-    return console.log('Data from universal receiver could not be loaded');
-  }
-
-  const receivedAssets = [];
-
-  // Retrieve addresses
-  for (let i = 0; i < rawValues.length; i++) {
-    receivedAssets[i] = web3.utils.toChecksumAddress(rawValues[i].substr(26));
-  }
-  return receivedAssets;
-}
-
-/*
- * Fetch the ever issued assets from
- * the Universal Profile
- *
- * @param address of the Universal Profile
- * @return address[] of the issued assets or custom error
- */
-async function fetchIssuedAssets(address) {
-  try {
-    const profile = new ERC725(ERC725LegacySchema, address, provider, config);
-    const result = await profile.getData('LSP3IssuedAssets[]');
-    return result.value;
-  } catch (error) {
-    return console.log('Issued assets could not be fetched');
-  }
-}
-
-/*
- * Return an array of assets
- * that are owned by the
- * Universal Profile.
- *
- * @param owner of the Universal Profile
- * @return address[] of owned assets
- */
-async function fetchOwnedAssets(owner) {
-  const receiverAddress = await fetchUniversalReceiverAddress(owner);
-  const digitalAssets = await fetchReceivedAssets(receiverAddress);
-  const ownedAssets = [];
-
-  for (let i = 0; i < digitalAssets.length; i++) {
-    // Create instance of the asset to check owner balance
-    const LSP8Contract = new web3.eth.Contract(LSP8.abi, digitalAssets[i]);
-
-    const isCurrentOwner = await LSP8Contract.methods.balanceOf(owner).call();
-    if (isCurrentOwner > 0) {
-      ownedAssets[ownedAssets.length] = digitalAssets[i];
-    }
-  }
-  return ownedAssets;
-}
-
-/*
- * Check the ERC725Y interface of an asset
- *
- * @param assetAddress of the smart contract
- * @return boolean isERC725YLegacy
- */
-
-async function checkErc725YInterfaceId(address) {
-  // Create an instance of the asset
-  const asset = new web3.eth.Contract(LSP4MinimalABI, address);
-
-  const erc725YLegacyInterfaceId = '0x2bd57b73';
-  let isERC725YLegacy = false;
-
-  // Check if the contract is a legacy key-value store interface
-  try {
-    isERC725YLegacy = await asset.methods
-      .supportsInterface(erc725YLegacyInterfaceId)
-      .call();
-    return isERC725YLegacy;
-  } catch (error) {
-    console.log('Address could not be checked for ERC725YLegacy interface');
-  }
-  return isERC725YLegacy;
-}
-
-/*
- * Get the dataset of an asset
- *
- * @param data key of the property to fetch
- * @return string of the encoded data
- */
-async function getAssetData(key, address) {
-  try {
-    // Instanciate asset
-    const digitalAsset = new web3.eth.Contract(ERC725MinimalABI, address);
-
-    // Fetch the encoded data
-    return await digitalAsset.methods.getData(key).call();
-  } catch (error) {
-    return console.log('Data of assets address could not be loaded');
-  }
-}
-
-/*
- * Decode the value from ERC725Y storage
- * based on its data key and phrase
- *
- * @param data key of the asset property to fetch
- * @param encodedData as string
- * @return JSON of the decoded data
- */
-async function decodeAssetData(keyName, encodedData) {
-  try {
-    // Instanciate the asset
-    const digitalAsset = new ERC725(
-      LSP4schema,
-      SAMPLE_ASSET_ADDRESS,
-      provider,
-      config,
-    );
-
-    // Decode the assets data
-    return digitalAsset.decodeData({
-      keyName: keyName,
-      value: encodedData,
-    });
-  } catch (error) {
-    console.log('Data of an asset could not be decoded');
-  }
-}
-
-/*
- * Create a fetchable storage link that
- * was embeded into the decoded asset data
- *
- * @param decodedAssetMetadata as JSON
- * @return string of asset data URL
- */
-async function getMetaDataLink(decodedAssetMetadata) {
-  try {
-    // Generate IPFS link from decoded metadata
-    return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
-  } catch (error) {
-    console.log('URL could not be fetched');
-  }
-}
-
-/*
- * Fetch the asset data from the provided
- * storage link
- *
- * @param dataURL as string
- * @return string with asset data as JSON
- */
-async function fetchAssetData(dataURL) {
-  try {
-    const response = await fetch(dataURL);
-    return await response.json();
-  } catch (error) {
-    console.log('JSON data of IPFS link could not be fetched');
-  }
-}
-
-// Step 1.1
-fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) =>
-  console.log(receiverAddress),
+// Fetch the LSP1 data of the Universal Profile to get its Universal Receiver
+const profile = new ERC725(
+  UniversalProfileSchema,
+  SAMPLE_PROFILE_ADDRESS,
+  provider,
+  config,
 );
 
-// Step 1.2
-fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then(
-  (receiverAddress) => {
-    fetchReceivedAssets(receiverAddress).then((receivedAssets) =>
-      console.log(receivedAssets),
-    );
-  },
+const result = await profile.fetchData('LSP1UniversalReceiverDelegate');
+const universalReceiverAddress = result.value;
+
+const web3 = new Web3(RPC_ENDPOINT);
+
+// Get all received assets from the Universal Receiver of the Universal Profile.
+const universalReceiver = new web3.eth.Contract(
+  LSP1MinimalABI,
+  receiverAddress,
 );
 
-// Step 2
-fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((issuedAssets) =>
-  console.log(issuedAssets),
-);
+// Fetch all raw values
+const rawValues = await universalReceiver.methods.getAllRawValues().call();
 
-// Step 2
-checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
-  console.log(isLegacy),
-);
-
-// Step 4
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData),
-);
-
-// Step 5
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData),
-  );
+// Convert raw values to addresses
+const ownedAssets = rawValues.map((returnedRawValue) => {
+  return web3.utils.toChecksumAddress(returnedRawValue.substr(26));
 });
 
-// Step 6
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => console.log(dataURL));
-  });
+const ownedAssetsMetadata = await ownedAssets.map(async (ownedAsset) => {
+  // Instantiate the asset
+  const digitalAsset = new ERC725(LSP4Schema, ownedAsset, provider, config);
+
+  // Get the encoded data
+  return await digitalAsset.fetchData('LSP4Metadata');
 });
 
-// Step 7
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => {
-      fetchAssetData(dataURL).then((assetJSON) => console.log(assetJSON));
-    });
-  });
-});
+console.log(ownedAssetsMetadata);
 ```
 
   </TabItem>
 
 </Tabs>
-
-<!-- Links and References -->
-
-[function overloading]: https://docs.soliditylang.org/en/v0.8.13/contracts.html?highlight=function%20overloading#function-overloading

--- a/docs/guides/digital-assets/read-asset-data.md
+++ b/docs/guides/digital-assets/read-asset-data.md
@@ -14,9 +14,8 @@ Complete _"ready to use"_ JSON and JS files are available at the end in the [**F
 
 In this guide, we will learn how to:
 
-- get all assets ever received by a profile.
-- get all assets ever issued by a profile.
-- fetch the data of all owned assets.
+- get all assets owned by a Universal Profile.
+- fetch the metadata of all owned assets.
 
 <div style={{textAlign: 'center', color: 'grey'}}>
   <img
@@ -31,7 +30,6 @@ We will use:
 
 - [web3.js](https://web3js.readthedocs.io/en/v1.7.0/) for utility as well as connecting to the LUKSO L14 or L16 network.
 - [erc725.js](../../tools/erc725js/getting-started/) library to check the interface of a profile.
-- [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) to enable you to use `fetch()` in Node.js code.
 - [lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts) to integrate the ABIs for the LUKSO Standards.
 
 ## Setup
@@ -39,7 +37,7 @@ We will use:
 Open a terminal in the project's folder of your choice and install all required libraries.
 
 ```shell
-npm install web3 @erc725/erc725.js isomorphic-fetch @lukso/lsp-smart-contracts
+npm install web3 @erc725/erc725.js @lukso/lsp-smart-contracts
 ```
 
 ## Step 1 - Get all owned assets
@@ -48,6 +46,16 @@ npm install web3 @erc725/erc725.js isomorphic-fetch @lukso/lsp-smart-contracts
   <TabItem value="Current Standard" label="Current Standard">
 
 In the [**Read Profile Data** guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch all the assets owned by the Universal Profile by fetching the `LSP5ReceivedAssets[]` metadata.
+
+:::info
+This same method can also be used to fetch all assets a Universal Profile has ever issued by using the `LSP12IssuedAssets[]` key.
+
+:::
+
+:::caution
+If using erc725.js in a NodeJS environment you may need to install and import [`isomorphic-fetch`](https://www.npmjs.com/package/isomorphic-fetch) to use the `fetchData()` method.
+
+:::
 
 ```javascript title="read_assets.js"
 // Import and network setup
@@ -71,6 +79,7 @@ const profile = new ERC725(
   provider,
   config,
 );
+
 const result = await profile.fetchData('LSP5ReceivedAssets[]');
 const ownedAssets = result.value;
 
@@ -105,6 +114,7 @@ const profile = new ERC725(
   provider,
   config,
 );
+
 const result = await profile.fetchData('LSP1UniversalReceiverDelegate');
 const universalReceiverAddress = result.value;
 ```
@@ -164,180 +174,7 @@ console.log(receivedAssets),
   </TabItem>
 </Tabs>
 
-## Step 2 - Get all assets ever issued
-
-<Tabs>
-  <TabItem value="Current Standard" label="Current Standard">
-
-Using same method we used to fetch received assets, we can fetch all assets ever created by the Universal Profile by fetching the `LSP12IssuedAssets[]` metadata using the [erc725.js](../../tools/erc725js/getting-started/) library.
-
-```javascript title="read_assets.js"
-// ...
-
-// Fetch the ever issued assets from the Universal Profile
-const profile = new ERC725(UniversalProfileSchema, address, provider, config);
-const result = await profile.fetchData('LSP12IssuedAssets[]');
-const issuedAssets = result.value;
-
-console.log(issuedAssets),
-```
-
-  </TabItem>
-  <TabItem value="Legacy Standard" label="Legacy Standard">
-
-<details>
-<summary>ERC725 Legacy Schema</summary>
-
-```json title="erc725_legacy_minimal_schema.json"
-[
-  {
-    "name": "LSP3IssuedAssets[]",
-    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-    "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
-  }
-]
-```
-
-</details>
-
-```javascript title="read_assets.js"
-import ERC725LegacySchema from './erc725_legacy_minimal_schema.json';
-
-// ...
-
-// Fetch the ever issued assets from the Universal Profile
-const profile = new ERC725(ERC725LegacySchema, address, provider, config);
-const result = await profile.getData('LSP3IssuedAssets[]');
-const issuedAssets = result.value;
-
-console.log(issuedAssets);
-```
-
-  </TabItem>
-</Tabs>
-
-## Step 3 - Check the type of an asset
-
-Now that we have retrieved all the owned assets, we need to check which interface is behind these smart contract addresses, to get their data.
-
-UniversalProfile contracts on the [profile explorer](https://universalprofile.cloud/) on the LUKSO L14 test network have been deployed using different `ERC725Y` interfaces. We have to know which interface to use, to assure the right interaction and bypass errors.
-
-<Tabs>
-  
-  <TabItem value="Current Standards" label="Current Standards">
-
-:::info
-
-By using [function overloading], the `ERC725Y` interface function `getData(...)` can accept:
-
-- either one data key: `getData(key)` to fetch a single value.
-- or an array of data keys: `getData(keys[])` to fetch multiple values at once.
-
-:::
-
-```javascript title="read_assets.js"
-
-import LSP4 from '@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json';
-import { ERC725Y_INTERFACE_IDS} from '@erc725/erc725.js/build/main/src/lib/constants';
-
-// ...
-
-const SAMPLE_ASSET_ADDRESS = '0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353';
-
-// Check the ERC725Y interface of an asset
-// Create an instance of the asset
-const asset = new web3.eth.Contract(LSP4.abi, SAMPLE_ASSET_ADDRESS);
-
-
-// Check if the contract supports the ERC725Y interface
-const isERC725Y = await asset.methods.supportsInterface(ERC725Y_INTERFACE_IDS['3.0']).call();
-
-console.log(isERC725Y)
-```
-
-  </TabItem>
-
-  <TabItem value="Legacy Standards" label="Legacy Standards">
-
-:::info
-
-While using the **legacy** `ERC725Y` interface, `getData(...)` only takes one data single key: `getData(key)`.
-
-:::
-
-<details>
-  <summary>LSP4 Legacy ABI</summary>
-
-```json title="lsp4_legacy_minimal_abi.json"
-[
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "outputs": [
-      {
-        "type": "bool",
-        "name": "",
-        "internalType": "bool"
-      }
-    ],
-    "name": "supportsInterface",
-    "inputs": [
-      {
-        "type": "bytes4",
-        "name": "interfaceId",
-        "internalType": "bytes4"
-      }
-    ]
-  }
-]
-```
-
-</details>
-
-```javascript title="read_assets.js"
-// ...
-
-const SAMPLE_ASSET_ADDRESS = '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78';
-const LSP4MinimalABI = require('./lsp4_legacy_minimal_abi.json');
-
-/*
- * Check the ERC725Y interface of an asset
- *
- * @param assetAddress of the smart contract
- * @return boolean isERC725YLegacy
- */
-
-async function checkErc725YInterfaceId(address) {
-  // Create an instance of the asset
-  const asset = new web3.eth.Contract(LSP4MinimalABI, address);
-
-  const erc725YLegacyInterfaceId = '0x2bd57b73';
-  let isERC725YLegacy = false;
-
-  // Check if the contract is a legacy key-value store interface
-  try {
-    isERC725YLegacy = await asset.methods
-      .supportsInterface(erc725YLegacyInterfaceId)
-      .call();
-    return isERC725YLegacy;
-  } catch (error) {
-    console.log('Address could not be checked for ERC725YLegacy interface');
-  }
-  return isERC725YLegacy;
-}
-
-// Debug
-checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
-  console.log(isLegacy),
-);
-```
-
-  </TabItem>
-</Tabs>
-
-## Step 4 - Receive the encoded asset data
+## Step 2 - Fetch the asset metadata
 
 Now we can safely retrieve the metadata for the asset address. The [LSP4](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) metadata is saved under the ERC725Y key-value store of the digital asset. We need to input the correct data key to fetch the associated value. There are multiple [LSP4 keys](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) for different properties.
 
@@ -348,292 +185,23 @@ Now we can safely retrieve the metadata for the asset address. The [LSP4](../../
 
 In this guide, we will use the `LSP4Metadata` key to read the asset metadata.
 
-<Tabs>
-
-  <TabItem value="Current Standards" label="Current Standards">
-
 ```javascript title="read_assets.js"
-// ...
-
 // ABIs
-const LSP4schema = require('@erc725/erc725.js/schemas/LSP4DigitalAsset.json');
+import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 
-// Data keys for asset properties
-const TokenNameKey = LSP4schema[1].key;
-const TokenSymbolKey = LSP4schema[2].key;
-const MetaDataKey = LSP4schema[3].key;
-const CreatorsKey = LSP4schema[4].key;
+// ...
 
-/*
- * Get the dataset of an asset
- *
- * @param data key of the property to fetch
- * @return string of the encoded data
- */
-async function getAssetData(key, address) {
-  try {
-    // Instantiate the asset
-    const digitalAsset = new web3.eth.Contract(LSP4.abi, address);
-
-    // Get the encoded data
-    return await digitalAsset.methods['getData(bytes32)'](key).call();
-  } catch (error) {
-    return console.error('Data of assets address could not be loaded');
-  }
-}
-
-// Debug
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData),
+// Instantiate the asset
+const digitalAsset = new ERC725(
+  LSP4Schema,
+  SAMPLE_ASSET_ADDRESS,
+  provider,
+  config,
 );
+
+// Get the encoded data
+const decodedAssetMetadata = await digitalAsset.fetchData('LSP4Metadata');
 ```
-
-  </TabItem>
-  
-  <TabItem value="Legacy Standards" label="Legacy Standards">
-
-<details>
-    <summary>ERC725 Legacy ABI</summary>
-
-```json title="erc725_legacy_minimal_abi.json"
-[
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_keys",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getData",
-    "outputs": [
-      {
-        "internalType": "bytes",
-        "name": "values",
-        "type": "bytes"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  }
-]
-```
-
-</details>
-
-```javascript title="read_assets.js"
-// ...
-
-// ABIs
-const ERC725MinimalABI = require('./erc725_legacy_minimal_abi.json');
-const LSP4schema = require('@erc725/erc725.js/schemas/LSP4DigitalAsset.json');
-
-// Data keys for asset properties
-const TokenNameKey = LSP4schema[1].key;
-const TokenSymbolKey = LSP4schema[2].key;
-const MetaDataKey = LSP4schema[3].key;
-const CreatorsKey = LSP4schema[4].key;
-
-/*
- * Get the dataset of an asset
- *
- * @param data key of the property to fetch
- * @return string of the encoded data
- */
-async function getAssetData(key, address) {
-  try {
-    // Instanciate asset
-    const digitalAsset = new web3.eth.Contract(ERC725MinimalABI, address);
-
-    // Fetch the encoded data
-    return await digitalAsset.methods.getData(key).call();
-  } catch (error) {
-    return console.log('Data of assets address could not be loaded');
-  }
-}
-
-// Debug
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData),
-);
-```
-
-  </TabItem>
-
-</Tabs>
-
-## Step 5 - Decode the asset data
-
-We can now decode the encoded metadata to fetch readable information. We use
-the `decodeData()` function from the [`erc725.js`](../../tools/erc725js/classes/ERC725#decodedata) library. We will continue the step before and showcase decoding the `LSP4Metadata` key.
-
-```javascript title="read_assets.js"
-// ...
-
-/*
- * Decode the value from ERC725Y storage
- * based on its data key and phrase
- *
- * @param data key of the asset property to fetch
- * @param encodedData as string
- * @return JSON of the decoded data
- */
-async function decodeAssetData(keyName, encodedData) {
-  try {
-    // Instance the asset
-    const digitalAsset = new ERC725(
-      LSP4schema,
-      SAMPLE_ASSET_ADDRESS,
-      provider,
-      config,
-    );
-
-    // Decode the assets data
-    return digitalAsset.decodeData({
-      keyName: keyName,
-      value: encodedData,
-    });
-  } catch (error) {
-    console.log('Data of an asset could not be decoded');
-  }
-}
-
-// Debug
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData),
-  );
-});
-```
-
-The [LSP4 Digital Asset Metadata](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) will resolve in a following JSON structure:
-
-<details>
-    <summary>Show Metadata JSON response</summary>
-
-```json
-{
-  "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
-  "name": "LSP4Metadata",
-  "value": {
-    "hashFunction": "keccak256(utf8)",
-    "hash": "0x...",
-    "url": "ipfs:..."
-  }
-}
-```
-
-</details>
-
-## Step 6 - Create the storage link
-
-To fetch the data for the previously decoded metadata, we can access the JSON file and change the URL to access its properties. You may not need this library if you use browser environments like `ReactJS` or `VueJS`.
-
-:::info
-Profiles created on the [Profile Explorer](https://universalprofile.cloud/) currently use IPFS. Therefore, we will use a static IPFS link for the guide. If there are several storage solutions, you can change them or make distinctions.
-:::
-
-```javascript title="read_assets.js"
-// ...
-
-/*
- * Create a fetchable storage link that
- * was embeded into the decoded asset data
- *
- * @param decodedAssetMetadata as JSON
- * @return string of asset data URL
- */
-async function getMetaDataLink(decodedAssetMetadata) {
-  try {
-    // Generate IPFS link from decoded metadata
-    return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
-  } catch (error) {
-    console.log('URL could not be fetched');
-  }
-}
-
-// Debug
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => console.log(dataURL));
-  });
-});
-```
-
-## Step 7 - Get the asset data
-
-We can now access the created storage link through a simple URL call and are using `isomorphic-fetch` to read the HTTP response from the asset URL in our `node` environment.
-
-:::note
-You may not need the `isomorphic-fetch` library if you use browser environments like `ReactJS` or `VueJS`.
-:::
-
-```javascript title="read_assets.js"
-// ...
-
-/*
- * Fetch the asset data from the provided
- * storage link
- *
- * @param dataURL as string
- * @return JSON of asset data
- */
-async function fetchAssetData(dataURL) {
-  try {
-    const response = await fetch(dataURL);
-    return await response.json();
-  } catch (error) {
-    console.log('JSON data of IPFS link could not be fetched');
-  }
-}
-
-// Debug
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
-  decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
-    getMetaDataLink(decodedData).then((dataURL) => {
-      fetchAssetData(dataURL).then((assetJSON) => console.log(assetJSON));
-    });
-  });
-});
-```
-
-For fetching `LSP4Metadata`, the JSON file will have the following structure:
-
-<details>
-    <summary>Show JSON response</summary>
-
-```json
-{
-  "LSP4Metadata": {
-    "description": "...",
-    "links": [
-      ...
-    ],
-    "images": [
-      [
-        {
-          "width": 1512,
-          "height": 1998,
-          "hashFunction": "keccak256(bytes)",
-          "hash": "0x...",
-          "url": "..."
-        },
-        ...
-      ]
-    ],
-    "assets": [
-      {
-        "hash": "0x...",
-        "hashFunction": "keccak256(bytes)",
-        "fileType": "...",
-        "url": "..."
-      }
-    ]
-  }
-}
-```
-
-</details>
 
 ## Final Code
 
@@ -847,7 +415,7 @@ fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
   console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
-// Step 3
+// Step 2
 fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
   console.log(ownedAssets),
 );
@@ -1238,7 +806,7 @@ fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((issuedAssets) =>
   console.log(issuedAssets),
 );
 
-// Step 3
+// Step 2
 checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
   console.log(isLegacy),
 );

--- a/docs/guides/digital-assets/read-asset-data.md
+++ b/docs/guides/digital-assets/read-asset-data.md
@@ -42,51 +42,39 @@ Open a terminal in the project's folder of your choice and install all required 
 npm install web3 @erc725/erc725.js isomorphic-fetch @lukso/lsp-smart-contracts
 ```
 
-## Step 1 - Get all assets ever received
+## Step 1 - Get all owned assets
 
 <Tabs>
   <TabItem value="Current Standard" label="Current Standard">
 
-In the [**Read Profile Data** guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library.  In the same way, we can now fetch all ever received assets using `fetchData('LSP5ReceivedAssets[]')`.
+In the [**Read Profile Data** guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch all the assets owned by the Universal Profile by fetching the `LSP5ReceivedAssets[]` metadata.
 
 ```javascript title="read_assets.js"
-
 // Import and network setup
-const Web3 = require("web3");
-const { ERC725 } = require("@erc725/erc725.js");
-require("isomorphic-fetch");
+import { ERC725 } from '@erc725/erc725.js';
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import Web3 from 'web3';
 
 // Static variables
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = '0xa907c1904c22DFd37FF56c1f3c3d795682539196';
+const RPC_ENDPOINT = 'https://rpc.l16.lukso.network';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Parameters for the ERC725 instance
-const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
-/*
- * Fetch the LSP5 data of the Universal Profile
- * to get its ever received assets
- *
- * @param address of the Universal Profile
- * @return address[] of received assets or custom error
- */
-async function fetchReceivedAssets(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP5ReceivedAssets[]")
-    return result.value;
-  } catch (error) {
-    return console.log("This is not an ERC725 Contract");
-  }
-}
-
-// Debug
-fetchReceivedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2))
+// Fetch the LSP5 data of the Universal Profile to get its owned assets
+const profile = new ERC725(
+  UniversalProfileSchema,
+  SAMPLE_PROFILE_ADDRESS,
+  provider,
+  config,
 );
+const result = await profile.fetchData('LSP5ReceivedAssets[]');
+const ownedAssets = result.value;
+
+console.log(ownedAssets);
 ```
 
   </TabItem>
@@ -96,43 +84,29 @@ fetchReceivedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
 In the [previous guide](../universal-profile/read-profile-data), we learned how to read the Universal Profile properties and use the data key names with the `fetchData()` function of the [erc725.js](../../tools/erc725js/getting-started/) library. In the same way, we can now fetch the address of the [Universal Receiver](../../standards/generic-standards/lsp1-universal-receiver/) by using `fetchData("LSP1UniversalReceiverDelegate")`.
 
 ```javascript title="read_assets.js"
-
 // Import and network setup
-const Web3 = require("web3");
-const { ERC725 } = require("@erc725/erc725.js");
-require("isomorphic-fetch");
+import { ERC725 } from '@erc725/erc725.js';
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import Web3 from 'web3';
 
 // Static variables
-const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
-const RPC_ENDPOINT = "https://rpc.l14.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
+const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Parameters for the ERC725 instance
-const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
- /*
- * Fetch the LSP1 data of the Universal Profile
- * to get its Universal Receiver
- *
- * @param address of the Universal Profile
- * @return address of Universal Receiver or custom error
- */
-async function fetchUniversalReceiverAddress(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP1UniversalReceiverDelegate")
-    return result.value;
-  } catch (error) {
-    return console.log("This is not an ERC725 Contract");
-  }
-}
-
-// Debug
-fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) =>
-  console.log(receiverAddress)
+// Fetch the LSP1 data of the Universal Profile to get its Universal Receiver
+const profile = new ERC725(
+  UniversalProfileSchema,
+  SAMPLE_PROFILE_ADDRESS,
+  provider,
+  config,
 );
+const result = await profile.fetchData('LSP1UniversalReceiverDelegate');
+const universalReceiverAddress = result.value;
 ```
 
 Using the Universal Receiver address, we can now call the `getAllRawValues()` function on this contract to retrieve an array of received assets.
@@ -161,53 +135,32 @@ Using the Universal Receiver address, we can now call the `getAllRawValues()` fu
 </details>
 
 ```javascript title="read_assets.js"
+// ABI for the Universal Receiver
+import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json';
 
 // ...
 
-// ABI for the Universal Receiver
-const LSP1MinimalABI = require("./lsp1_legacy_minimal_abi.json");
-const web3 = new Web3("https://rpc.l14.lukso.network");
+const web3 = new Web3('https://rpc.l14.lukso.network');
 
-/*
- * Get all received assets from the 
- * Universal Receiver of the 
- * Universal Profile.
- * 
- * @param address of the Universal Receiver
- * @return address[] of the received assets
- */
-async function fetchReceivedAssets(receiverAddress) {
-  const universalReceiver = new web3.eth.Contract(
-    LSP1MinimalABI,
-    receiverAddress
-  );
+// Get all received assets from the Universal Receiver of the Universal Profile.
+const universalReceiver = new web3.eth.Contract(
+  LSP1MinimalABI,
+  receiverAddress,
+);
 
-  let rawValues = [];
 
-  try {
+// Fetch all raw values
+const rawValues = await universalReceiver.methods.getAllRawValues().call();
 
-    // Fetch all raw values
-    rawValues = await universalReceiver.methods.getAllRawValues().call();
-  } catch (error) {
-    return console.log("Data from universal receiver could not be loaded");
-  }
-
-  const receivedAssets = [];
-
-  // Retrieve addresses
-  for (let i = 0; i < rawValues.length; i++) {
-    receivedAssets[i] = web3.utils.toChecksumAddress(rawValues[i].substr(26));
-  }
-  return receivedAssets;
-}
-
-// Debug
-fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) => {
-  fetchReceivedAssets(receiverAddress).then((receivedAssets) =>
-    console.log(receivedAssets)
-  );
+// Convert raw values to addresses
+const receivedAssets = rawValues.map((returnedRawValue) => {
+  return web3.utils.toChecksumAddress(returnedRawValue.substr(26));
 });
+
+console.log(receivedAssets),
+
 ```
+
   </TabItem>
 </Tabs>
 
@@ -216,33 +169,17 @@ fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) => 
 <Tabs>
   <TabItem value="Current Standard" label="Current Standard">
 
-The same way, we fetched received assets, we can fetch all ever issued assets with the `fetchData('LSP12IssuedAssets[]')` function from the [erc725.js](../../tools/erc725js/getting-started/) library.
+Using same method we used to fetch received assets, we can fetch all assets ever created by the Universal Profile by fetching the `LSP12IssuedAssets[]` metadata using the [erc725.js](../../tools/erc725js/getting-started/) library.
 
 ```javascript title="read_assets.js"
-
 // ...
 
-/*
- * Fetch the ever issued assets from 
- * the Universal Profile
- *
- * @param address of the Universal Profile
- * @return address[] of the issued assets or custom error
- */
-async function fetchIssuedAssets(address) {
-  try {
-    const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP12IssuedAssets[]");
-    return result.value;
-  } catch (error) {
-    return console.log("This is not an ERC725 Contract");
-  }
-}
+// Fetch the ever issued assets from the Universal Profile
+const profile = new ERC725(UniversalProfileSchema, address, provider, config);
+const result = await profile.fetchData('LSP12IssuedAssets[]');
+const issuedAssets = result.value;
 
-// Debug
-fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2))
-);
+console.log(issuedAssets),
 ```
 
   </TabItem>
@@ -253,153 +190,35 @@ fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
 
 ```json title="erc725_legacy_minimal_schema.json"
 [
-    {
-       "name":"LSP3IssuedAssets[]",
-       "key":"0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-       "keyType":"Array",
-       "valueContent":"Address",
-       "valueType":"address"
-    }
+  {
+    "name": "LSP3IssuedAssets[]",
+    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+    "keyType": "Array",
+    "valueContent": "Address",
+    "valueType": "address"
+  }
 ]
 ```
 
 </details>
 
 ```javascript title="read_assets.js"
+import ERC725LegacySchema from './erc725_legacy_minimal_schema.json';
 
 // ...
 
-const ERC725LegacySchema = require("./erc725_legacy_minimal_schema.json");
+// Fetch the ever issued assets from the Universal Profile
+const profile = new ERC725(ERC725LegacySchema, address, provider, config);
+const result = await profile.getData('LSP3IssuedAssets[]');
+const issuedAssets = result.value;
 
-/*
- * Fetch the ever issued assets from
- * the Universal Profile
- *
- * @param address of the Universal Profile
- * @return address[] of the received assets or custom error
-*/
-async function fetchIssuedAssets(address) {
-  try {
-    const profile = new ERC725(ERC725LegacySchema, address, provider, config);
-    const result = await profile.getData("LSP3IssuedAssets[]");
-    return result.value;
-  } catch (error) {
-    return console.log("Issued assets could not be fetched");
-  }
-}
-
-fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((issuedAssets) =>
-  console.log(issuedAssets)
-);
+console.log(issuedAssets);
 ```
 
   </TabItem>
 </Tabs>
 
-## Step 3 - Check ownership of assets
-
-After receiving a list of asset addresses, we can check which assets are owned by the Universal Profile. We can do this by comparing the balances of the assets within the receiver contract. If the `balance` is greater than zero, the asset is still owned by the address.
-
-:::info Difference between Token Ownership
-
-- For [LSP7](../../standards/nft-2.0/LSP7-Digital-Asset.md), you will get back the amount of tokens you own.
-- For [LSP8](../../standards/nft-2.0/LSP8-Identifiable-Digital-Asset.md), you will get back the number of NFTs you own (without knowing which specific tokenId you own).
-
-:::
-
-<Tabs>
-
-<TabItem value="Current Standard" label="Current Standard">
-
-```javascript title="read_assets.js"
-
-// ...
-
-// ABI for the asset
-const LSP8 = require("@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json");
-
-// New Web3 instance for LUKSO L16
-const web3 = new Web3("https://rpc.l16.lukso.network");
-
-/*
- * Return an array of assets  
- * that are owned by the
- * Universal Profile.
- *
- * @param owner of the Universal Profile
- * @return address[] of owned assets
- */
-async function fetchOwnedAssets(owner) {
-  const digitalAssets = await fetchReceivedAssets(owner);
-  const ownedAssets = [];
-
-  for (let i = 0; i < digitalAssets.length; i++) {
-    
-    // Create instance of the asset to check owner balance
-    const LSP8Contract = new web3.eth.Contract(LSP8.abi, digitalAssets[i]);
-
-    const isCurrentOwner = await LSP8Contract.methods.balanceOf(owner).call();
-    if (isCurrentOwner > 0) {
-      ownedAssets[ownedAssets.length] = digitalAssets[i];
-    }
-  }
-  return ownedAssets;
-}
-
-// Debug
-fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
-  console.log(ownedAssets)
-);
-```
-
-</TabItem>
-<TabItem value="Legacy Standard" label="Legacy Standard">
-
-```javascript title="read_assets.js"
-
-// ...
-
-// ABI for the asset
-const LSP8 = require("@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json");
-
-/*
- * Return an array of assets  
- * that are owned by the
- * Universal Profile.
- *
- * @param owner of the Universal Profile
- * @return address[] of owned assets
- */
-async function fetchOwnedAssets(owner) {
-  const receiverAddress = await fetchUniversalReceiverAddress(owner);
-  const digitalAssets = await fetchReceivedAssets(receiverAddress);
-  const ownedAssets = [];
-
-  for (let i = 0; i < digitalAssets.length; i++) {
-    
-    // Create instance of the asset to check owner balance
-    const LSP8Contract = new web3.eth.Contract(LSP8.abi, digitalAssets[i]);
-
-    const isCurrentOwner = await LSP8Contract.methods.balanceOf(owner).call();
-    if (isCurrentOwner > 0) {
-      ownedAssets[ownedAssets.length] = digitalAssets[i];
-    }
-  }
-  return ownedAssets;
-}
-
-// Debug
-fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
-  console.log(ownedAssets)
-);
-```
-
-</TabItem>
-
-</Tabs>
-
-
-## Step 4 - Check the type of an asset
+## Step 3 - Check the type of an asset
 
 Now that we have retrieved all the owned assets, we need to check which interface is behind these smart contract addresses, to get their data.
 
@@ -420,41 +239,22 @@ By using [function overloading], the `ERC725Y` interface function `getData(...)`
 
 ```javascript title="read_assets.js"
 
+import LSP4 from '@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json';
+import { ERC725Y_INTERFACE_IDS} from '@erc725/erc725.js/build/main/src/lib/constants';
+
 // ...
 
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
-const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
-const {
-  ERC725Y_INTERFACE_IDS,
-} = require("@erc725/erc725.js/build/main/src/lib/constants");
+const SAMPLE_ASSET_ADDRESS = '0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353';
 
-/*
- * Check the ERC725Y interface of an asset
- *
- * @param assetAddress of the smart contract
- * @return boolean isERC725Y
- */
-async function checkErc725YInterfaceId(assetAddress) {
-  // Create an instance of the asset
-  const asset = new web3.eth.Contract(LSP4.abi, assetAddress);
+// Check the ERC725Y interface of an asset
+// Create an instance of the asset
+const asset = new web3.eth.Contract(LSP4.abi, SAMPLE_ASSET_ADDRESS);
 
-  let isERC725Y = false;
 
-  // Check if the contract has a key-value store
-  try {
-    isERC725Y = await asset.methods
-      .supportsInterface(ERC725Y_INTERFACE_IDS["3.0"])
-      .call();
-  } catch (error) {
-    console.log("Address could not be checked for ERC725Y interface");
-  }
-  return isERC725Y;
-}
+// Check if the contract supports the ERC725Y interface
+const isERC725Y = await asset.methods.supportsInterface(ERC725Y_INTERFACE_IDS['3.0']).call();
 
-// Debug
-checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isERC725Y) =>
-  console.log(isERC725Y)
-);
+console.log(isERC725Y)
 ```
 
   </TabItem>
@@ -497,11 +297,10 @@ While using the **legacy** `ERC725Y` interface, `getData(...)` only takes one da
 </details>
 
 ```javascript title="read_assets.js"
-
 // ...
 
-const SAMPLE_ASSET_ADDRESS = "0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78";
-const LSP4MinimalABI = require("./lsp4_legacy_minimal_abi.json");
+const SAMPLE_ASSET_ADDRESS = '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78';
+const LSP4MinimalABI = require('./lsp4_legacy_minimal_abi.json');
 
 /*
  * Check the ERC725Y interface of an asset
@@ -514,7 +313,7 @@ async function checkErc725YInterfaceId(address) {
   // Create an instance of the asset
   const asset = new web3.eth.Contract(LSP4MinimalABI, address);
 
-  const erc725YLegacyInterfaceId = "0x2bd57b73";
+  const erc725YLegacyInterfaceId = '0x2bd57b73';
   let isERC725YLegacy = false;
 
   // Check if the contract is a legacy key-value store interface
@@ -524,21 +323,21 @@ async function checkErc725YInterfaceId(address) {
       .call();
     return isERC725YLegacy;
   } catch (error) {
-    console.log("Address could not be checked for ERC725YLegacy interface");
+    console.log('Address could not be checked for ERC725YLegacy interface');
   }
   return isERC725YLegacy;
 }
 
 // Debug
 checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
-  console.log(isLegacy)
+  console.log(isLegacy),
 );
 ```
 
   </TabItem>
 </Tabs>
 
-## Step 5 - Receive the encoded asset data
+## Step 4 - Receive the encoded asset data
 
 Now we can safely retrieve the metadata for the asset address. The [LSP4](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) metadata is saved under the ERC725Y key-value store of the digital asset. We need to input the correct data key to fetch the associated value. There are multiple [LSP4 keys](../../standards/nft-2.0/LSP4-Digital-Asset-Metadata) for different properties.
 
@@ -554,7 +353,6 @@ In this guide, we will use the `LSP4Metadata` key to read the asset metadata.
   <TabItem value="Current Standards" label="Current Standards">
 
 ```javascript title="read_assets.js"
-
 // ...
 
 // ABIs
@@ -574,20 +372,19 @@ const CreatorsKey = LSP4schema[4].key;
  */
 async function getAssetData(key, address) {
   try {
-
     // Instantiate the asset
     const digitalAsset = new web3.eth.Contract(LSP4.abi, address);
 
     // Get the encoded data
-    return await digitalAsset.methods["getData(bytes32)"](key).call();
+    return await digitalAsset.methods['getData(bytes32)'](key).call();
   } catch (error) {
-    return console.error("Data of assets address could not be loaded");
+    return console.error('Data of assets address could not be loaded');
   }
 }
 
 // Debug
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData)
+  console.log(encodedData),
 );
 ```
 
@@ -625,12 +422,11 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
 </details>
 
 ```javascript title="read_assets.js"
-
 // ...
 
 // ABIs
-const ERC725MinimalABI = require("./erc725_legacy_minimal_abi.json");
-const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
+const ERC725MinimalABI = require('./erc725_legacy_minimal_abi.json');
+const LSP4schema = require('@erc725/erc725.js/schemas/LSP4DigitalAsset.json');
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;
@@ -645,25 +441,20 @@ const CreatorsKey = LSP4schema[4].key;
  * @return string of the encoded data
  */
 async function getAssetData(key, address) {
-  
   try {
+    // Instanciate asset
+    const digitalAsset = new web3.eth.Contract(ERC725MinimalABI, address);
 
-      // Instanciate asset
-      const digitalAsset = new web3.eth.Contract(
-        ERC725MinimalABI,
-        address
-      );
-
-      // Fetch the encoded data
-      return await digitalAsset.methods.getData(key).call();
+    // Fetch the encoded data
+    return await digitalAsset.methods.getData(key).call();
   } catch (error) {
-    return console.log("Data of assets address could not be loaded");
+    return console.log('Data of assets address could not be loaded');
   }
 }
 
 // Debug
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData)
+  console.log(encodedData),
 );
 ```
 
@@ -671,14 +462,12 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
 
 </Tabs>
 
-## Step 6 - Decode the asset data
+## Step 5 - Decode the asset data
 
 We can now decode the encoded metadata to fetch readable information. We use
 the `decodeData()` function from the [`erc725.js`](../../tools/erc725js/classes/ERC725#decodedata) library. We will continue the step before and showcase decoding the `LSP4Metadata` key.
 
-
 ```javascript title="read_assets.js"
-
 // ...
 
 /*
@@ -691,13 +480,12 @@ the `decodeData()` function from the [`erc725.js`](../../tools/erc725js/classes/
  */
 async function decodeAssetData(keyName, encodedData) {
   try {
-
     // Instance the asset
     const digitalAsset = new ERC725(
       LSP4schema,
       SAMPLE_ASSET_ADDRESS,
       provider,
-      config
+      config,
     );
 
     // Decode the assets data
@@ -706,14 +494,14 @@ async function decodeAssetData(keyName, encodedData) {
       value: encodedData,
     });
   } catch (error) {
-    console.log("Data of an asset could not be decoded");
+    console.log('Data of an asset could not be decoded');
   }
 }
 
 // Debug
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
   decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData)
+    console.log(decodedData),
   );
 });
 ```
@@ -725,19 +513,19 @@ The [LSP4 Digital Asset Metadata](../../standards/nft-2.0/LSP4-Digital-Asset-Met
 
 ```json
 {
-  key: '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
-  name: 'LSP4Metadata',
-  value: {
-    hashFunction: 'keccak256(utf8)',
-    hash: '0x...',
-    url: 'ipfs:...'
+  "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
+  "name": "LSP4Metadata",
+  "value": {
+    "hashFunction": "keccak256(utf8)",
+    "hash": "0x...",
+    "url": "ipfs:..."
   }
 }
 ```
 
 </details>
 
-## Step 7 - Create the storage link
+## Step 6 - Create the storage link
 
 To fetch the data for the previously decoded metadata, we can access the JSON file and change the URL to access its properties. You may not need this library if you use browser environments like `ReactJS` or `VueJS`.
 
@@ -749,7 +537,7 @@ Profiles created on the [Profile Explorer](https://universalprofile.cloud/) curr
 // ...
 
 /*
- * Create a fetchable storage link that 
+ * Create a fetchable storage link that
  * was embeded into the decoded asset data
  *
  * @param decodedAssetMetadata as JSON
@@ -760,7 +548,7 @@ async function getMetaDataLink(decodedAssetMetadata) {
     // Generate IPFS link from decoded metadata
     return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
   } catch (error) {
-    console.log("URL could not be fetched");
+    console.log('URL could not be fetched');
   }
 }
 
@@ -772,7 +560,7 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
 });
 ```
 
-## Step 8 - Get the asset data
+## Step 7 - Get the asset data
 
 We can now access the created storage link through a simple URL call and are using `isomorphic-fetch` to read the HTTP response from the asset URL in our `node` environment.
 
@@ -781,11 +569,10 @@ You may not need the `isomorphic-fetch` library if you use browser environments 
 :::
 
 ```javascript title="read_assets.js"
-
 // ...
 
 /*
- * Fetch the asset data from the provided 
+ * Fetch the asset data from the provided
  * storage link
  *
  * @param dataURL as string
@@ -796,7 +583,7 @@ async function fetchAssetData(dataURL) {
     const response = await fetch(dataURL);
     return await response.json();
   } catch (error) {
-    console.log("JSON data of IPFS link could not be fetched");
+    console.log('JSON data of IPFS link could not be fetched');
   }
 }
 
@@ -857,33 +644,32 @@ Below is the complete code snippet of this guide, with all the steps compiled to
   <TabItem value="Current Standards" label="Current Standards">
 
 ```javascript title="read_assets.js"
-
 // Imports
-const Web3 = require("web3");
-const { ERC725 } = require("@erc725/erc725.js");
-require("isomorphic-fetch");
-const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
-const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
-const LSP8 = require("@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json");
-const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
+const Web3 = require('web3');
+const { ERC725 } = require('@erc725/erc725.js');
+require('isomorphic-fetch');
+const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
+const LSP4schema = require('@erc725/erc725.js/schemas/LSP4DigitalAsset.json');
+const LSP8 = require('@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json');
+const LSP4 = require('@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json');
 const {
   ERC725Y_INTERFACE_IDS,
-} = require("@erc725/erc725.js/build/main/src/lib/constants");
+} = require('@erc725/erc725.js/build/main/src/lib/constants');
 
 // Sample addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
+const SAMPLE_PROFILE_ADDRESS = '0xa907c1904c22DFd37FF56c1f3c3d795682539196';
+const SAMPLE_ASSET_ADDRESS = '0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353';
 
 // Network and storage
-const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const RPC_ENDPOINT = 'https://rpc.l16.lukso.network';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3('https://rpc.l16.lukso.network');
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;
@@ -901,27 +687,27 @@ const CreatorsKey = LSP4schema[4].key;
 async function fetchReceivedAssets(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP5ReceivedAssets[]")
+    const result = await profile.fetchData('LSP5ReceivedAssets[]');
     return result.value;
   } catch (error) {
-    return console.log("This is not an ERC725 Contract");
+    return console.log('This is not an ERC725 Contract');
   }
 }
 
 /*
-* Fetch the ever issued assets from
-* the Universal Profile
-*
-* @param address of the Universal Profile
+ * Fetch the ever issued assets from
+ * the Universal Profile
+ *
+ * @param address of the Universal Profile
  * @return address[] of the issued assets or custom error
-*/
+ */
 async function fetchIssuedAssets(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP12IssuedAssets[]");
+    const result = await profile.fetchData('LSP12IssuedAssets[]');
     return result.value;
   } catch (error) {
-    return console.log("This is not an ERC725 Contract");
+    return console.log('This is not an ERC725 Contract');
   }
 }
 
@@ -964,10 +750,10 @@ async function checkErc725YInterfaceId(assetAddress) {
   // Check if the contract has a key-value store
   try {
     isERC725Y = await asset.methods
-      .supportsInterface(ERC725Y_INTERFACE_IDS["3.0"])
+      .supportsInterface(ERC725Y_INTERFACE_IDS['3.0'])
       .call();
   } catch (error) {
-    console.log("Address could not be checked for ERC725Y interface");
+    console.log('Address could not be checked for ERC725Y interface');
   }
 
   return isERC725Y;
@@ -981,18 +767,17 @@ async function checkErc725YInterfaceId(assetAddress) {
  */
 async function getAssetData(key, address) {
   try {
-
     // Instantiate the asset
     const digitalAsset = new web3.eth.Contract(LSP4.abi, address);
 
     // Get the encoded data
-    return await digitalAsset.methods["getData(bytes32)"](key).call();
+    return await digitalAsset.methods['getData(bytes32)'](key).call();
   } catch (error) {
-    return console.error("Data of assets address could not be loaded");
+    return console.error('Data of assets address could not be loaded');
   }
 }
 
- /*
+/*
  * Decode the value from ERC725Y storage
  * based on its data key and phrase
  *
@@ -1007,7 +792,7 @@ async function decodeAssetData(keyName, encodedData) {
       LSP4schema,
       SAMPLE_ASSET_ADDRESS,
       provider,
-      config
+      config,
     );
 
     // Decode the assets data
@@ -1016,7 +801,7 @@ async function decodeAssetData(keyName, encodedData) {
       value: encodedData,
     });
   } catch (error) {
-    console.log("Data of an asset could not be decoded");
+    console.log('Data of an asset could not be decoded');
   }
 }
 
@@ -1032,7 +817,7 @@ async function getMetaDataLink(decodedAssetMetadata) {
     // Generate IPFS link from decoded metadata
     return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
   } catch (error) {
-    console.log("URL could not be fetched");
+    console.log('URL could not be fetched');
   }
 }
 
@@ -1048,39 +833,39 @@ async function fetchAssetData(dataURL) {
     const response = await fetch(dataURL);
     return await response.json();
   } catch (error) {
-    console.log("JSON data of IPFS link could not be fetched");
+    console.log('JSON data of IPFS link could not be fetched');
   }
 }
 
 // Step 1
 fetchReceivedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2))
+  console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
 // Step 2
 fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((profileData) =>
-  console.log(JSON.stringify(profileData, undefined, 2))
+  console.log(JSON.stringify(profileData, undefined, 2)),
 );
 
 // Step 3
 fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
-  console.log(ownedAssets)
+  console.log(ownedAssets),
 );
 
 // Step 4
 checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isERC725Y) =>
-  console.log(isERC725Y)
+  console.log(isERC725Y),
 );
 
 // Step 5
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData)
+  console.log(encodedData),
 );
 
 // Step 6
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
   decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData)
+    console.log(decodedData),
   );
 });
 
@@ -1099,8 +884,6 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
     });
   });
 });
-
-
 ```
 
   </TabItem>
@@ -1135,13 +918,13 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
 
 ```json title="erc725_legacy_minimal_schema.json"
 [
-    {
-       "name":"LSP3IssuedAssets[]",
-       "key":"0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-       "keyType":"Array",
-       "valueContent":"Address",
-       "valueType":"address"
-    }
+  {
+    "name": "LSP3IssuedAssets[]",
+    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+    "keyType": "Array",
+    "valueContent": "Address",
+    "valueType": "address"
+  }
 ]
 ```
 
@@ -1206,35 +989,34 @@ getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
 </details>
 
 ```javascript title="read_assets.js"
-
 // Imports
-const Web3 = require("web3");
-const { ERC725 } = require("@erc725/erc725.js");
-require("isomorphic-fetch");
-const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
-const LSP8 = require("@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json");
-const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
+const Web3 = require('web3');
+const { ERC725 } = require('@erc725/erc725.js');
+require('isomorphic-fetch');
+const erc725schema = require('@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json');
+const LSP8 = require('@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json');
+const LSP4schema = require('@erc725/erc725.js/schemas/LSP4DigitalAsset.json');
 
 // Sample addresses
-const SAMPLE_ASSET_ADDRESS = "0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78";
-const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
+const SAMPLE_ASSET_ADDRESS = '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78';
+const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';
 
 // Network and storage
-const RPC_ENDPOINT = "https://rpc.l14.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const RPC_ENDPOINT = 'https://rpc.l14.lukso.network';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
 
 // Legacy ABIs and schemas
-const LSP1MinimalABI = require("./lsp1_legacy_minimal_abi.json");
-const LSP4MinimalABI = require("./lsp4_legacy_minimal_abi.json");
-const ERC725MinimalABI = require("./erc725_legacy_minimal_abi.json");
-const ERC725LegacySchema = require("./erc725_legacy_minimal_schema.json");
+const LSP1MinimalABI = require('./lsp1_legacy_minimal_abi.json');
+const LSP4MinimalABI = require('./lsp4_legacy_minimal_abi.json');
+const ERC725MinimalABI = require('./erc725_legacy_minimal_abi.json');
+const ERC725LegacySchema = require('./erc725_legacy_minimal_schema.json');
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l14.lukso.network");
+const web3 = new Web3('https://rpc.l14.lukso.network');
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;
@@ -1252,35 +1034,34 @@ const CreatorsKey = LSP4schema[4].key;
 async function fetchUniversalReceiverAddress(address) {
   try {
     const profile = new ERC725(erc725schema, address, provider, config);
-    const result = await profile.fetchData("LSP1UniversalReceiverDelegate")
+    const result = await profile.fetchData('LSP1UniversalReceiverDelegate');
     return result.value;
   } catch (error) {
-    return console.log("This is not an ERC725 Contract");
+    return console.log('This is not an ERC725 Contract');
   }
 }
 
- /*
-  * Get all received assets from the
-  * Universal Receiver of the
-  * Universal Profile.
-  *
-  * @param address of the Universal Receiver
-  * @return address[] of the received assets
-  */
+/*
+ * Get all received assets from the
+ * Universal Receiver of the
+ * Universal Profile.
+ *
+ * @param address of the Universal Receiver
+ * @return address[] of the received assets
+ */
 async function fetchReceivedAssets(receiverAddress) {
   const universalReceiver = new web3.eth.Contract(
     LSP1MinimalABI,
-    receiverAddress
+    receiverAddress,
   );
 
   let rawValues = [];
 
   try {
-
     // Fetch all raw values
     rawValues = await universalReceiver.methods.getAllRawValues().call();
   } catch (error) {
-    return console.log("Data from universal receiver could not be loaded");
+    return console.log('Data from universal receiver could not be loaded');
   }
 
   const receivedAssets = [];
@@ -1302,10 +1083,10 @@ async function fetchReceivedAssets(receiverAddress) {
 async function fetchIssuedAssets(address) {
   try {
     const profile = new ERC725(ERC725LegacySchema, address, provider, config);
-    const result = await profile.getData("LSP3IssuedAssets[]");
+    const result = await profile.getData('LSP3IssuedAssets[]');
     return result.value;
   } catch (error) {
-    return console.log("Issued assets could not be fetched");
+    return console.log('Issued assets could not be fetched');
   }
 }
 
@@ -1323,7 +1104,6 @@ async function fetchOwnedAssets(owner) {
   const ownedAssets = [];
 
   for (let i = 0; i < digitalAssets.length; i++) {
-    
     // Create instance of the asset to check owner balance
     const LSP8Contract = new web3.eth.Contract(LSP8.abi, digitalAssets[i]);
 
@@ -1346,7 +1126,7 @@ async function checkErc725YInterfaceId(address) {
   // Create an instance of the asset
   const asset = new web3.eth.Contract(LSP4MinimalABI, address);
 
-  const erc725YLegacyInterfaceId = "0x2bd57b73";
+  const erc725YLegacyInterfaceId = '0x2bd57b73';
   let isERC725YLegacy = false;
 
   // Check if the contract is a legacy key-value store interface
@@ -1356,31 +1136,26 @@ async function checkErc725YInterfaceId(address) {
       .call();
     return isERC725YLegacy;
   } catch (error) {
-    console.log("Address could not be checked for ERC725YLegacy interface");
+    console.log('Address could not be checked for ERC725YLegacy interface');
   }
   return isERC725YLegacy;
 }
 
- /*
+/*
  * Get the dataset of an asset
  *
  * @param data key of the property to fetch
  * @return string of the encoded data
  */
 async function getAssetData(key, address) {
-  
   try {
+    // Instanciate asset
+    const digitalAsset = new web3.eth.Contract(ERC725MinimalABI, address);
 
-      // Instanciate asset
-      const digitalAsset = new web3.eth.Contract(
-        ERC725MinimalABI,
-        address
-      );
-
-      // Fetch the encoded data
-      return await digitalAsset.methods.getData(key).call();
+    // Fetch the encoded data
+    return await digitalAsset.methods.getData(key).call();
   } catch (error) {
-    return console.log("Data of assets address could not be loaded");
+    return console.log('Data of assets address could not be loaded');
   }
 }
 
@@ -1394,13 +1169,12 @@ async function getAssetData(key, address) {
  */
 async function decodeAssetData(keyName, encodedData) {
   try {
-
     // Instanciate the asset
     const digitalAsset = new ERC725(
       LSP4schema,
       SAMPLE_ASSET_ADDRESS,
       provider,
-      config
+      config,
     );
 
     // Decode the assets data
@@ -1409,7 +1183,7 @@ async function decodeAssetData(keyName, encodedData) {
       value: encodedData,
     });
   } catch (error) {
-    console.log("Data of an asset could not be decoded");
+    console.log('Data of an asset could not be decoded');
   }
 }
 
@@ -1425,11 +1199,11 @@ async function getMetaDataLink(decodedAssetMetadata) {
     // Generate IPFS link from decoded metadata
     return decodedAssetMetadata.value.url.replace('ipfs://', IPFS_GATEWAY);
   } catch (error) {
-    console.log("URL could not be fetched");
+    console.log('URL could not be fetched');
   }
 }
 
- /*
+/*
  * Fetch the asset data from the provided
  * storage link
  *
@@ -1441,57 +1215,54 @@ async function fetchAssetData(dataURL) {
     const response = await fetch(dataURL);
     return await response.json();
   } catch (error) {
-    console.log("JSON data of IPFS link could not be fetched");
+    console.log('JSON data of IPFS link could not be fetched');
   }
 }
 
 // Step 1.1
 fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) =>
-  console.log(receiverAddress)
+  console.log(receiverAddress),
 );
 
 // Step 1.2
-fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then((receiverAddress) => {
-  fetchReceivedAssets(receiverAddress).then((receivedAssets) =>
-    console.log(receivedAssets)
-  );
-});
+fetchUniversalReceiverAddress(SAMPLE_PROFILE_ADDRESS).then(
+  (receiverAddress) => {
+    fetchReceivedAssets(receiverAddress).then((receivedAssets) =>
+      console.log(receivedAssets),
+    );
+  },
+);
 
 // Step 2
 fetchIssuedAssets(SAMPLE_PROFILE_ADDRESS).then((issuedAssets) =>
-  console.log(issuedAssets)
+  console.log(issuedAssets),
 );
 
 // Step 3
-fetchOwnedAssets(SAMPLE_PROFILE_ADDRESS).then((ownedAssets) =>
-  console.log(ownedAssets)
+checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
+  console.log(isLegacy),
 );
 
 // Step 4
-checkErc725YInterfaceId(SAMPLE_ASSET_ADDRESS).then((isLegacy) =>
-  console.log(isLegacy)
+getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
+  console.log(encodedData),
 );
 
 // Step 5
-getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) =>
-  console.log(encodedData)
-);
-
-// Step 6
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
   decodeAssetData(MetaDataKey, encodedData).then((decodedData) =>
-    console.log(decodedData)
+    console.log(decodedData),
   );
 });
 
-// Step 7
+// Step 6
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
   decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
     getMetaDataLink(decodedData).then((dataURL) => console.log(dataURL));
   });
 });
 
-// Step 8
+// Step 7
 getAssetData(MetaDataKey, SAMPLE_ASSET_ADDRESS).then((encodedData) => {
   decodeAssetData(MetaDataKey, encodedData).then((decodedData) => {
     getMetaDataLink(decodedData).then((dataURL) => {


### PR DESCRIPTION
Improves digital asset metadata guide.

- Uses `erc725.fetchData` to get and decode LSP4 metadata rather than doing these steps manually
- Removes unnecessary steps in guide (get issued assets, check ownership)

Before:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/54543428/182134939-fb039664-9018-49ce-8876-d80b1e521005.png">

After
<img width="236" alt="image" src="https://user-images.githubusercontent.com/54543428/182134973-1a4c45af-c189-4edd-a077-3081a2dcbdfd.png">

