### PR TITLE
update `DataChanged` event with value param + add notice for LSPs

### DIFF
--- a/docs/standards/smart-contracts/erc725-contract.md
+++ b/docs/standards/smart-contracts/erc725-contract.md
@@ -276,16 +276,17 @@ _**MUST** be fired when the **[`execute(...)`](#execute)** function creates a ne
 ### DataChanged
 
 ```solidity
-event DataChanged(bytes32 dataKey)
+event DataChanged(bytes32 dataKey, bytes dataValue)
 ```
 
 _**MUST** be fired when the **[`setData(...)`](#setdata)** function is successfully executed._
 
 #### Values:
 
-| Name        | Type    | Description                      |
-| :---------- | :------ | :------------------------------- |
-| `dataKey`   | bytes32 | The data key which value is set. |
+| Name        | Type    | Description                           |
+| :---------- | :------ | :------------------------------------ |
+| `dataKey`   | bytes32 | The data key which data value is set. |
+| `dataValue` | bytes   | The data value to set.                |
 
 
 ## References

--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -412,16 +412,21 @@ _**MUST** be fired when the **[`execute(...)`](#execute)** function creates a ne
 ### DataChanged
 
 ```solidity
-event DataChanged(bytes32 dataKey)
+event DataChanged(bytes32 dataKey, bytes dataValue)
 ```
 
 _**MUST** be fired when the **[`setData(...)`](#setdata)** function is successfully executed._
 
 #### Values:
 
-| Name        | Type    | Description                      |
-| :---------- | :------ | :------------------------------- |
-| `dataKey`   | bytes32 | The data key which value is set. |
+| Name        | Type    | Description                           |
+| :---------- | :------ | :------------------------------------ |
+| `dataKey`   | bytes32 | The data key which data value is set. |
+| `dataValue` | bytes   | The data value to set.                |
+
+:::info
+The `DataChanged` event will emit only the first 256 bytes of `dataValue` (for large values set in the ERC725Y storage).
+:::
 
 ### UniversalReceiver
 

--- a/docs/standards/smart-contracts/lsp4-digital-asset-metadata.md
+++ b/docs/standards/smart-contracts/lsp4-digital-asset-metadata.md
@@ -57,6 +57,27 @@ Sets the **initial owner** of the contract and the following data keys on the **
 | `symbol_`   | string  | The symbol of the token.   |
 | `newOwner_` | address | The owner of the contract. |
 
+## Events
+
+### DataChanged
+
+```solidity
+event DataChanged(bytes32 dataKey, bytes dataValue)
+```
+
+_**MUST** be fired when the **[`setData(...)`](#setdata)** function is successfully executed._
+
+#### Values:
+
+| Name        | Type    | Description                           |
+| :---------- | :------ | :------------------------------------ |
+| `dataKey`   | bytes32 | The data key which data value is set. |
+| `dataValue` | bytes   | The data value to set.                |
+
+:::info
+The `DataChanged` event will emit only the first 256 bytes of `dataValue` (for large values set in the ERC725Y storage).
+:::
+
 ## References
 
 - [LUKSO Standards Proposals: LSP4 - DigitalAsset-Metadata (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -388,16 +388,23 @@ _**MUST** be fired when the **[`execute(...)`](#execute)** function creates a ne
 ### DataChanged
 
 ```solidity
-event DataChanged(bytes32 dataKey)
+event DataChanged(bytes32 dataKey, bytes dataValue)
 ```
 
 _**MUST** be fired when the **[`setData(...)`](#setdata)** function is successfully executed._
 
 #### Values:
 
-| Name        | Type    | Description                      |
-| :---------- | :------ | :------------------------------- |
-| `dataKey`   | bytes32 | The data key which value is set. |
+| Name        | Type    | Description                           |
+| :---------- | :------ | :------------------------------------ |
+| `dataKey`   | bytes32 | The data key which data value is set. |
+| `dataValue` | bytes   | The data value to set.                |
+
+:::info
+The `DataChanged` event will emit only the first 256 bytes of `dataValue` (for large values set in the ERC725Y storage).
+:::
+
+
 
 ### UniversalReceiver
 


### PR DESCRIPTION
add the extra parameter in the ERC725 Smart Contract ABI + extra notice about max number of bytes emitted for LSP0, LSP4 and LSP9.

For reference, see:

- https://github.com/ERC725Alliance/ERC725/pull/163
- https://github.com/lukso-network/lsp-smart-contracts/pull/301