### PR TITLE
Remove link to technical whitepaper

### DIFF
--- a/docs/faq/lukso.md
+++ b/docs/faq/lukso.md
@@ -16,7 +16,7 @@ You can follow us on [Twitter](https://twitter.com/lukso_io), read our [Medium a
 
 ## Where can I download the Whitepaper?
 
-Here you can find the download link for the [LUKSO Whitepaper](https://uploads-ssl.webflow.com/629f44560745074760731ba4/62b200bfe0af12186845519a_LUKSO_Whitepaper_V1-1.pdf), and the [Technical Lightpaper](https://lukso.network/assets/LUKSO_Technical_Lightpaper.pdf).
+Here you can find the download link for the [LUKSO Whitepaper](https://uploads-ssl.webflow.com/629f44560745074760731ba4/62b200bfe0af12186845519a_LUKSO_Whitepaper_V1-1.pdf).
 
 ## What is LYXe and LYX?
 


### PR DESCRIPTION
This link was outdated and the related file is not relevant anymore. More information can be found in this article:

- [An update on the Road to Mainnet](https://medium.com/lukso/an-update-on-the-road-to-mainnet-48d39ce411d7)

https://medium.com/lukso

Closes #451 