### PR TITLE
chore: specifying the type of timestamp

### DIFF
--- a/docs/standards/relayer-api.md
+++ b/docs/standards/relayer-api.md
@@ -36,7 +36,7 @@ Executes a signed transaction on behalf of a Universal Profile using [`executeRe
 
 Returns the available quota left for a registered Universal Profile.
 
-- `signature` is the message value signed by a controller key with the [`SIGN` permission](./universal-profile/lsp6-key-manager#permissions) of the Universal Profile. The hash to sign should be calculated as `keccack256(address, timestamp)`. To calculate the hash to verify the signature in the backed code, we use the solidity way: [soliditysha3()](https://web3js.readthedocs.io/en/v1.7.4/web3-utils.html#soliditysha3).
+- `signature` is the message value signed by a controller key with the [`SIGN` permission](./universal-profile/lsp6-key-manager#permissions) of the Universal Profile. The hash to sign should be calculated as `keccack256(address, timestamp)`. Make sure that no matter the language or platform timestamp is of type `int`, `int256`, `uint` or `uint256`. To calculate the hash to verify the signature in the backed code, we use the solidity way: [soliditysha3()](https://web3js.readthedocs.io/en/v1.7.4/web3-utils.html#soliditysha3).
 - `timestamp` in **seconds**. Must be now +/- 5 seconds.
 
 <details>


### PR DESCRIPTION
Timestamp type specification must be in place to make sure the hash is calculated correctly across all platforms. Had issues in iOS that weren't right away obvious with hash calculation because the timestamp type used was `UInt64` but it had to be `UInt`.

Note: that in [soliditysha3()](https://web3js.readthedocs.io/en/v1.7.4/web3-utils.html#soliditysha3) `int` is by default converted to `int256`. Same applies to `uint`.

https://github.com/web3/web3.js/blob/1b42e65fdaca901c88ba00e303db99971c3196cc/packages/web3-utils/src/soliditySha3.js#L33