### PR TITLE
Add a Smart Contracts ABI page for LSP2Utils.sol, LSP5Utils.sol, LSP6Utils.sol & LSP10Utils.sol

### DIFF
--- a/docs/standards/smart-contracts/lsp10-received-vaults-utils.md
+++ b/docs/standards/smart-contracts/lsp10-received-vaults-utils.md
@@ -1,0 +1,93 @@
+---
+title: LSP6KeyManagerUtils
+sidebar_position: 15
+---
+
+# LSP6KeyManagerUtils
+
+:::info
+
+[`LSP10Utils.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP10ReceivedVaults/LSP10Utils.sol)
+
+:::
+
+This library should be used to generate ERC725Y data keys and values for transferring vaults (LSP9).
+
+## Functions
+
+### getPermissionsFor
+
+```solidity
+function generateReceivedVaultKeys(
+    address receiver,
+    address vault,
+    bytes32 vaultMapKey,
+    bytes4 interfaceID
+) internal view returns (bytes32[] memory keys, bytes[] memory values);
+```
+
+Generating the data keys/values to be set on the receiver address after receiving vaults.
+
+#### Parameters:
+
+| Name        | Type    | Description                                                                                                 |
+| :---------- | :------ | :---------------------------------------------------------------------------------------------------------- |
+| receiver    | address | The address receiving the vault and where the Keys should be added.                                         |
+| vault       | address | The address of the vault being received.                                                                    |
+| vaultMapKey | bytes32 | The map key of the vault being received containing the interfaceId of the vault and the index in the array. |
+| interfaceID | bytes4  | The interfaceID of the vault being received.                                                                |
+
+#### Return Values:
+
+| Name     | Type      | Description           |
+| :------- | :-------- | :-------------------- |
+| `keys`   | bytes32[] | Array of data keys.   |
+| `values` | bytes[]   | Array of data values. |
+
+### generateSentVaultKeys
+
+```solidity
+function generateSentVaultKeys(
+    address sender,
+    bytes32 vaultMapKey,
+    bytes memory vaultInterfaceIdAndIndex
+) internal view returns (bytes32[] memory keys, bytes[] memory values)
+```
+
+Generating the data keys/values to be set on the sender address after sending vaults.
+
+#### Parameters:
+
+| Name                     | Type    | Description                                                                                             |
+| :----------------------- | :------ | :------------------------------------------------------------------------------------------------------ |
+| sender                   | address | The address sending the vault and where the Keys should be updated.                                     |
+| vaultMapKey              | bytes32 | The map key of the vault being sent containing the interfaceId of the vault and the index in the array. |
+| vaultInterfaceIdAndIndex | bytes   | The value of the map key of the vault being sent.                                                       |
+
+#### Return Values:
+
+| Name     | Type      | Description           |
+| :------- | :-------- | :-------------------- |
+| `keys`   | bytes32[] | Array of data keys.   |
+| `values` | bytes[]   | Array of data values. |
+
+### extractIndexFromMap
+
+```solidity
+function extractIndexFromMap(
+    bytes memory mapValue
+) internal pure returns (uint64);
+```
+
+Extracts the index from a mapping of `valueType` (bytes8,bytes4) and `valueContent` (Bytes4,Number).
+Returns an index of type uint64.
+
+#### Parameters:
+
+| Name     | Type  | Description                                                                         |
+| :------- | :---- | :---------------------------------------------------------------------------------- |
+| mapValue | bytes | A bytes12 mapping of `valueType` (bytes8,bytes4) and `valueContent` (Bytes4,Number) |
+
+## References
+
+- [Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts)

--- a/docs/standards/smart-contracts/lsp2-json-schema-utils.md
+++ b/docs/standards/smart-contracts/lsp2-json-schema-utils.md
@@ -1,0 +1,326 @@
+---
+title: LSP2JSONSchemaUtils
+sidebar_position: 12
+---
+
+# LSP2JSONSchemaUtils
+
+:::info
+
+[`LSP2Utils.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol)
+
+:::
+
+This library should be used to generate ERC725Y keys described in the JSON Schema.
+
+## Functions
+
+### generateSingletonKey
+
+```solidity
+function generateSingletonKey(
+    string memory keyName
+) internal pure returns (bytes32);
+```
+
+Generates a data key of `keyType` Singleton.
+
+#### Parameters:
+
+| Name      | Type   | Description                                          |
+| :-------- | :----- | :--------------------------------------------------- |
+| `keyName` | string | The string to hash to generate a Singleton data key. |
+
+#### Return Values:
+
+| Name     | Type    | Description                      |
+| :------- | :------ | :------------------------------- |
+| `result` | bytes32 | Data key of `keyType` Singleton. |
+
+### generateArrayKey
+
+```solidity
+function generateArrayKey(
+    string memory keyName
+) internal pure returns (bytes32);
+```
+
+Generates a data key of `keyType` Array by hashing `keyName`.
+
+#### Parameters:
+
+| Name      | Type   | Description                                                             |
+| :-------- | :----- | :---------------------------------------------------------------------- |
+| `keyName` | string | The string that will be used to generate an data key of `keyType` Array |
+
+#### Return Values:
+
+| Name     | Type    | Description                  |
+| :------- | :------ | :--------------------------- |
+| `result` | bytes32 | Data key of `keyType` Array. |
+
+### generateArrayElementKeyAtIndex
+
+```solidity
+function generateArrayElementKeyAtIndex(
+    bytes32 arrayKey,
+    uint256 index
+) internal pure returns (bytes32);
+```
+
+Generates a Array index data key by concatenating the first 16 bytes of `arrayKey` and `index` transformed from uint256 to bytes16 (uint256 -> uint128 -> bytes16)
+
+#### Parameters:
+
+| Name      | Type    | Description                                                                       |
+| :-------- | :------ | :-------------------------------------------------------------------------------- |
+| `keyName` | string  | The key from which we're getting the first half of the Array index data key from. |
+| `index`   | uint256 | Used to generate the second half of the Array index data key.                     |
+
+#### Return Values:
+
+| Name     | Type    | Description                        |
+| :------- | :------ | :--------------------------------- |
+| `result` | bytes32 | Data key of `keyType` Array Index. |
+
+### generateMappingKey(string,srting)
+
+```solidity
+function generateMappingKey(
+    string memory firstWord,
+    string memory lastWord
+) internal pure returns (bytes32);
+```
+
+Generates a data key of `keyType` Mapping by hashing two strings:
+`<bytes10(keccak256(firstWord))>:<bytes2(0)>:<bytes20(keccak256(firstWord))>`
+
+#### Parameters:
+
+| Name        | Type   | Description                                                                                                      |
+| :---------- | :----- | :--------------------------------------------------------------------------------------------------------------- |
+| `firstWord` | string | Used to generate a hash and its first 10 bytes are used for the first part of the data key of `keyType` Mapping. |
+| `lastWord`  | string | Used to generate a hash and its first 20 bytes are used for the last part of the data key of `keyType` Mapping.  |
+
+#### Return Values:
+
+| Name     | Type    | Description                    |
+| :------- | :------ | :----------------------------- |
+| `result` | bytes32 | Data key of `keyType` Mapping. |
+
+### generateMappingKey(string,address)
+
+```solidity
+function generateMappingKey(
+    string memory firstWord,
+    address addr
+) internal pure returns (bytes32);
+```
+
+Generates a data key of `keyType` Mapping by hashing a string and concatenating it with an address:
+`<bytes10(keccak256(firstWord))>:<bytes2(0)>:<bytes20(addr)>`
+
+#### Parameters:
+
+| Name        | Type    | Description                                                                                                      |
+| :---------- | :------ | :--------------------------------------------------------------------------------------------------------------- |
+| `firstWord` | string  | Used to generate a hash and its first 10 bytes are used for the first part of the data key of `keyType` Mapping. |
+| `addr`      | address | Used for the last part of the data key of `keyType` Mapping.                                                     |
+
+#### Return Values:
+
+| Name     | Type    | Description                    |
+| :------- | :------ | :----------------------------- |
+| `result` | bytes32 | Data key of `keyType` Mapping. |
+
+### generateMappingKey(bytes10,bytes20)
+
+```solidity
+function generateMappingKey(
+    bytes10 keyPrefix,
+    bytes20 bytes20Value
+) internal pure returns (bytes32);
+```
+
+Generate a data key of `keyType` Mapping:
+`<keyPrefix>:<bytes2(0)>:<bytes20Value>`
+
+#### Parameters:
+
+| Name           | Type    | Description                                       |
+| :------------- | :------ | :------------------------------------------------ |
+| `keyPrefix`    | bytes10 | First part of the data key of `keyType` Mapping.  |
+| `bytes20Value` | bytes20 | Second part of the data key of `keyType` Mapping. |
+
+#### Return Values:
+
+| Name     | Type    | Description                    |
+| :------- | :------ | :----------------------------- |
+| `result` | bytes32 | Data key of `keyType` Mapping. |
+
+### generateMappingWithGroupingKey(string,string,address)
+
+```solidity
+function generateMappingWithGroupingKey(
+    string memory firstWord,
+    string memory secondWord,
+    address addr
+) internal pure returns (bytes32);
+```
+
+Generate a data key of `keyType` MappingWithGrouping by using two strings and an address:
+`<bytes6(keccak256(firstWord))>:<bytes4(keccak256(secondWord))>:<bytes2(0)>:<bytes20(addr)>`
+
+#### Parameters:
+
+| Name         | Type    | Description                                                                                                                  |
+| :----------- | :------ | :--------------------------------------------------------------------------------------------------------------------------- |
+| `firstWord`  | string  | Used to generate a hash and its first 6 bytes are used for the first part of the data key of `keyType` MappingWithGrouping.  |
+| `secondWord` | string  | Used to generate a hash and its first 4 bytes are used for the second part of the data key of `keyType` MappingWithGrouping. |
+| `addr`       | address | Used for the last part of the data key of `keyType` MappingWithGrouping.                                                     |
+
+#### Return Values:
+
+| Name     | Type    | Description                                |
+| :------- | :------ | :----------------------------------------- |
+| `result` | bytes32 | Data key of `keyType` MappingWithGrouping. |
+
+### generateMappingWithGroupingKey(bytes10,bytes20)
+
+```solidity
+function generateMappingWithGroupingKey(
+    bytes10 keyPrefix,
+    bytes20 bytes20Value
+) internal pure returns (bytes32);
+```
+
+Generate a data key of `keyType` MappingWithGrouping:
+`<keyPrefix>:<bytes2(0)>:<bytes20Value>`
+
+#### Parameters:
+
+| Name           | Type    | Description                                                               |
+| :------------- | :------ | :------------------------------------------------------------------------ |
+| `keyPrefix`    | bytes10 | Used for the first part of the data key of `keyType` MappingWithGrouping. |
+| `bytes20Value` | bytes20 | Used for the first last of the data key of `keyType` MappingWithGrouping. |
+
+#### Return Values:
+
+| Name     | Type    | Description                                |
+| :------- | :------ | :----------------------------------------- |
+| `result` | bytes32 | Data key of `keyType` MappingWithGrouping. |
+
+### generateJSONURLValue
+
+```solidity
+function generateJSONURLValue(
+    string memory hashFunction,
+    string memory json,
+    string memory url
+) internal pure returns (bytes memory key);
+```
+
+Generate a JSONURL valueContent.
+
+#### Parameters:
+
+| Name           | Type   | Description                              |
+| :------------- | :----- | :--------------------------------------- |
+| `hashFunction` | string | The function used to hash the JSON file. |
+| `json`         | string | Bytes value of the JSON file.            |
+| `url`          | string | The URL where the JSON file is hosted.   |
+
+#### Return Values:
+
+| Name     | Type    | Description     |
+| :------- | :------ | :-------------- |
+| `result` | bytes32 | JSON URL Value. |
+
+### generateASSETURLValue
+
+```solidity
+function generateASSETURLValue(
+    string memory hashFunction,
+    string memory assetBytes,
+    string memory url
+) internal pure returns (bytes memory key);
+```
+
+Generate a ASSETURL valueContent.
+
+#### Parameters:
+
+| Name           | Type   | Description                              |
+| :------------- | :----- | :--------------------------------------- |
+| `hashFunction` | string | The function used to hash the JSON file. |
+| `assetBytes`   | string | Bytes value of the JSON file.            |
+| `url`          | string | The URL where the JSON file is hosted.   |
+
+#### Return Values:
+
+| Name     | Type    | Description      |
+| :------- | :------ | :--------------- |
+| `result` | bytes32 | ASSET URL Value. |
+
+### isEncodedArray
+
+```solidity
+function isEncodedArray(
+    bytes memory data
+) internal pure returns (bool);
+```
+
+Verifing if `data` is an encoded array
+
+#### Parameters:
+
+| Name   | Type  | Description                       |
+| :----- | :---- | :-------------------------------- |
+| `data` | bytes | The value that is to be verified. |
+
+### isEncodedArrayOfAddresses
+
+```solidity
+function isEncodedArrayOfAddresses(
+    bytes memory data
+) internal pure returns (bool);
+```
+
+Verifing if `data` is an encoded array of addresses (address[])
+
+#### Parameters:
+
+| Name   | Type  | Description                       |
+| :----- | :---- | :-------------------------------- |
+| `data` | bytes | The value that is to be verified. |
+
+### isBytes4EncodedArray
+
+```solidity
+function isBytes4EncodedArray(
+    bytes memory data
+) internal pure returns (bool);
+```
+
+Verify that `data` is an array of bytes4 (bytes4[]) encoded according to the Solidity ABI specs.
+
+#### Parameters:
+
+| Name   | Type  | Description                       |
+| :----- | :---- | :-------------------------------- |
+| `data` | bytes | The value that is to be verified. |
+
+### uncheckedIncrement
+
+```solidity
+uncheckedIncrement(
+    uint256 i
+) internal pure returns (uint256);
+```
+
+Will return unchecked incremented uint256.
+Can be used to save gas when iterating over loops.
+
+## References
+
+- [Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts)

--- a/docs/standards/smart-contracts/lsp5-received-assets-utils.md
+++ b/docs/standards/smart-contracts/lsp5-received-assets-utils.md
@@ -1,0 +1,93 @@
+---
+title: LSP5ReceivedAssetsUtils
+sidebar_position: 13
+---
+
+# LSP5ReceivedAssetsUtils
+
+:::info
+
+[`LSP5Utils.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP5ReceivedAsstes/LSP5Utils.sol)
+
+:::
+
+This library should be used to generate ERC725Y data keys and values for transferring assets (LSP7 & LSP8).
+
+## Functions
+
+### generateReceivedAssetKeys
+
+```solidity
+function generateReceivedAssetKeys(
+    address receiver,
+    address asset,
+    bytes32 assetMapKey,
+    bytes4 interfaceID
+) internal view returns (bytes32[] memory keys, bytes[] memory values);
+```
+
+Generating the data keys/values to be set on the receiver address after receiving assets.
+
+#### Parameters:
+
+| Name          | Type    | Description                                                                                                 |
+| :------------ | :------ | :---------------------------------------------------------------------------------------------------------- |
+| `receiver`    | address | The address receiving the asset and where the Keys should be added.                                         |
+| `asset`       | address | The address of the asset being received.                                                                    |
+| `assetMapKey` | bytes32 | The map key of the asset being received containing the interfaceId of the asset and the index in the array. |
+| `interfaceID` | bytes4  | The interfaceID of the asset being received.                                                                |
+
+#### Return Values:
+
+| Name     | Type      | Description           |
+| :------- | :-------- | :-------------------- |
+| `keys`   | bytes32[] | Array of data keys.   |
+| `values` | bytes[]   | Array of data values. |
+
+### generateSentAssetKeys
+
+```solidity
+function generateSentAssetKeys(
+    address sender,
+    bytes32 assetMapKey,
+    bytes memory assetInterfaceIdAndIndex
+) internal view returns (bytes32[] memory keys, bytes[] memory values);
+```
+
+Generating the data keys/values to be set on the sender address after sending assets.
+
+#### Parameters:
+
+| Name                     | Type    | Description                                                                                                 |
+| :----------------------- | :------ | :---------------------------------------------------------------------------------------------------------- |
+| sender                   | address | The address sending the asset and where the Keys should be updated.                                         |
+| assetMapKey              | bytes32 | The map key of the asset being received containing the interfaceId of the asset and the index in the array. |
+| assetInterfaceIdAndIndex | bytes   | The value of the map key of the asset being sent.                                                           |
+
+#### Return Values:
+
+| Name     | Type      | Description           |
+| :------- | :-------- | :-------------------- |
+| `keys`   | bytes32[] | Array of data keys.   |
+| `values` | bytes[]   | Array of data values. |
+
+### extractIndexFromMap
+
+```solidity
+function extractIndexFromMap(
+    bytes memory mapValue
+) internal pure returns (uint64);
+```
+
+Extracts the index from a mapping of `valueType` (bytes8,bytes4) and `valueContent` (Bytes4,Number).
+Returns an index of type uint64.
+
+#### Parameters:
+
+| Name     | Type  | Description                                                                         |
+| :------- | :---- | :---------------------------------------------------------------------------------- |
+| mapValue | bytes | A bytes12 mapping of `valueType` (bytes8,bytes4) and `valueContent` (Bytes4,Number) |
+
+## References
+
+- [Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts)

--- a/docs/standards/smart-contracts/lsp6-key-manager-utils.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager-utils.md
@@ -1,0 +1,182 @@
+---
+title: LSP6KeyManagerUtils
+sidebar_position: 14
+---
+
+# LSP6KeyManagerUtils
+
+:::info
+
+[`LSP6Utils.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP6KeyManager/LSP6Utils.sol)
+
+:::
+
+This library should be used to querry the permissions that a controller address has for a Key Manager Controlled ERC725 Account.
+
+## Functions
+
+### getPermissionsFor
+
+```solidity
+function getPermissionsFor(
+    IERC725Y target,
+    address caller
+) internal view returns (bytes32);
+```
+
+Returns the permissions of the `caller` for the ERC725Y `target`.
+
+#### Parameters:
+
+| Name   | Type     | Description                   |
+| :----- | :------- | :---------------------------- |
+| target | IERC725Y | A valid `IERC725Y` interface. |
+| caller | address  | The controller address.       |
+
+#### Return Value
+
+Returns a `bytes32` BitArray containing the permissions of a controller address.
+
+### getAllowedAddressesFor
+
+```solidity
+function getAllowedAddressesFor(
+    IERC725Y target,
+    address caller
+) internal view returns (bytes memory);
+```
+
+Returns the allowed addresses of the `caller` for the ERC725Y `target`.
+
+#### Parameters:
+
+| Name   | Type     | Description                   |
+| :----- | :------- | :---------------------------- |
+| target | IERC725Y | A valid `IERC725Y` interface. |
+| caller | address  | The controller address.       |
+
+#### Return Value
+
+Returns an encoded `bytes` value which contains an array of allowed addresses (to interact with) for the controller address.
+
+### getAllowedFunctionsFor
+
+```solidity
+function getAllowedFunctionsFor(
+    IERC725Y target,
+    address caller
+) internal view returns (bytes memory);
+```
+
+Returns the allowed functions of the `caller` for the ERC725Y `target`.
+
+#### Parameters:
+
+| Name   | Type     | Description                   |
+| :----- | :------- | :---------------------------- |
+| target | IERC725Y | A valid `IERC725Y` interface. |
+| caller | address  | The controller address.       |
+
+#### Return Value
+
+Returns an encoded `bytes` value which contains an array of allowed function signatures (to interact with) for the controller address.
+
+### getAllowedStandardsFor
+
+```solidity
+function getAllowedStandardsFor(
+    IERC725Y target,
+    address caller
+) internal view returns (bytes memory);
+```
+
+Returns the allowed standards of the `caller` for the ERC725Y `target`.
+
+#### Parameters:
+
+| Name   | Type     | Description                   |
+| :----- | :------- | :---------------------------- |
+| target | IERC725Y | A valid `IERC725Y` interface. |
+| caller | address  | The controller address.       |
+
+#### Return Value
+
+Returns an encoded `bytes` value which contains an array of allowed standards/interfaceIds (to interact with) for the controller address.
+
+### getAllowedERC725YKeysFor
+
+```solidity
+function getAllowedERC725YKeysFor(
+    IERC725Y target,
+    address caller
+) internal view returns (bytes memory);
+```
+
+Returns the allowed ERC725Y keys of the `caller` for the ERC725Y `target`.
+
+#### Parameters:
+
+| Name   | Type     | Description                   |
+| :----- | :------- | :---------------------------- |
+| target | IERC725Y | A valid `IERC725Y` interface. |
+| caller | address  | The controller address.       |
+
+#### Return Value
+
+Returns an encoded `bytes` value which contains an array of allowed ERC725 keys (to interact with) for the controller address.
+
+### hasPermission
+
+```solidity
+function hasPermission(
+    bytes32 addressPermission,
+    bytes32 permissionToCheck
+) internal pure returns (bool);
+```
+
+Compare the permissions `addressPermissions` of an address to check if they includes the permissions `permissionToCheck`.
+
+#### Parameters:
+
+| Name              | Type    | Description                                                |
+| :---------------- | :------ | :--------------------------------------------------------- |
+| addressPermission | bytes32 | The permissions of an address stored on an ERC725 account. |
+| permissionToCheck | bytes32 | The permissions to check.                                  |
+
+#### Return Value
+
+Returns `true` if `addressPermission` is containing the `permissionToCheck`.
+
+### hasPermission
+
+```solidity
+/**
+     * @dev use the `setData(bytes32[],bytes[])` via the KeyManager of the target
+     * @param keyManagerAddress the address of the KeyManager
+     * @param keys the array of data keys
+     * @param values the array of data values
+     */
+function setDataViaKeyManager(
+    address keyManagerAddress,
+    bytes32[] memory keys,
+    bytes[] memory values
+) internal returns (bytes memory result)
+```
+
+Use the `setData(bytes32[],bytes[])` via the KeyManager of the target.
+
+#### Parameters:
+
+| Name              | Type      | Description                     |
+| :---------------- | :-------- | :------------------------------ |
+| keyManagerAddress | address   | Tthe address of the KeyManager. |
+| keys              | bytes32[] | The array of data keys.         |
+| values            | bytes[]   | The array of data values.       |
+
+#### Return Value
+
+Returns the reuslt of the external call.
+
+## References
+
+- [Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts)


### PR DESCRIPTION
## What does this PR introduce?

In this PR we introduce 4 new pages for describing the Smart Contract ABI of the following contracts:
- LSP2Utils.sol
- LSP5Utils.sol
- LSP6Utils.sol
- LSP10Utils.sol