### PR TITLE
Change isOperatorFor(..) to authorizedAmountFor(..) in LSP7

### DIFF
--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -29,6 +29,6 @@ const ERC725X_ID = INTERFACE_IDS.ERC725X
 | **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |               |
 | **LSP1UniversalReceiverDelegate** | `0xa245bbda` | Universal Receiver delegated to an other smart contract.              |
 | **LSP6KeyManager**                | `0xc403d48f` | Controller for the ERC725Account.                                     |
-| **LSP7DigitalAsset**              | `0xe33f65c3` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
+| **LSP7DigitalAsset**              | `0x5fcaac27` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
 | **LSP8IdentifiableDigitalAsset**  | `0x49399145` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |
 | **LSP9Vault**                     | `0x8c1d44f6` | Vault that could interact with other smart contracts and hold assets. |

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -163,10 +163,10 @@ _Triggers the **[RevokedOperator](#revokedoperator)** event when an address get 
 
 :::
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(
+function authorizedAmountFor(
     address tokenOwner,
     address operator
 ) public view returns (uint256 amount)


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ Breaking Change

- Change `isOperatorFor` in LSP7 docs to `authorizedAmountFor`
- Update the `interfaceId` of LSP7 `0xe33f65c3` -> `0x5fcaac27`

## Why is this PR needed?

`isOperatorFor(address operator, address tokenOwner)` this method returns `uint256`, the amount of tokens that `operator` is authorised to spend on behalf of `tokenOwner`. The naming of the method is quite misleading as one would expect that `isOperatorFor` would return a `bool`. That’s why the name `authorizedAmountFor` would fit better in this context.