### PR TITLE
Fix: Update webjs execute call example

### DIFF
--- a/docs/guides/universal-profile/interact-with-contracts.md
+++ b/docs/guides/universal-profile/interact-with-contracts.md
@@ -48,7 +48,7 @@ let abiPayload = await myUp.methods
   .encodeABI();
 
 // 3. execute via the KeyManager, passing the UP payload
-await myKeyManager.execute(abiPayload, {
+await myKeyManager.methods.execute(abiPayload).send({
   from: '<address-of-up-owner>',
   gasLimit: 300_000,
 });


### PR DESCRIPTION
The example shows to call `execute` with 2 params. However, `execute` only accepts 1 param, so this change fixes it to expected syntax.