### PR TITLE
[Code Documentation] Fixing grammar issues in LSP6KeyManager docs

### DIFF
--- a/docs/standards/generic-standards/lsp2-json-schema.md
+++ b/docs/standards/generic-standards/lsp2-json-schema.md
@@ -146,7 +146,7 @@ Below are some examples of the **Mapping** key type.
 ```json
 {
   "name": "SupportedStandards:LSP3UniversalProfile",
-  "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+  "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
   "keyType": "Mapping",
   "valueType": "bytes4",
   "valueContent": "0xabe425d6"

--- a/docs/standards/universal-profile/lsp0-erc725account.md
+++ b/docs/standards/universal-profile/lsp0-erc725account.md
@@ -108,7 +108,7 @@ Unlike Externally Owned Accounts (EOAs), smart contracts cannot sign messages si
 
 **ClaimOwnership** is a modified version of [EIP173 - Contract Ownership Standard](https://eips.ethereum.org/EIPS/eip-173) that uses a safer mechanism for transferring ownership.
 
-In EIP713, ownership of a contract is transferred directly to a new owner, potentially leading to blocking access to the contract. For instance, if the owner calls `transferOwnership()` and the new owner:
+In EIP173, ownership of a contract is transferred directly to a new owner, potentially leading to blocking access to the contract. For instance, if the owner calls `transferOwnership()` and the new owner:
 
 - is an EOA that lost its private key.
 - is an `address` entered incorrectly.

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -179,7 +179,7 @@ When deployed with our [**lsp-factory.js** tool](https://docs.lukso.tech/tools/l
 
 ### SUPER Permissions
 
-The super permissions grants the same permissions as their non-super counter parts, with the difference being that they check on restrictions for `addresses`, `standards`, or `functions` are _skipped_. This allows for cheaper transactions where, these restrictions aren't set anyway.
+The super permissions grants the same permissions as their non-super counter parts, with the difference being that the checks on restrictions for `addresses`, `standards`, or `functions` are _skipped_. This allows for cheaper transactions where, these restrictions aren't set anyway.
 
 <details>
     <summary><code>SUPER_SETDATA</code></summary>

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -546,7 +546,7 @@ Dapps can then leverage the relay execution features to create their own busines
 
 Since the Key Manager offers **relay execution** via signed message, it's important to provide security measurements to ensure that the signed message can't be repeated once executed. **[Nonces](https://www.techtarget.com/searchsecurity/definition/nonce#:~:text=A%20nonce%20is%20a%20random,to%20as%20a%20cryptographic%20nonce.)** existed to solve this problem, but with the following drawback:
 
-- Signed messages with sequentiel nonces should be **executed in order**, meaning a signed message with nonce 4 can't be executed before the signed message with nonce 3. This is a critical problem which can limit the usage of relay execution.
+- Signed messages with sequential nonces should be **executed in order**, meaning a signed message with nonce 4 can't be executed before the signed message with nonce 3. This is a critical problem which can limit the usage of relay execution.
 
 Here comes the **Multi-channel** nonces which provide the ability to execute signed message **with**/**without** a specific order depending on the signer choice.
 

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -550,7 +550,7 @@ Since the Key Manager offers **relay execution** via signed message, it's import
 
 Here comes the **Multi-channel** nonces which provide the ability to execute signed message **with**/**without** a specific order depending on the signer choice.
 
-Signed messages should be executed sequentielially if signed on the same channel and should be executed independently if signed on different channel.
+Signed messages should be executed sequentially if signed on the same channel and should be executed independently if signed on different channel.
 
 - Message signed with nonce 4 on channel 1 can't be executed before the message signed with nonce 3 on channel 1 but can be executed before the message signed with nonce 3 on channel 2.
 

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -179,7 +179,7 @@ When deployed with our [**lsp-factory.js** tool](https://docs.lukso.tech/tools/l
 
 ### SUPER Permissions
 
-The super permissions grants the same permissions as their non-super counter parts, with the difference being that the checks on restrictions for `addresses`, `standards`, or `functions` are _skipped_. This allows for cheaper transactions where, these restrictions aren't set anyway.
+The super permissions grants the same permissions as their non-super counter parts, with the difference being that the checks on restrictions for `addresses`, `standards`, or `functions` are _skipped_. This allows for cheaper transactions whether these restrictions are set or not.
 
 <details>
     <summary><code>SUPER_SETDATA</code></summary>


### PR DESCRIPTION
## What does this PR introduce

- In LSP6 - "they check on restrictions for addresses, standards, or functions are skipped." is improper grammar.
- In LSP6 - similarly, "This allows for cheaper transactions where, these restrictions aren't set anyway."
- In LSP6 - sequentiel -> sequential
- In LSP6 - sequentielially -> sequentially
- claimownership: a typo "In EIP713", should be "In EIP173" instead.
- singleton, the "key" inside the example JSON:
`
{
  "name": "SupportedStandards:LSP3UniversalProfile",
  "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
  "keyType": "Mapping",
  "valueType": "bytes4",
  "valueContent": "0xabe425d6"
}
`
is different from the key listed in the image.
(https://docs.lukso.tech/assets/images/lsp2-key-type-mapping-to-word-8e6a56b5f9c08d8f86ad97002a04c7a7.jpeg)
Please check which one is correct.