### PR TITLE
Switch last 2 parameters of the UniversalReceiver event

### DIFF
--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -450,7 +450,7 @@ _**MUST** be fired when the **[`universalReceiver(...)`](#universalreceiver)** f
 | `value`         | uint256 | The amount of value sent to the **universalReceiver** function. |
 | `typeId`        | bytes32 | The hash of a specific standard or a hook.                      |
 | `receivedData`  | bytes   | The arbitrary data passed to **universalReceiver** function.    |
-| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
+| `returnedValue` | bytes   | The value returned by the **universalReceiver** function.             |
 
 ## References
 

--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -435,8 +435,8 @@ event UniversalReceiver(
     address from,
     uint256 value,
     bytes32 typeId,
-    bytes returnedValue,
     bytes receivedData
+    bytes returnedValue,
 )
 ```
 
@@ -449,8 +449,8 @@ _**MUST** be fired when the **[`universalReceiver(...)`](#universalreceiver)** f
 | `from`          | address | The address calling the **universalReceiver** function.         |
 | `value`         | uint256 | The amount of value sent to the **universalReceiver** function. |
 | `typeId`        | bytes32 | The hash of a specific standard or a hook.                      |
-| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
 | `receivedData`  | bytes   | The arbitrary data passed to **universalReceiver** function.    |
+| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
 
 ## References
 

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -427,7 +427,7 @@ _**MUST** be fired when the **[`universalReceiver(...)`](#universalreceiver)** f
 | `value`         | uint256 | The amount of value sent to the **universalReceiver** function. |
 | `typeId`        | bytes32 | The hash of a specific standard or a hook.                      |
 | `receivedData`  | bytes   | The arbitrary data passed to **universalReceiver** function.    |
-| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
+| `returnedValue` | bytes   | The value returned by the **universalReceiver** function.       |
 
 ## References
 

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -412,8 +412,8 @@ event UniversalReceiver(
     address from,
     uint256 value,
     bytes32 typeId,
-    bytes returnedValue,
     bytes receivedData
+    bytes returnedValue,
 )
 ```
 
@@ -426,8 +426,8 @@ _**MUST** be fired when the **[`universalReceiver(...)`](#universalreceiver)** f
 | `from`          | address | The address calling the **universalReceiver** function.         |
 | `value`         | uint256 | The amount of value sent to the **universalReceiver** function. |
 | `typeId`        | bytes32 | The hash of a specific standard or a hook.                      |
-| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
 | `receivedData`  | bytes   | The arbitrary data passed to **universalReceiver** function.    |
+| `returnedValue` | bytes   | The return value of **universalReceiver** function.             |
 
 ## References
 


### PR DESCRIPTION
## What does this PR introduce?

- Switch between receivedData and returnedValue parameters.

Before: 
```js
event UniversalReceiver(
     address indexed from,
     uint256 value,
     bytes32 indexed typeId,
     bytes indexed returnedValue,
     bytes receivedData,
);
```
Now: 

```js
event UniversalReceiver(
     address indexed from,
     uint256 indexed value,
     bytes32 indexed typeId,
     bytes receivedData,
     bytes returnedValue
);
```

Note: Event signature will not change since both switched parameters are bytes.