### PR TITLE
Update Smart Contract ABIs references + interface IDs

### DIFF
--- a/docs/standards/smart-contracts/erc725-contract.md
+++ b/docs/standards/smart-contracts/erc725-contract.md
@@ -165,6 +165,53 @@ Retrieves the data set for the given data key.
 | :---------- | :---- | :----------------------------------- |
 | `dataValue` | bytes | The data for the requested data key. |
 
+### execute (Array) - ERC725X
+
+```solidity
+function execute(
+    uint256[] memory operationsType,
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory memory datas
+) public payable returns (bytes memory result)
+```
+
+Same as [`execute(uint256,address,uint256,bytes)`](#execute---erc725x) but executes a batch of calls on any other smart contracts, transferring values, or deploying new smart contracts.
+
+The values in the list of `operationsType` can be one of the following:
+
+- `0` for `CALL`
+- `1` for `CREATE`
+- `2` for `CREATE2`
+- `3` for `STATICCALL`
+- `4` for `DELEGATECALL`
+
+_Triggers the **[Executed](#executed)** event on every successful call that used operation type `CALL`, `STATICCALL` or `DELEGATECALL`._
+
+_Triggers the **[ContractCreated](#contractcreated)** event on every newly created smart contract that used operation `CREATE` or `CREATE2`._
+
+:::note
+The `execute(uint256[],address[],uint256[],bytes[])` function can only be called by the current owner of the contract.
+
+The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
+:::
+
+#### Parameters:
+
+| Name             | Type        | Description                                                                                                                  |
+| :--------------- | :-----------| :--------------------------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                             |
+| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                          |
+| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                       |
+| `datas`          | `bytes[]`   | The calldatas (ABI-encoded payloads of functions to run on other contracts), or the bytecodes of the contracts to deploy. |
+
+#### Return Values:
+
+| Name     | Type  | Description                                                                                                                                        |
+| :------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `results` | `bytes[]` | The datas that were returned by the functions called on the external contracts, or the addresses of the contracts created (operations 1 & 2). |
+
+
 ### setData (Array) - ERC725Y 
 
 ```solidity

--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -14,26 +14,27 @@ _Interface IDs are not the most secure way to ensure that a contract implements 
 :::
 
 Interface IDs can be easily accessed in your code using the [LSP smart contract NPM package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts) as follows. The accessible interface IDs can be found in the [constants.js file](https://github.com/lukso-network/lsp-smart-contracts/blob/main/constants.js)
-```js
-import { INTERFACE_IDS } from "@lukso/lsp-smart-contracts/constants.js"
 
-const ERC725X_ID = INTERFACE_IDS.ERC725X
+```js
+import { INTERFACE_IDS } from '@lukso/lsp-smart-contracts/constants.js';
+
+const ERC725X_ID = INTERFACE_IDS.ERC725X;
 ```
 
-| Contract                          | InterfaceId   Description                                                            |
-| :-------------------------------- | :----------- | :-------------------------------------------------------------------- |
-| **ERC165**                        | `0x01ffc9a7` | Standard Interface Detection                                          |
-| **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.                   |
-| **ERC725X**                       | `0x570ef073` | General executor.                                                     |
-| **ERC725Y**                       | `0x714df77c` | General Data key-value store.                                         |
-| **LSP0ERC725Account**             | `0xcf6e8efc` | Account that represent an identity on-chain                           |
-| **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |
-| **LSP1UniversalReceiverDelegate** | `0xa245bbda` | Universal Receiver delegated to an other smart contract.              |
-| **LSP6KeyManager**                | `0xf9150d55` | Controller for the ERC725Account.                                     |
-| **LSP7DigitalAsset**              | `0xda1f85e4` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
-| **LSP8IdentifiableDigitalAsset**  | `0x622e7a01` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |
-| **LSP9Vault**                     | `0xd9483482` | Vault that can interact with other smart contracts and hold assets.   |
-| **LSP14Ownable2Steps**            | `0x94be5999` | Extended version of [EIP173] (Ownable) with a 2-step process to transfer or renounce ownership. |
+| Contract                         | InterfaceId Description |
+| :------------------------------- | :---------------------- | :---------------------------------------------------------------------------------------------- |
+| **ERC165**                       | `0x01ffc9a7`            | Standard Interface Detection                                                                    |
+| **ERC1271**                      | `0x1626ba7e`            | Standard Signature Validation Method for Contracts.                                             |
+| **ERC725X**                      | `0x570ef073`            | General executor.                                                                               |
+| **ERC725Y**                      | `0x714df77c`            | General Data key-value store.                                                                   |
+| **LSP0ERC725Account**            | `0x66767497`            | Account that represent an identity on-chain                                                     |
+| **LSP1UniversalReceiver**        | `0x6bb56a14`            | Universal Receiver entry function.                                                              |
+| **LSP6KeyManager**               | `0xfb437414`            | Controller for the ERC725Account.                                                               |
+| **LSP7DigitalAsset**             | `0xda1f85e4`            | Digital Assets either fungible or non-fungible. _ERC20 A-like_                                  |
+| **LSP8IdentifiableDigitalAsset** | `0x622e7a01`            | Identifiable Digital Assets (NFT). _ERC721 A-like_                                              |
+| **LSP9Vault**                    | `0x7050cee9`            | Vault that can interact with other smart contracts and hold assets.                             |
+| **LSP14Ownable2Steps**           | `0x94be5999`            | Extended version of [EIP173] (Ownable) with a 2-step process to transfer or renounce ownership. |
+| **LSP17Extendable**              | `0xa918fa6b`            | Extension standard to extend functionalities of a contract via the `fallback` function.         |
+| **LSP17Extension**               | `0xcee78b40`            | Extension standard to build custom extensions for extendable contracts.                         |
 
-
-[EIP173]: https://eips.ethereum.org/EIPS/eip-173
+[eip173]: https://eips.ethereum.org/EIPS/eip-173

--- a/docs/standards/smart-contracts/interface-ids.md
+++ b/docs/standards/smart-contracts/interface-ids.md
@@ -20,15 +20,20 @@ import { INTERFACE_IDS } from "@lukso/lsp-smart-contracts/constants.js"
 const ERC725X_ID = INTERFACE_IDS.ERC725X
 ```
 
-| Contract                          | InterfaceId  | Description                                                           |
+| Contract                          | InterfaceId   Description                                                            |
 | :-------------------------------- | :----------- | :-------------------------------------------------------------------- |
-| **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.    
-| **ERC725X**                       | `0x44c028fe` | General executor.                                                     |
+| **ERC165**                        | `0x01ffc9a7` | Standard Interface Detection                                          |
+| **ERC1271**                       | `0x1626ba7e` | Standard Signature Validation Method for Contracts.                   |
+| **ERC725X**                       | `0x570ef073` | General executor.                                                     |
 | **ERC725Y**                       | `0x714df77c` | General Data key-value store.                                         |
-| **LSP0ERC725Account**             | `0xeb6be62e` | Account that represent an identity on-chain                           |
-| **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |               |
+| **LSP0ERC725Account**             | `0xcf6e8efc` | Account that represent an identity on-chain                           |
+| **LSP1UniversalReceiver**         | `0x6bb56a14` | Universal Receiver entry function.                                    |
 | **LSP1UniversalReceiverDelegate** | `0xa245bbda` | Universal Receiver delegated to an other smart contract.              |
-| **LSP6KeyManager**                | `0xc403d48f` | Controller for the ERC725Account.                                     |
-| **LSP7DigitalAsset**              | `0x5fcaac27` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
-| **LSP8IdentifiableDigitalAsset**  | `0x49399145` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |
-| **LSP9Vault**                     | `0xfd4d5c50` | Vault that could interact with other smart contracts and hold assets. |
+| **LSP6KeyManager**                | `0xf9150d55` | Controller for the ERC725Account.                                     |
+| **LSP7DigitalAsset**              | `0xda1f85e4` | Digital Assets either fungible or non-fungible. _ERC20 A-like_        |
+| **LSP8IdentifiableDigitalAsset**  | `0x622e7a01` | Identifiable Digital Assets (NFT). _ERC721 A-like_                    |
+| **LSP9Vault**                     | `0xd9483482` | Vault that can interact with other smart contracts and hold assets.   |
+| **LSP14Ownable2Steps**            | `0x94be5999` | Extended version of [EIP173] (Ownable) with a 2-step process to transfer or renounce ownership. |
+
+
+[EIP173]: https://eips.ethereum.org/EIPS/eip-173

--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -227,7 +227,7 @@ Retrieves the data set for the given data key.
 | :---------- | :---- | :----------------------------------- |
 | `dataValue` | bytes | The data for the requested data key. |
 
-### execute (Array) - ERC725X
+### execute (Array)
 
 ```solidity
 function execute(

--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -227,6 +227,53 @@ Retrieves the data set for the given data key.
 | :---------- | :---- | :----------------------------------- |
 | `dataValue` | bytes | The data for the requested data key. |
 
+### execute (Array) - ERC725X
+
+```solidity
+function execute(
+    uint256[] memory operationsType,
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory memory datas
+) public payable returns (bytes memory result)
+```
+
+Same as [`execute(uint256,address,uint256,bytes)`](#execute---erc725x) but executes a batch of calls on any other smart contracts, transferring values, or deploying new smart contracts.
+
+The values in the list of `operationsType` can be one of the following:
+
+- `0` for `CALL`
+- `1` for `CREATE`
+- `2` for `CREATE2`
+- `3` for `STATICCALL`
+- `4` for `DELEGATECALL`
+
+_Triggers the **[Executed](#executed)** event on every successful call that used operation type `CALL`, `STATICCALL` or `DELEGATECALL`._
+
+_Triggers the **[ContractCreated](#contractcreated)** event on every newly created smart contract that used operation `CREATE` or `CREATE2`._
+
+:::note
+The `execute(uint256[],address[],uint256[],bytes[])` function can only be called by the current owner of the contract.
+
+The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
+:::
+
+#### Parameters:
+
+| Name             | Type        | Description                                                                                                                  |
+| :--------------- | :-----------| :--------------------------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                             |
+| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                          |
+| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                       |
+| `datas`          | `bytes[]`   | The calldatas (ABI-encoded payloads of functions to run on other contracts), or the bytecodes of the contracts to deploy. |
+
+#### Return Values:
+
+| Name     | Type  | Description                                                                                                                                        |
+| :------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `results` | `bytes[]` | The datas that were returned by the functions called on the external contracts, or the addresses of the contracts created (operations 1 & 2). |
+
+
 ### setData (Array)
 
 ```solidity

--- a/docs/standards/smart-contracts/lsp0-erc725-account.md
+++ b/docs/standards/smart-contracts/lsp0-erc725-account.md
@@ -104,6 +104,13 @@ function acceptOwnership() public
 
 Transfers ownership of the contract to the `pendingOwner` address. Can only be called by the `pendingOwner`.
 
+Once ownership of the contract has been transfered, this function will clear the address stored under the `pendingOwner`.
+
+Requirements:
+
+- MUST be called by the `pendingOwner` only.
+- The `acceptOwnership` function cannot be called in the same transaction as [`transferOwnership`](#transferownership). It MUST be called in a separate transaction.
+
 _Triggers the **[OwnershipTransferred](#ownershiptransferred)** event once the new owner has claimed ownership._
 
 ### renounceOwnership
@@ -118,6 +125,8 @@ The current block number is saved as a part of initiation because the following 
 
 - The first 100 blocks after the saved block is the pending period, if you call `renounceOwnership(..)` during this period, the transaction will be reverted.
 - the following 100 blocks is the period when you can confirm the renouncement of the contract by calling `renounceOwnership(..)` the second time.
+
+Calling the `renounceOwnership` function at the initiation stage will also clear any address previously set as `pendingOwner`.
 
 _Triggers the **[RenounceOwnershipInitiated](#renounceownershipinitiated)** event in the first call._
 
@@ -135,7 +144,7 @@ fallback() external payable
 
 Executed when value is transferred to the contract or when function identifier doesn't match any of the available functions.
 
-_Triggers the **[ValueReceived](#valuereceived)** event when a native token is received._
+_Triggers the **[ValueReceived](#valuereceived)** event when receiving native tokens._
 
 ### execute
 
@@ -161,6 +170,8 @@ The `operationType` can be the following:
 _Triggers the **[Executed](#executed)** event when a call is successfully executed using `CALL/STATICCALL/DELEGATECALL` operations._
 
 _Triggers the **[ContractCreated](#contractcreated)** event when a smart contract is created using `CREATE/CREATE2` operations._
+
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
 
 :::note
 The `execute(...)` function can only be called by the current owner of the contract.
@@ -252,6 +263,8 @@ _Triggers the **[Executed](#executed)** event on every successful call that used
 
 _Triggers the **[ContractCreated](#contractcreated)** event on every newly created smart contract that used operation `CREATE` or `CREATE2`._
 
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
+
 :::note
 The `execute(uint256[],address[],uint256[],bytes[])` function can only be called by the current owner of the contract.
 
@@ -260,19 +273,18 @@ The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to 
 
 #### Parameters:
 
-| Name             | Type        | Description                                                                                                                  |
-| :--------------- | :-----------| :--------------------------------------------------------------------------------------------------------------------------- |
-| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                             |
-| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                          |
-| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                       |
+| Name             | Type        | Description                                                                                                               |
+| :--------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------ |
+| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                          |
+| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                       |
+| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                    |
 | `datas`          | `bytes[]`   | The calldatas (ABI-encoded payloads of functions to run on other contracts), or the bytecodes of the contracts to deploy. |
 
 #### Return Values:
 
-| Name     | Type  | Description                                                                                                                                        |
-| :------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name      | Type      | Description                                                                                                                                   |
+| :-------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
 | `results` | `bytes[]` | The datas that were returned by the functions called on the external contracts, or the addresses of the contracts created (operations 1 & 2). |
-
 
 ### setData (Array)
 
@@ -330,6 +342,8 @@ function universalReceiver(
 Forwards the call to the **UniversalReceiverDelegate** contract if its address is stored at the [LSP1UniversalReceiverDelegate](../generic-standards/lsp1-universal-receiver.md#extension) data Key. The contract being called is expected to be an **[LSP1UniversalReceiverDelegateUP](./lsp1-universal-receiver-delegate-up.md)**, supporting [LSP1UniversalReceiverDelegate InterfaceId](./interface-ids.md) using [ERC165](https://eips.ethereum.org/EIPS/eip-165).
 
 _Triggers the **[UniversalReceiver](#universalreceiver-1)** event when this function gets successfully executed._
+
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
 
 #### Parameters:
 

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -175,6 +175,9 @@ bytes memory payload = abi.encodeWithSignature(
     ...[<A comma-separated list of parameters that will be passed to the methods>]
 );
 
+// version number for EIP191
+uint256 LSP6_VERSION = 6;
+
 // The chain id of the blockchain where the `payload` will be executed
 uint256 chainId = block.chainid; // or <The chain id of the blockchain where you will interact with the key manager>
 
@@ -188,20 +191,21 @@ uint256 nonce = ILSP6KeyManager(keyManagerAddress).getNonce(...);
 
 ```solidity
 bytes memory encodedMessage = abi.encodePacked(
+    LSP6_VERSION,
     chainId,
-    keyManagerAddress,
     nonce,
+    msg.value,
     payload
 );
 ```
 
-3. Then you must get the hash of the `encodedMessage`:
+3. After that you can sign the encodedMessage using EIP191, providing the address of the Key Manager (`keyManagerAddress`) as the validator address.
 
-```solidity
-bytes32 encodedMessageHash = keccak256(encodedMessage);
-```
+:::info
 
-4. After that you can sign the encodedMessageHash and voila, you have the signature ready.
+You can use our tool [eip191-signer.js](../../tools/eip191-signerjs/Classes/EIP191Signer.md#signdatawithintendedvalidator) to do this. It provides convenience functions to do this.
+
+:::
 
 5. To execute the `payload` you would have to do the following:
 

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -72,7 +72,7 @@ function execute(bytes memory payload) public payable returns (bytes memory resu
 
 Executes a payload on the linked **LSP0ERC725Account**.
 
-This payload must represent the abi-encoded function call of one of the functions on the linked **LSP0ERC725Account**: 
+This payload must represent the abi-encoded function call of one of the functions on the linked **LSP0ERC725Account**:
 
 - **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
 - **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
@@ -84,8 +84,8 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 #### Parameters:
 
-| Name        | Type  | Description                 |
-| :---------- | :---- | :-------------------------- |
+| Name      | Type  | Description                 |
+| :-------- | :---- | :-------------------------- |
 | `payload` | bytes | The payload to be executed. |
 
 #### Return Values:
@@ -97,12 +97,12 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 ### execute (Array)
 
 ```solidity
-function execute(bytes[] calldata payloads) public payable returns (bytes memory result)
+function execute(uint256[] calldata values, bytes[] calldata payloads) public payable returns (bytes memory result)
 ```
 
 Same than `execute(bytes)` but executes a batch of payloads on the linked **LSP0ERC725Account**.
 
-The payloads must represent the abi-encoded function calls of one of the **LSP0ERC725Account** contract functions: 
+The payloads must represent the abi-encoded function calls of one of the **LSP0ERC725Account** contract functions:
 
 - **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
 - **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
@@ -114,14 +114,15 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 #### Parameters:
 
-| Name        | Type  | Description                 |
-| :---------- | :---- | :-------------------------- |
-| `payloads` | `bytes[]` | The payloads to be executed. |
+| Name       | Type        | Description                                        |
+| :--------- | :---------- | :------------------------------------------------- |
+| `values`   | `uint256[]` | The `msg.value` to be sent for a specific payload. |
+| `payloads` | `bytes[]`   | The payloads to be executed.                       |
 
 #### Return Values:
 
-| Name     | Type  | Description                                                                  |
-| :------- | :---- | :--------------------------------------------------------------------------- |
+| Name      | Type      | Description                                                                      |
+| :-------- | :-------- | :------------------------------------------------------------------------------- |
 | `results` | `bytes[]` | The returned datas as ABI-encoded bytes[] if the calls on the account succeeded. |
 
 ### getNonce
@@ -218,21 +219,23 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 | Name        | Type    | Description                                       |
 | :---------- | :------ | :------------------------------------------------ |
-| `signature` | bytes   | The bytes65 EIP191 signature.                   |
+| `signature` | bytes   | The bytes65 EIP191 signature.                     |
 | `nonce`     | uint256 | The nonce of the address that signed the message. |
 | `_calldata` | bytes   | The payload to be executed.                       |
 
 #### Return Value:
 
-| Name    | Type    | Description        |
-| :------ | :------ | :----------------- |
+| Name     | Type    | Description                                                                                                                      |
+| :------- | :------ | :------------------------------------------------------------------------------------------------------------------------------- |
 | `result` | `bytes` | If the payload on the linked **LSP0ERC725Account** was `ERC725X.execute(...)`, the data returned by the external made by the UP. |
+
 ### executeRelayCall (Array)
 
 ```solidity
 function executeRelayCall(
     bytes[] calldata signatures,
     uint256[] calldata nonces,
+    uint256[] calldata values,
     bytes[] calldata payloads
 ) public
 ```
@@ -241,17 +244,17 @@ Same as [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall), but allows
 
 #### Parameters:
 
-| Name        | Type    | Description                                       |
-| :---------- | :------ | :------------------------------------------------ |
-| `signatures` | `bytes[]`   | An array of bytes65 EIP191 signatures.                   |
+| Name         | Type        | Description                                                   |
+| :----------- | :---------- | :------------------------------------------------------------ |
+| `signatures` | `bytes[]`   | An array of bytes65 EIP191 signatures.                        |
 | `nonces`     | `uint256[]` | An array of nonces of the addresses that signed the messages. |
-| `payloads` | `bytes[]`  | An array of payloads to be executed.                       |
-
+| `values`     | `uint256[]` | An array of values to be sent sent for each payload.          |
+| `payloads`   | `bytes[]`   | An array of payloads to be executed.                          |
 
 #### Return Values:
 
-| Name    | Type    | Description        |
-| :------ | :------ | :----------------- |
+| Name      | Type      | Description                                                                                                                             |
+| :-------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
 | `results` | `bytes[]` | For each payload on the linked **LSP0ERC725Account** that was `ERC725X.execute(...)`, the data returned by the external made by the UP. |
 
 ### isValidSignature

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -67,12 +67,18 @@ This can be a contract that implements:
 ### execute
 
 ```solidity
-function execute(bytes memory _calldata) public payable returns (bytes memory result)
+function execute(bytes memory payload) public payable returns (bytes memory result)
 ```
 
-Executes a payload on the **LSP0ERC725Account** contract.
+Executes a payload on the linked **LSP0ERC725Account**.
 
-This payload must represent the abi-encoded function call of one of the **LSP0ERC725Account** contract functions: **[`setData(...)`](./lsp0-erc725-account.md#setdata)**, **[`execute(...)`](./lsp0-erc725-account.md#execute)**, or **[`transferOwnership(...)`](./lsp0-erc725-account.md#transferownership)**.
+This payload must represent the abi-encoded function call of one of the functions on the linked **LSP0ERC725Account**: 
+
+- **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
+- **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
+- **[`execute(uint256,address,uint256,bytes)`](./lsp0-erc725-account.md#execute)**.
+- **[`transferOwnership(address)`](./lsp0-erc725-account.md#transferownership)**.
+- **[`acceptOwnership()`](./lsp0-erc725-account.md#acceptownership)**.
 
 _Triggers the **[Executed](#executed)** event when a call is successfully executed._
 
@@ -80,13 +86,43 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 | Name        | Type  | Description                 |
 | :---------- | :---- | :-------------------------- |
-| `_calldata` | bytes | The payload to be executed. |
+| `payload` | bytes | The payload to be executed. |
 
 #### Return Values:
 
 | Name     | Type  | Description                                                                  |
 | :------- | :---- | :--------------------------------------------------------------------------- |
 | `result` | bytes | The returned data as ABI-encoded bytes if the call on the account succeeded. |
+
+### execute (Array)
+
+```solidity
+function execute(bytes[] calldata payloads) public payable returns (bytes memory result)
+```
+
+Same than `execute(bytes)` but executes a batch of payloads on the linked **LSP0ERC725Account**.
+
+The payloads must represent the abi-encoded function calls of one of the **LSP0ERC725Account** contract functions: 
+
+- **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
+- **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
+- **[`execute(uint256,address,uint256,bytes)`](./lsp0-erc725-account.md#execute)**.
+- **[`transferOwnership(address)`](./lsp0-erc725-account.md#transferownership)**.
+- **[`acceptOwnership()`](./lsp0-erc725-account.md#acceptownership)**.
+
+_Triggers the **[Executed](#executed)** event when a call is successfully executed._
+
+#### Parameters:
+
+| Name        | Type  | Description                 |
+| :---------- | :---- | :-------------------------- |
+| `payloads` | `bytes[]` | The payloads to be executed. |
+
+#### Return Values:
+
+| Name     | Type  | Description                                                                  |
+| :------- | :---- | :--------------------------------------------------------------------------- |
+| `results` | `bytes[]` | The returned datas as ABI-encoded bytes[] if the calls on the account succeeded. |
 
 ### getNonce
 
@@ -126,7 +162,7 @@ function executeRelayCall(
 ) public
 ```
 
-Allows anybody to execute a payload on the **LSP0ERC725Account** contract, if they have a signed message from an executor.
+Allows anybody to execute a payload on the linked **LSP0ERC725Account**, if they have a signed message from an address with some permissions.
 
 To obtain a valid signature you must do the following:
 
@@ -182,9 +218,41 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 
 | Name        | Type    | Description                                       |
 | :---------- | :------ | :------------------------------------------------ |
-| `signature` | bytes   | The bytes65 ethereum signature.                   |
+| `signature` | bytes   | The bytes65 EIP191 signature.                   |
 | `nonce`     | uint256 | The nonce of the address that signed the message. |
 | `_calldata` | bytes   | The payload to be executed.                       |
+
+#### Return Value:
+
+| Name    | Type    | Description        |
+| :------ | :------ | :----------------- |
+| `result` | `bytes` | If the payload on the linked **LSP0ERC725Account** was `ERC725X.execute(...)`, the data returned by the external made by the UP. |
+### executeRelayCall (Array)
+
+```solidity
+function executeRelayCall(
+    bytes[] calldata signatures,
+    uint256[] calldata nonces,
+    bytes[] calldata payloads
+) public
+```
+
+Same as [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall), but allows anybody to execute a **batch of payloads** on the linked **LSP0ERC725Account** on behalf of other addresses, as long as the addresses that signed the `payloads` have some permissions.
+
+#### Parameters:
+
+| Name        | Type    | Description                                       |
+| :---------- | :------ | :------------------------------------------------ |
+| `signatures` | `bytes[]`   | An array of bytes65 EIP191 signatures.                   |
+| `nonces`     | `uint256[]` | An array of nonces of the addresses that signed the messages. |
+| `payloads` | `bytes[]`  | An array of payloads to be executed.                       |
+
+
+#### Return Values:
+
+| Name    | Type    | Description        |
+| :------ | :------ | :----------------- |
+| `results` | `bytes[]` | For each payload on the linked **LSP0ERC725Account** that was `ERC725X.execute(...)`, the data returned by the external made by the UP. |
 
 ### isValidSignature
 

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -130,7 +130,7 @@ _Triggers the **[Executed](#executed)** event when a call is successfully execut
 ```solidity
 function getNonce(
     address signer,
-    uint256 channel
+    uint128 channel
 ) public view returns (uint256 nonce)
 ```
 
@@ -145,7 +145,7 @@ More info about **channel** can be found here: **[What are multi-channel nonces]
 | Name      | Type    | Description                                                              |
 | :-------- | :------ | :----------------------------------------------------------------------- |
 | `signer`  | address | The address of the signer of the transaction.                            |
-| `channel` | uint256 | The channel which the signer wants to use for executing the transaction. |
+| `channel` | uint128 | The channel which the signer wants to use for executing the transaction. |
 
 #### Return Values:
 
@@ -214,6 +214,19 @@ ILSP6KeyManager(keyManagerAddress).executeRelayCall(
 ```
 
 _Triggers the **[Executed](#executed)** event when a call is successfully executed._
+
+:::caution
+
+If the `payload` related to the `signature` fails when being executed, `executeRelayCall(...)` will revert the whole transaction and bubble up the error. **The nonce of the signer will not be incremented!**
+
+This might potentially block any future transactions/payloads signed with an incremented nonce in the same channel. If you want to have non-blocking transactions independant from each others, consider signing payloads across multiple channels using **multi channel nonces**.
+
+For more details, see:
+
+- [**LSP6 - Key Manager > Out of order execution**](../universal-profile/lsp6-key-manager.md#out-of-order-execution)
+- [**FAQ > What are multi-channel nonces?**](../faq/channel-nonce.md)
+
+:::
 
 #### Parameters:
 
@@ -287,8 +300,8 @@ Checks if a signature was signed by an address having at least the **[SIGN](../u
 
 ```solidity
 event Executed(
-    uint256 value,
-    bytes4 selector
+    bytes4 indexed selector,
+    uint256 indexed value,
 )
 ```
 
@@ -296,12 +309,12 @@ _**MUST** be fired when a transaction was successfully executed from the **[exec
 
 #### Values:
 
-| Name       | Type    | Description                                                                       |
-| :--------- | :------ | :-------------------------------------------------------------------------------- |
-| `value`    | uint256 | The amount to be sent with the payload.                                           |
-| `selector` | bytes4  | The bytes4 selector of the function executed on the linked [`target()`](#target). |
+| Name       | Type      | Description                                                                         |
+| :--------- | :-------- | :---------------------------------------------------------------------------------- |
+| `selector` | `bytes4`  | The selector of the function executed on the linked [`target()`](#target) contract. |
+| `value`    | `uint256` | The amount to be sent with the payload.                                             |
 
 ## References
 
 - [LUKSO Standards Proposals: LSP6 - Key Manager (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md)
-- [LSP6 KeyManager: Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts/LSP6KeyManager)
+- [LSP6 KeyManager: Solidity implementations (GitHub)](https://github.com/lukso-network/lsp-smart-contracts/tree/develop/contracts/LSP6KeyManager)

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -141,7 +141,7 @@ fallback() external payable
 
 Executed when value is transferred to the contract or when function identifier doesn't match any of the available functions.
 
-_Triggers the **[ValueReceived](#valuereceived)** event when receivng native tokens._
+_Triggers the **[ValueReceived](#valuereceived)** event when receiving native tokens._
 
 ### execute
 

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -223,7 +223,7 @@ Retrieves the data that was set for a particular data `key`.
 | :------ | :---- | :----------------------------------- |
 | `value` | bytes | The data for the requested data key. |
 
-### execute (Array) - ERC725X
+### execute (Array)
 
 ```solidity
 function execute(

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -101,6 +101,13 @@ function acceptOwnership() public
 
 Transfers ownership of the contract to the `pendingOwner` address. Can only be called by the `pendingOwner`.
 
+Once ownership of the contract has been transfered, this function will clear the address stored under the `pendingOwner`.
+
+Requirements:
+
+- MUST be called by the `pendingOwner` only.
+- The `acceptOwnership` function cannot be called in the same transaction as [`transferOwnership`](#transferownership). It MUST be called in a separate transaction.
+
 _Triggers the **[OwnershipTransferred](#ownershiptransferred)** event once the new owner has claimed ownership._
 
 ### renounceOwnership
@@ -115,6 +122,8 @@ The current block number is saved as a part of initiation because the following 
 
 - The first 100 blocks after the saved block is the pending period, if you call `renounceOwnership(..)` during this period, the transaction will be reverted.
 - the following 100 blocks is the period when you can confirm the renouncement of the contract by calling `renounceOwnership(..)` the second time.
+
+Calling the `renounceOwnership` function at the initiation stage will also clear any address previously set as `pendingOwner`.
 
 _Triggers the **[RenounceOwnershipInitiated](#renounceownershipinitiated)** event in the first call._
 
@@ -132,7 +141,7 @@ fallback() external payable
 
 Executed when value is transferred to the contract or when function identifier doesn't match any of the available functions.
 
-_Triggers the **[ValueReceived](#valuereceived)** event when a native token is received._
+_Triggers the **[ValueReceived](#valuereceived)** event when receivng native tokens._
 
 ### execute
 
@@ -157,6 +166,8 @@ The following `operationType` MUST exist:
 _Triggers the **[Executed](#executed)** event when a call is successfully executed using `CALL/STATICCALL` operations._
 
 _Triggers the **[ContractCreated](#contractcreated)** event when a smart contract is created using `CREATE/CREATE2` operations._
+
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
 
 :::note
 The `execute(...)` function can only be called by the current owner of the vault.
@@ -248,6 +259,8 @@ _Triggers the **[Executed](#executed)** event on every successful call that used
 
 _Triggers the **[ContractCreated](#contractcreated)** event on every newly created smart contract that used operation `CREATE` or `CREATE2`._
 
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
+
 :::note
 The `execute(uint256[],address[],uint256[],bytes[])` function can only be called by the current owner of the contract.
 
@@ -256,19 +269,18 @@ The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to 
 
 #### Parameters:
 
-| Name             | Type        | Description                                                                                                                  |
-| :--------------- | :-----------| :--------------------------------------------------------------------------------------------------------------------------- |
-| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                             |
-| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                          |
-| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                       |
+| Name             | Type        | Description                                                                                                               |
+| :--------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------ |
+| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                          |
+| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                       |
+| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                    |
 | `datas`          | `bytes[]`   | The calldatas (ABI-encoded payloads of functions to run on other contracts), or the bytecodes of the contracts to deploy. |
 
 #### Return Values:
 
-| Name     | Type  | Description                                                                                                                                        |
-| :------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name      | Type      | Description                                                                                                                                   |
+| :-------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
 | `results` | `bytes[]` | The datas that were returned by the functions called on the external contracts, or the addresses of the contracts created (operations 1 & 2). |
-
 
 ### setData (Array)
 
@@ -327,6 +339,8 @@ Forwards the call to the **UniversalReceiverDelegate** contract if its address i
 The contract being called is expected to be an **[LSP1UniversalReceiverDelegateVault](./lsp1-universal-receiver-delegate-vault.md)**, supporting [LSP1UniversalReceiverDelegate InterfaceId](./interface-ids.md) using ERC165.
 
 _Triggers the **[UniversalReceiver](#universalreceiver-1)** event when this function gets successfully executed._
+
+_Triggers the **[ValueReceived](#valuereceived)** event when sending native tokens while calling the function._
 
 #### Parameters:
 

--- a/docs/standards/smart-contracts/lsp9-vault.md
+++ b/docs/standards/smart-contracts/lsp9-vault.md
@@ -223,6 +223,53 @@ Retrieves the data that was set for a particular data `key`.
 | :------ | :---- | :----------------------------------- |
 | `value` | bytes | The data for the requested data key. |
 
+### execute (Array) - ERC725X
+
+```solidity
+function execute(
+    uint256[] memory operationsType,
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory memory datas
+) public payable returns (bytes memory result)
+```
+
+Same as [`execute(uint256,address,uint256,bytes)`](#execute---erc725x) but executes a batch of calls on any other smart contracts, transferring values, or deploying new smart contracts.
+
+The values in the list of `operationsType` can be one of the following:
+
+- `0` for `CALL`
+- `1` for `CREATE`
+- `2` for `CREATE2`
+- `3` for `STATICCALL`
+- `4` for `DELEGATECALL`
+
+_Triggers the **[Executed](#executed)** event on every successful call that used operation type `CALL`, `STATICCALL` or `DELEGATECALL`._
+
+_Triggers the **[ContractCreated](#contractcreated)** event on every newly created smart contract that used operation `CREATE` or `CREATE2`._
+
+:::note
+The `execute(uint256[],address[],uint256[],bytes[])` function can only be called by the current owner of the contract.
+
+The operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
+:::
+
+#### Parameters:
+
+| Name             | Type        | Description                                                                                                                  |
+| :--------------- | :-----------| :--------------------------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The type of operations that need to be executed.                                                                             |
+| `targets`        | `address[]` | The addresses to interact with. Unused if a contract is created (operations 1 & 2).                                          |
+| `values`         | `uint256[]` | The amount of native tokens to transfer with the transaction (in Wei).                                                       |
+| `datas`          | `bytes[]`   | The calldatas (ABI-encoded payloads of functions to run on other contracts), or the bytecodes of the contracts to deploy. |
+
+#### Return Values:
+
+| Name     | Type  | Description                                                                                                                                        |
+| :------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `results` | `bytes[]` | The datas that were returned by the functions called on the external contracts, or the addresses of the contracts created (operations 1 & 2). |
+
+
 ### setData (Array)
 
 ```solidity


### PR DESCRIPTION
> We are merging this PR in a separate branch called `smart-contracts-breaking-changes` rather than in the `main` branch for now. This is for preparing the changes in docs overtime.
The branch `smart-contracts-breaking-change`  will be merged with `main` once a new version the `@lukso/lsp-smart-contracts` package has been released. These docs change will reflect this new release.

# What does this PR introduce?

Update the Smart Contract ABIs technical reference with the new breaking changes behaviours.
Updated all the interface IDs.