### PR TITLE
corrected npm package name

### DIFF
--- a/docs/guides/key-manager/give-permissions.md
+++ b/docs/guides/key-manager/give-permissions.md
@@ -31,7 +31,7 @@ The Key Manager (KM) enables us to give permissions to other 3rd party addresses
 ## Setup
 
 ```shell
-npm install erc725.js @lukso/lsp-smart-contracts
+npm install @erc725/erc725.js @lukso/lsp-smart-contracts
 ```
 
 ## Step 1 - Initialize erc725.js


### PR DESCRIPTION
`erc725.js` is an incorrect npm package. It should be [@erc725/erc725.js]( https://www.npmjs.com/package/@erc725/erc725.js). This error caused tutorial to break.