### PR TITLE
Add LSP video to introduction

### DIFF
--- a/docs/standards/introduction.md
+++ b/docs/standards/introduction.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 
 # The LUKSO Standard Proposals (LSPs)
 
+<div class="video-container">
+<iframe src="https://www.youtube.com/embed/skA4Y-vvt5s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 :::success Implementation
 
 See the [Contracts Implementation](./smart-contracts/introduction.md) section for the Solidity implementation of these standards.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,7 +77,6 @@ html[data-theme='dark'] .header-github-link:before {
   margin-bottom: 3%;
   border-radius: 0.4rem;
   transform: translateZ(0px);
-  border: 3px solid black;
   background-color: black;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,3 +67,26 @@ html[data-theme='dark'] .header-github-link:before {
 .discord-logo {
   float: left;
 }
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 0;
+  height: 0;
+  overflow: hidden;
+  margin-bottom: 3%;
+  border-radius: 0.4rem;
+  transform: translateZ(0px);
+  border: 3px solid black;
+  background-color: black;
+}
+
+.video-container iframe,
+.video-container object,
+.video-container embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
This PR introduces 

- Responsive Youtube Video Integration with a custom-styled video wrapper fitting for the Docusaurus style that always scales to 100% docs width
- Adding the LSP Introduction video