### PR TITLE
improve explanation for SIGN permission

### DIFF
--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -187,7 +187,7 @@ Developers can use the `DECRYPT` permission to decrypt data or messages, for ins
         <b>value = </b><code>0x0000000000000000000000000000000000000000000000000000000000000800</code>
     </p>
 
-Developers can use the `SIGN` permission for keys to sign login messages. It is primarily for web2.0 apps to know which key SHOULD sign.
+The permission `SIGN` enables an address to authenticate on behalf of the UP. It can be used primarily in web2.0 apps to sign login messages.
 
 </details>
 

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -187,7 +187,7 @@ Developers can use the `DECRYPT` permission to decrypt data or messages, for ins
         <b>value = </b><code>0x0000000000000000000000000000000000000000000000000000000000000800</code>
     </p>
 
-The permission `SIGN` enables an address to authenticate on behalf of the UP. It can be used primarily in web2.0 apps to sign login messages.
+The permission `SIGN` enables an address to authenticate on behalf of the UP. It can be used primarily in web2.0 apps to [sign login messages](../../guides/browser-extension/sign-in-with-ethereum).
 
 </details>
 


### PR DESCRIPTION
In the Standard page for the LSP6 Key Manager, the description for the permission `SIGN` seems quite confusing and not clear. See screenshot below.

![image](https://user-images.githubusercontent.com/31145285/201148786-f245c506-4252-4250-8a79-af27c68d45fb.png)

Just reworded it as follow to something more simple and straight forward.

![image](https://user-images.githubusercontent.com/31145285/201149020-f93104f2-c8d9-4068-a849-c2b7882d97b5.png)


