### PR TITLE
Update LSP0 and LSP9 InterfaceIds

### DIFF
--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -25,10 +25,10 @@ const ERC725X_ID = INTERFACE_IDS.ERC725X
 | **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.    
 | **ERC725X**                       | `0x44c028fe` | General executor.                                                     |
 | **ERC725Y**                       | `0x714df77c` | General Data key-value store.                                         |
-| **LSP0ERC725Account**             | `0x9a3bfe88` | Account that represent an identity on-chain                           |
+| **LSP0ERC725Account**             | `0xeb6be62e` | Account that represent an identity on-chain                           |
 | **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |               |
 | **LSP1UniversalReceiverDelegate** | `0xa245bbda` | Universal Receiver delegated to an other smart contract.              |
 | **LSP6KeyManager**                | `0xc403d48f` | Controller for the ERC725Account.                                     |
 | **LSP7DigitalAsset**              | `0x5fcaac27` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
 | **LSP8IdentifiableDigitalAsset**  | `0x49399145` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |
-| **LSP9Vault**                     | `0x8c1d44f6` | Vault that could interact with other smart contracts and hold assets. |
+| **LSP9Vault**                     | `0xfd4d5c50` | Vault that could interact with other smart contracts and hold assets. |


### PR DESCRIPTION
## What does this PR introduce?

- Update InterfaceId of LSP0 and LSP9.

Updating ClaimOwnership InterfaceId affected LSP0 and LSP9 InterfaceIds as renounceOwnership function is part of the InterfaceId.