### PR TITLE
Adding descriptions for internal methods of LSP7 & LSP8 

### DIFF
--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -24,7 +24,7 @@ function supportsInterface(bytes4 interfaceId) public view returns (bool)
 
 :::
 
-## Functions
+## Public Functions
 
 ### constructor
 
@@ -262,6 +262,206 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 - No values in `to` can be the zero address.
 - Each `amount` tokens must be owned by `from`.
 - If the caller is not `from`, it must be an operator for `from` with access to at least `amount` tokens.
+
+:::
+
+## Internal Functions
+
+:::info Warning
+By deploying the smart contracts directly the methods _burn and _mint will lack implementantion.
+In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
+:::
+
+### _mint
+
+```
+function _mint(
+    address to,
+    uint256 amount,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+Mints `amount` tokens and transfers it to `to`.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `to`     | address  | The receiving address. |
+| `amount` | uint256  | The amount of token to mint. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `to` address. |
+
+:::note
+
+#### Requirements:
+
+- `to` cannot be the zero address.
+
+:::
+
+### _transfer
+
+```
+function _transfer(
+    address from,
+    address to,
+    uint256 amount,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+Transfers `amount` tokens from `from` to `to`.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `amount` | uint256  | The amount of token to transfer. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+- `to` cannot be the zero address.
+- `from` cannot be the zero address.
+- `from` must have at least `amount` tokens.
+- If the caller is not `from`, it must be an operator for `from` with access to at least `amount` tokens.
+
+:::
+
+### _burn
+
+```
+function _burn(
+    address from,
+    uint256 amount,
+    bytes memory data
+) internal virtual
+```
+
+Destroys `amount` tokens.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `amount` | uint256  | The amount of token to burn. |
+| `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `from` address. |
+
+:::note
+
+#### Requirements:
+
+- `from` cannot be the zero address.
+- `from` must have at least `amount` tokens.
+- If the caller is not `from`, it must be an operator for `from` with access to at least `amount` tokens.
+
+:::
+
+### _beforeTokenTransfer
+
+```
+function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+) internal virtual
+```
+
+Hook that is called before any token transfer. This includes minting and burning.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `amount` | uint256  | The amount of token to transfer. |
+
+:::note
+
+#### Requirements:
+
+- When `from` and `to` are both non-zero, ``from``'s `amount` tokens will betransferred to `to`.
+- When `from` is zero, `amount` tokens will be minted for `to`.
+- When `to` is zero, ``from``'s `amount` tokens will be burned.
+
+:::
+
+### _notifyTokenSender
+
+```
+function _notifyTokenSender(
+    address from,
+    address to,
+    uint256 amount,
+    bytes memory data
+) internal virtual
+```
+
+An attempt is made to notify the token sender about the `amount` tokens changing owners using LSP1 interface.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `amount` | uint256  | The amount of token to transfer. |
+| `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+-
+
+:::
+
+### _notifyTokenReceiver
+
+```
+function _notifyTokenReceiver(
+    address from,
+    address to,
+    uint256 amount,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+An attempt is made to notify the token receiver about the `amount` tokens changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `amount` | uint256  | The amount of token to transfer. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+- The receiver may revert when the token being sent is not wanted.
 
 :::
 

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -268,13 +268,13 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 ## Internal Functions
 
 :::info Warning
-By deploying the smart contracts directly the methods _burn and _mint will lack implementantion.
+By deploying an LSP7DigitalAsset contract, there will be no public mint or burn function.
 In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
 :::
 
 ### _mint
 
-```
+```solidity
 function _mint(
     address to,
     uint256 amount,
@@ -306,7 +306,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _transfer
 
-```
+```solidity
 function _transfer(
     address from,
     address to,
@@ -343,7 +343,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _burn
 
-```
+```solidity
 function _burn(
     address from,
     uint256 amount,
@@ -351,7 +351,7 @@ function _burn(
 ) internal virtual
 ```
 
-Destroys `amount` tokens.
+Burns `amount` tokens.
 
 _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
 
@@ -375,7 +375,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _beforeTokenTransfer
 
-```
+```solidity
 function _beforeTokenTransfer(
     address from,
     address to,
@@ -405,7 +405,7 @@ Hook that is called before any token transfer. This includes minting and burning
 
 ### _notifyTokenSender
 
-```
+```solidity
 function _notifyTokenSender(
     address from,
     address to,
@@ -425,17 +425,9 @@ An attempt is made to notify the token sender about the `amount` tokens changing
 | `amount` | uint256  | The amount of token to transfer. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
-:::note
-
-#### Requirements:
-
--
-
-:::
-
 ### _notifyTokenReceiver
 
-```
+```solidity
 function _notifyTokenReceiver(
     address from,
     address to,
@@ -446,6 +438,7 @@ function _notifyTokenReceiver(
 ```
 
 An attempt is made to notify the token receiver about the `amount` tokens changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+The receiver may revert when the token being sent is not wanted.
 
 #### Parameters:
 
@@ -457,11 +450,33 @@ An attempt is made to notify the token receiver about the `amount` tokens changi
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
+### _updateOperator
+
+```
+function _updateOperator(
+    address tokenOwner,
+    address operator,
+    uint256 amount
+) internal virtual
+```
+
+Changes token `amount` the `operator` has access to from `tokenOwner` tokens. If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+
+_Triggers the **[AuthorizedOperator](#authorizedoperator)** event if an address get authorized as an operator or **[RevokedOperator](#revokedoperator)** event if an address get revoked as an operator._
+
+#### Parameters
+
+|     Name     |   Type   | Description |
+| :----------- | :------- | :---------- |
+| `tokenOwner` | address | The address that is the owner of tokens. |
+| `operator`   | address | The address to authorize as an operator. |
+| `amount`     | uint256 | The amount of tokens operator has access to. |
+
 :::note
 
-#### Requirements:
+#### Requirements
 
-- The receiver may revert when the token being sent is not wanted.
+- `operator` cannot be the zero address.
 
 :::
 

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -204,7 +204,7 @@ Transfers an `amount` of tokens from the `from` address to the `to` address. The
 
 Will notify the token sender and receiver by calling the `universalReceiver(...)` function on the `from` and `to` address.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -241,7 +241,7 @@ function transferBatch(
 
 Transfers multiple tokens based on the `from`, `to`, and `amount` arrays. If any transfer fails, the whole call will revert.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -285,7 +285,7 @@ function _mint(
 
 Mints `amount` tokens and transfers it to `to`.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -318,7 +318,7 @@ function _transfer(
 
 Transfers `amount` tokens from `from` to `to`.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -353,7 +353,7 @@ function _burn(
 
 Burns `amount` tokens.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -414,7 +414,7 @@ function _notifyTokenSender(
 ) internal virtual
 ```
 
-An attempt is made to notify the token sender about the `amount` tokens changing owners using LSP1 interface.
+An attempt is made to notify the token sender about the `amount` tokens being sent by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the sender address if it exist.
 
 #### Parameters:
 
@@ -437,8 +437,7 @@ function _notifyTokenReceiver(
 ) internal virtual
 ```
 
-An attempt is made to notify the token receiver about the `amount` tokens changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+An attempt is made to notify the token receiver about the `amount` tokens being received by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the receiver address if it exists.
 
 #### Parameters:
 

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -210,8 +210,8 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 | Name     | Type    | Description                                                                                                                               |
 | :------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | address | The sending address.                                                                                                                      |
-| `to`     | address | The receiving address.                                                                                                                    |
+| `from`   | address | The sender address.                                                                                                                      |
+| `to`     | address | The recipient address.                                                                                                                    |
 | `amount` | uint256 | The amount of token to transfer.                                                                                                          |
 | `force`  | bool    | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`   | bytes   | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                       |
@@ -247,8 +247,8 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 | Name     | Type      | Description                                                                                                                               |
 | :------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | address[] | The list of sending addresses.                                                                                                            |
-| `to`     | address[] | The list of receiving addresses.                                                                                                          |
+| `from`   | address[] | The list of sender addresses.                                                                                                            |
+| `to`     | address[] | The list of recipient addresses.                                                                                                          |
 | `amount` | uint256[] | The amount of tokens to transfer.                                                                                                         |
 | `force`  | bool[]    | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`   | bytes[]   | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                       |
@@ -266,6 +266,8 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 :::
 
 ## Internal Functions
+
+These internal functions can be extended via `override` to add some custom logic.
 
 :::info Warning
 By deploying an LSP7DigitalAsset contract, there will be no public mint or burn function.
@@ -291,7 +293,7 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `to`     | address  | The receiving address. |
+| `to`     | address  | The recipient address. |
 | `amount` | uint256  | The amount of token to mint. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `to` address. |
@@ -324,8 +326,8 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `amount` | uint256  | The amount of token to transfer. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
@@ -359,7 +361,7 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
+| `from`   | address  | The sender address. |
 | `amount` | uint256  | The amount of token to burn. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `from` address. |
 
@@ -389,8 +391,8 @@ Hook that is called before any token transfer. This includes minting and burning
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `amount` | uint256  | The amount of token to transfer. |
 
 :::note
@@ -414,14 +416,14 @@ function _notifyTokenSender(
 ) internal virtual
 ```
 
-An attempt is made to notify the token sender about the `amount` tokens being sent by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the sender address if it exist.
+An attempt is made to notify the token sender about the `amount` of tokens being sent by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the sender address if it exists.
 
 #### Parameters:
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `amount` | uint256  | The amount of token to transfer. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
@@ -437,14 +439,14 @@ function _notifyTokenReceiver(
 ) internal virtual
 ```
 
-An attempt is made to notify the token receiver about the `amount` tokens being received by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the receiver address if it exists.
+An attempt is made to notify the token receiver about the `amount` of tokens being received by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the receiver address if it exists.
 
 #### Parameters:
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `amount` | uint256  | The amount of token to transfer. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
@@ -459,9 +461,9 @@ function _updateOperator(
 ) internal virtual
 ```
 
-Changes token `amount` the `operator` has access to from `tokenOwner` tokens. If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+Changes token `amount` the `operator` has access to from `tokenOwner` tokens. Setting the `amount` to zero is equivalent to revoking the operator.
 
-_Triggers the **[AuthorizedOperator](#authorizedoperator)** event if an address get authorized as an operator or **[RevokedOperator](#revokedoperator)** event if an address get revoked as an operator._
+_Triggers the **[AuthorizedOperator](#authorizedoperator)** event if an address gets authorized as an operator or **[RevokedOperator](#revokedoperator)** event if an address gets revoked as an operator._
 
 #### Parameters
 
@@ -500,9 +502,9 @@ _**MUST** be fired when the **[transfer](#transfer)** function gets executed suc
 
 | Name       | Type    | Description                                                                                                                           |
 | :--------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `operator` | address | The address of operator sending tokens.                                                                                               |
+| `operator` | address | The address of operator sender tokens.                                                                                               |
 | `from`     | address | The address which tokens are sent.                                                                                                    |
-| `to`       | address | The receiving address.                                                                                                                |
+| `to`       | address | The recipient address.                                                                                                                |
 | `amount`   | uint256 | The amount of tokens transferred.                                                                                                     |
 | `force`    | bool    | When set to TRUE, to may be any address; when set to FALSE to must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`     | bytes   | Additional data the caller wants included in the emitted event, and sent in the hooks to from and to addresses.                       |

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -502,7 +502,7 @@ _**MUST** be fired when the **[transfer](#transfer)** function gets executed suc
 
 | Name       | Type    | Description                                                                                                                           |
 | :--------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `operator` | address | The address of operator sender tokens.                                                                                               |
+| `operator` | address | The address of operator sending tokens.                                                                                               |
 | `from`     | address | The address which tokens are sent.                                                                                                    |
 | `to`       | address | The recipient address.                                                                                                                |
 | `amount`   | uint256 | The amount of tokens transferred.                                                                                                     |

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -274,7 +274,7 @@ function transfer(
 
 Transfers the token with a particular `tokenId` from the `from` address to the `to` address. The `force` parameter **MUST** be set to TRUE when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the [LSP1 - Universal Receiver Delegate](../generic-standards/lsp1-universal-receiver.md) standard.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when the token gets successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when the token gets successfully transferred._
 
 #### Parameters:
 
@@ -311,7 +311,7 @@ function transferBatch(
 
 Transfers multiple tokens based on the `from`, `to`, and `tokenId` arrays. If any transfer fails, the whole call will revert.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when the tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when the tokens get successfully transferred._
 
 #### Parameters:
 
@@ -355,7 +355,7 @@ function _mint(
 
 Mints `tokenId` and transfers it to `to`.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -389,7 +389,7 @@ function _transfer(
 
 Transfers `tokenId` from `from` to `to`.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -422,7 +422,7 @@ function _burn(
 
 Burns `tokenId`, clearing authorized operators.
 
-_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+_Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
 #### Parameters:
 
@@ -482,7 +482,7 @@ function _notifyTokenSender(
 ) internal virtual
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using LSP1 interface.
+An attempt is made to notify the token receiver about the `tokenId` token being received by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the receiver address if it exists.
 
 #### Parameters:
 
@@ -505,7 +505,7 @@ function _notifyTokenReceiver(
 ) internal virtual
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+An attempt is made to notify the token receiver about the `tokenId` token being received by calling the **[universalReceiver(...)](./lsp0-erc725-account.md#universalreceiver)** function on the receiver address if it exists.
 
 #### Parameters:
 
@@ -527,7 +527,7 @@ function _revokeOperator(
 ) internal virtual
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+Revoke the `operator` of the `tokenId` token which belongs to `tokenOwner`.
 
 #### Parameters:
 
@@ -539,12 +539,14 @@ An attempt is made to notify the token receiver about the `tokenId` changing own
 
 ### _clearOperators
 
-```
+```solidity
 function clearOperators(
     address tokenOwner,
     bytes32 tokenId
 ) internal virtual
 ```
+
+Revoke the all current operators of the `tokenId` token which belongs to `tokenOwner`.
 
 #### Parameters
 

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -338,13 +338,13 @@ _Triggers the **[Transfer](#trasnfer-2)** event when the tokens get successfully
 ## Internal Functions
 
 :::info Warning
-By deploying the smart contracts directly the methods _burn and _mint will lack implementantion.
+By deploying an LSP8IdentifiableDigitalAsset contract, there will be no public mint or burn function.
 In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
 :::
 
 ### _mint
 
-```
+```solidity
 function _mint(
     address to,
     bytes32 tokenId,
@@ -377,7 +377,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _transfer
 
-```
+```solidity
 function _transfer(
     address from,
     address to,
@@ -412,7 +412,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _burn
 
-```
+```solidity
 function _burn(
     address from,
     bytes32 tokenId,
@@ -420,7 +420,7 @@ function _burn(
 ) internal virtual
 ```
 
-Destroys `tokenId`, clearing authorized operators.
+Burns `tokenId`, clearing authorized operators.
 
 _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
 
@@ -443,7 +443,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully tra
 
 ### _beforeTokenTransfer
 
-```
+```solidity
 function _beforeTokenTransfer(
     address from,
     address to,
@@ -473,7 +473,7 @@ Hook that is called before any token transfer. This includes minting and burning
 
 ### _notifyTokenSender
 
-```
+```solidity
 function _notifyTokenSender(
     address from,
     address to,
@@ -493,17 +493,9 @@ An attempt is made to notify the token sender about the `tokenId` changing owner
 | `tokenId` | bytes32  | The token to transfer. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
-:::note
-
-#### Requirements:
-
--
-
-:::
-
 ### _notifyTokenReceiver
 
-```
+```solidity
 function _notifyTokenReceiver(
     address from,
     address to,
@@ -525,13 +517,41 @@ An attempt is made to notify the token receiver about the `tokenId` changing own
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
-:::note
+### _revokeOperator
 
-#### Requirements:
+```solidity
+function _revokeOperator(
+    address operator,
+    address tokenOwner,
+    bytes32 tokenId
+) internal virtual
+```
 
-- The receiver may revert when the token being sent is not wanted.
+An attempt is made to notify the token receiver about the `tokenId` changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 
-:::
+#### Parameters:
+
+|     Name     |   Type   | Description |
+| :----------- | :------- | :---------- |
+| `operator`   | address | The address to revoke as an operator.     |
+| `tokenOwner` | address | The address that is the owner of tokenId. |
+| `tokenId`    | bytes32 | The token to disable operator status to.  |
+
+### _clearOperators
+
+```
+function clearOperators(
+    address tokenOwner,
+    bytes32 tokenId
+) internal virtual
+```
+
+#### Parameters
+
+|     Name     |   Type   | Description |
+| :----------- | :------- | :---------- |
+| `tokenOwner` | address | The address that is the owner of tokenId. |
+| `tokenId`    | bytes32 | The token to disable operator status to.  |
 
 ## Events
 

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -25,7 +25,7 @@ function supportsInterface(bytes4 interfaceId) public view returns (bool)
 
 :::
 
-## Functions
+## Public Functions
 
 ### constructor
 
@@ -282,7 +282,7 @@ _Triggers the **[Transfer](#trasnfer-2)** event when the token gets successfully
 | :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | `from`    | address | The sending address.                                                                                                                      |
 | `to`      | address | The receiving address.                                                                                                                    |
-| `tokenId` | uint256 | The token to transfer.                                                                                                                    |
+| `tokenId` | bytes32 | The token to transfer.                                                                                                                    |
 | `force`   | bool    | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`    | bytes   | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                       |
 
@@ -332,6 +332,204 @@ _Triggers the **[Transfer](#trasnfer-2)** event when the tokens get successfully
 - No values in `to` can be the zero address.
 - Each `tokenId` token must be owned by `from`.
 - If the caller is not `from`, it must be an operator of each `tokenId`.
+
+:::
+
+## Internal Functions
+
+:::info Warning
+By deploying the smart contracts directly the methods _burn and _mint will lack implementantion.
+In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
+:::
+
+### _mint
+
+```
+function _mint(
+    address to,
+    bytes32 tokenId,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+Mints `tokenId` and transfers it to `to`.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `to`     | address  | The receiving address. |
+| `tokenId`| bytes32  | The token to transfer. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `to` address. |
+
+:::note
+
+#### Requirements:
+
+- `tokenId` must not exist.
+- `to` cannot be the zero address.
+
+:::
+
+### _transfer
+
+```
+function _transfer(
+    address from,
+    address to,
+    bytes32 tokenId,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+Transfers `tokenId` from `from` to `to`.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `tokenId`| bytes32  | The token to transfer. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+- `to` cannot be the zero address.
+- `tokenId` token must be owned by `from`.
+
+:::
+
+### _burn
+
+```
+function _burn(
+    address from,
+    bytes32 tokenId,
+    bytes memory data
+) internal virtual
+```
+
+Destroys `tokenId`, clearing authorized operators.
+
+_Triggers the **[Transfer](#trasnfer-2)** event when tokens get successfully transferred._
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `tokenId` | bytes32  | The token to burn. |
+| `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `from` address. |
+
+:::note
+
+#### Requirements:
+
+- `from` cannot be the zero address.
+- `tokenId` must exist.
+
+:::
+
+### _beforeTokenTransfer
+
+```
+function _beforeTokenTransfer(
+    address from,
+    address to,
+    bytes32 tokenId
+) internal virtual
+```
+
+Hook that is called before any token transfer. This includes minting and burning.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `tokenId` | bytes32  | The token to transfer. |
+
+:::note
+
+#### Requirements:
+
+- When `from` and `to` are both non-zero, ``from``'s `tokenId` will be transferred to `to`.
+- When `from` is zero, `tokenId` will be minted for `to`.
+- When `to` is zero, ``from``'s `tokenId` will be burned.
+
+:::
+
+### _notifyTokenSender
+
+```
+function _notifyTokenSender(
+    address from,
+    address to,
+    bytes32 tokenId,
+    bytes memory data
+) internal virtual
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using LSP1 interface.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `tokenId` | bytes32  | The token to transfer. |
+| `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+-
+
+:::
+
+### _notifyTokenReceiver
+
+```
+function _notifyTokenReceiver(
+    address from,
+    address to,
+    bytes32 tokenId,
+    bool force,
+    bytes memory data
+) internal virtual
+```
+
+An attempt is made to notify the token receiver about the `tokenId` changing owners using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+
+#### Parameters:
+
+|   Name   |   Type   | Description |
+| :------- | :------- | :---------- |
+| `from`   | address  | The sending address. |
+| `to`     | address  | The receiving address. |
+| `tokenId` | bytes32  | The token to transfer. |
+| `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
+| `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
+
+:::note
+
+#### Requirements:
+
+- The receiver may revert when the token being sent is not wanted.
 
 :::
 

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -280,8 +280,8 @@ _Triggers the **[Transfer](#transfer-2)** event when the token gets successfully
 
 | Name      | Type    | Description                                                                                                                               |
 | :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`    | address | The sending address.                                                                                                                      |
-| `to`      | address | The receiving address.                                                                                                                    |
+| `from`    | address | The sender address.                                                                                                                      |
+| `to`      | address | The recipient address.                                                                                                                    |
 | `tokenId` | bytes32 | The token to transfer.                                                                                                                    |
 | `force`   | bool    | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`    | bytes   | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                       |
@@ -317,8 +317,8 @@ _Triggers the **[Transfer](#transfer-2)** event when the tokens get successfully
 
 | Name      | Type      | Description                                                                                                                               |
 | :-------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`    | address[] | The list of sending addresses.                                                                                                            |
-| `to`      | address[] | The list of receiving addresses.                                                                                                          |
+| `from`    | address[] | The list of sender addresses.                                                                                                            |
+| `to`      | address[] | The list of recipient addresses.                                                                                                          |
 | `tokenId` | bytes32[] | The list of tokenIds to transfer.                                                                                                         |
 | `force`   | bool[]    | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `data`    | bytes[]   | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                       |
@@ -336,6 +336,8 @@ _Triggers the **[Transfer](#transfer-2)** event when the tokens get successfully
 :::
 
 ## Internal Functions
+
+These internal functions can be extended via `override` to add some custom logic.
 
 :::info Warning
 By deploying an LSP8IdentifiableDigitalAsset contract, there will be no public mint or burn function.
@@ -361,7 +363,7 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `to`     | address  | The receiving address. |
+| `to`     | address  | The recipient address. |
 | `tokenId`| bytes32  | The token to transfer. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `to` address. |
@@ -395,8 +397,8 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `tokenId`| bytes32  | The token to transfer. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
@@ -420,7 +422,7 @@ function _burn(
 ) internal virtual
 ```
 
-Burns `tokenId`, clearing authorized operators.
+Burns `tokenId` and clear the operators authorized for the `tokenId`.
 
 _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully transferred._
 
@@ -428,7 +430,7 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
+| `from`   | address  | The sender address. |
 | `tokenId` | bytes32  | The token to burn. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hook to `from` address. |
 
@@ -457,13 +459,13 @@ Hook that is called before any token transfer. This includes minting and burning
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `tokenId` | bytes32  | The token to transfer. |
 
 :::note
 
-#### Requirements:
+#### Notice:
 
 - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be transferred to `to`.
 - When `from` is zero, `tokenId` will be minted for `to`.
@@ -488,8 +490,8 @@ An attempt is made to notify the token receiver about the `tokenId` token being 
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `tokenId` | bytes32  | The token to transfer. |
 | `data`   | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
 
@@ -511,8 +513,8 @@ An attempt is made to notify the token receiver about the `tokenId` token being 
 
 |   Name   |   Type   | Description |
 | :------- | :------- | :---------- |
-| `from`   | address  | The sending address. |
-| `to`     | address  | The receiving address. |
+| `from`   | address  | The sender address. |
+| `to`     | address  | The recipient address. |
 | `tokenId` | bytes32  | The token to transfer. |
 | `force`  | bool     | When set to TRUE, `to` may be any address; when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver and not revert. |
 | `memory` | bytes    | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses. |
@@ -533,7 +535,7 @@ Revoke the `operator` of the `tokenId` token which belongs to `tokenOwner`.
 
 |     Name     |   Type   | Description |
 | :----------- | :------- | :---------- |
-| `operator`   | address | The address to revoke as an operator.     |
+| `operator`   | address | The address of the operator to revoke.    |
 | `tokenOwner` | address | The address that is the owner of tokenId. |
 | `tokenId`    | bytes32 | The token to disable operator status to.  |
 
@@ -576,9 +578,9 @@ _**MUST** be fired when the **[transfer](#transfer)** function gets executed suc
 
 | Name       | Type    | Description                                                                                                             |
 | :--------- | :------ | :---------------------------------------------------------------------------------------------------------------------- |
-| `operator` | address | The address of operator sending tokens.                                                                                 |
+| `operator` | address | The address of operator sender tokens.                                                                                 |
 | `from`     | address | The address which tokens are sent.                                                                                      |
-| `to`       | address | The receiving address.                                                                                                  |
+| `to`       | address | The recipient address.                                                                                                  |
 | `tokenId`  | bytes32 | The token to transfer.                                                                                                  |
 | `force`    | bool    | When set to `true`, may be any address; When set to `false`, address must be a contract supporting LSP1 and not revert. |
 | `data`     | bytes   | Additional data the caller wants included in the emitted event, and sent in the hooks to from and to addresses.         |

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -578,7 +578,7 @@ _**MUST** be fired when the **[transfer](#transfer)** function gets executed suc
 
 | Name       | Type    | Description                                                                                                             |
 | :--------- | :------ | :---------------------------------------------------------------------------------------------------------------------- |
-| `operator` | address | The address of operator sender tokens.                                                                                 |
+| `operator` | address | The address of operator sending tokens.                                                                                 |
 | `from`     | address | The address which tokens are sent.                                                                                      |
 | `to`       | address | The recipient address.                                                                                                  |
 | `tokenId`  | bytes32 | The token to transfer.                                                                                                  |


### PR DESCRIPTION
## What does this PR introduce?
In this PR we add description of the relevant internal methods of LSP7 & LSP8 in the “Smart Contract ABI” section of the docs.

## Motivation
Those descriptions can be used by people to extend the internal methods inside some custom methods of their choice.