### PR TITLE
Update Key manager guides with the new testnet

### DIFF
--- a/docs/guides/key-manager/execute-relay-transactions.md
+++ b/docs/guides/key-manager/execute-relay-transactions.md
@@ -87,7 +87,9 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import { ethers } from 'ethers';
 
-const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -128,10 +130,10 @@ const keyManager = new web3.eth.Contract(KeyManagerContract.abi, keyManagerAddre
 <!-- prettier-ignore-start -->
 
 ```typescript title="Contract instances"
-const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfileContract.abi);
+const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfileContract.abi, controllerAccount);
 
-const keyManagerAddress = await universalProfile.connect(controllerAccount).owner();
-const keyManager = new ethers.Contract(keyManagerAddress, KeyManagerContract.abi);
+const keyManagerAddress = await universalProfile.owner();
+const keyManager = new ethers.Contract(keyManagerAddress, KeyManagerContract.abi, controllerAccount);
 ```
 
 <!-- prettier-ignore-end -->
@@ -165,7 +167,7 @@ const nonce = await keyManager.methods.getNonce(controllerAccount.address, chann
 
 ```typescript title="Get the controller key nonce"
 const channelId = 0;
-const nonce = await keyManager.connect(controllerAccount).getNonce(controllerAccount.address, channelId);
+const nonce = await keyManager.getNonce(controllerAccount.address, channelId);
 ```
 
   </TabItem>
@@ -201,7 +203,7 @@ const abiPayload = universalProfile.interface.encodeFunctionData(
   [
     0, // Operation type: CALL
     '0x...', // Recipient address
-    ethers.utils.parseUnits("1", "ether"), // Value
+    ethers.utils.parseUnits('1', 'ether'), // Value
     '0x', // Data
   ],
 );
@@ -261,8 +263,8 @@ let { signature } = await eip191Signer.signDataWithIntendedValidator(
 const { chainId } = await provider.getNetwork(); // will be 2828 on L16
 
 let encodedMessage = ethers.utils.solidityPack(
-    ["uint256", "uint256", "uint256", "uint256", "bytes"],
-    [LSP6_VERSION, chainId, nonce, msgValue, abiPayload]
+  ['uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
+  [LSP6_VERSION, chainId, nonce, msgValue, abiPayload],
 );
 
 let eip191Signer = new EIP191Signer();
@@ -317,9 +319,9 @@ const executeRelayCallTransaction = await keyManager.methods[
   <TabItem value="ethersjs" label="ethers.js">
 
 ```javascript title="Send the transaction"
-const executeRelayCallTransaction = await keyManager
-  .connect(controllerAccount)
-  ['executeRelayCall(bytes,uint256,bytes)'](signature, nonce, abiPayload);
+const executeRelayCallTransaction = await keyManager[
+  'executeRelayCall(bytes,uint256,bytes)'
+](signature, nonce, abiPayload);
 ```
 
   </TabItem>
@@ -415,7 +417,9 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import { ethers } from 'ethers';
 
-const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -428,23 +432,25 @@ const controllerAccount = new ethers.Wallet(controllerPrivateKey).connect(
 const universalProfile = new ethers.Contract(
   universalProfileAddress,
   UniversalProfileContract.abi,
+  controllerAccount,
 );
 
-const keyManagerAddress = await universalProfile.connect(controllerAccount).owner();
+const keyManagerAddress = await universalProfile.owner();
 const keyManager = new ethers.Contract(
   keyManagerAddress,
   KeyManagerContract.abi,
+  controllerAccount,
 );
 
 const channelId = 0;
-const nonce = await keyManager.connect(controllerAccount).getNonce(controllerAccount.address, channelId);
+const nonce = await keyManager.getNonce(controllerAccount.address, channelId);
 
 const abiPayload = universalProfile.interface.encodeFunctionData(
   'execute(uint256,address,uint256,bytes)',
   [
     0, // Operation type: CALL
     '0x...', // Recipient address
-    ethers.utils.parseUnits("1", "ether"), // Value
+    ethers.utils.parseUnits('1', 'ether'), // Value
     '0x', // Data
   ],
 );
@@ -452,8 +458,8 @@ const abiPayload = universalProfile.interface.encodeFunctionData(
 const { chainId } = await provider.getNetwork(); // will be 2828 on L16
 
 let encodedMessage = ethers.utils.solidityPack(
-    ["uint256", "uint256", "uint256", "uint256", "bytes"],
-    [LSP6_VERSION, chainId, nonce, msgValue, abiPayload]
+  ['uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
+  [LSP6_VERSION, chainId, nonce, msgValue, abiPayload],
 );
 
 let eip191Signer = new EIP191Signer();
@@ -464,9 +470,9 @@ let { signature } = await eip191Signer.signDataWithIntendedValidator(
   controllerPrivateKey,
 );
 
-const executeRelayCallTransaction = await keyManager
-  .connect(controllerAccount)
-  ['executeRelayCall(bytes,uint256,bytes)'](signature, nonce, abiPayload);
+const executeRelayCallTransaction = await keyManager[
+  'executeRelayCall(bytes,uint256,bytes)'
+](signature, nonce, abiPayload);
 ```
 
   </TabItem>

--- a/docs/guides/key-manager/execute-relay-transactions.md
+++ b/docs/guides/key-manager/execute-relay-transactions.md
@@ -67,7 +67,7 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -87,7 +87,7 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -130,7 +130,7 @@ const keyManager = new web3.eth.Contract(KeyManagerContract.abi, keyManagerAddre
 ```typescript title="Contract instances"
 const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfileContract.abi);
 
-const keyManagerAddress = await universalProfile.owner();
+const keyManagerAddress = await universalProfile.connect(controllerAccount).owner();
 const keyManager = new ethers.Contract(keyManagerAddress, KeyManagerContract.abi);
 ```
 
@@ -165,7 +165,7 @@ const nonce = await keyManager.methods.getNonce(controllerAccount.address, chann
 
 ```typescript title="Get the controller key nonce"
 const channelId = 0;
-const nonce = await keyManager.getNonce(controllerAccount.address, channelId);
+const nonce = await keyManager.connect(controllerAccount).getNonce(controllerAccount.address, channelId);
 ```
 
   </TabItem>
@@ -201,7 +201,7 @@ const abiPayload = universalProfile.interface.encodeFunctionData(
   [
     0, // Operation type: CALL
     '0x...', // Recipient address
-    web3.utils.toWei('1'), // Value
+    ethers.utils.parseUnits("1", "ether"), // Value
     '0x', // Data
   ],
 );
@@ -260,12 +260,9 @@ let { signature } = await eip191Signer.signDataWithIntendedValidator(
 ```typescript title="Sign the transaction"
 const { chainId } = await provider.getNetwork(); // will be 2828 on L16
 
-let encodedMessage = web3.utils.encodePacked(
-  { value: LSP6_VERSION, type: 'uint256' },
-  { value: chainId, type: 'uint256' },
-  { value: nonce, type: 'uint256' },
-  { value: msgValue, type: 'uint256' },
-  { value: abiPayload, type: 'bytes' },
+let encodedMessage = ethers.utils.solidityPack(
+    ["uint256", "uint256", "uint256", "uint256", "bytes"],
+    [LSP6_VERSION, chainId, nonce, msgValue, abiPayload]
 );
 
 let eip191Signer = new EIP191Signer();
@@ -348,7 +345,7 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -418,7 +415,7 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { LSP6_VERSION } from '@lukso/lsp-smart-contracts/constants';
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 const universalProfileAddress = '0x...';
 const msgValue = 0; // Amount of native tokens to be sent
 
@@ -433,33 +430,30 @@ const universalProfile = new ethers.Contract(
   UniversalProfileContract.abi,
 );
 
-const keyManagerAddress = await universalProfile.owner();
+const keyManagerAddress = await universalProfile.connect(controllerAccount).owner();
 const keyManager = new ethers.Contract(
   keyManagerAddress,
   KeyManagerContract.abi,
 );
 
 const channelId = 0;
-const nonce = await keyManager.getNonce(controllerAccount.address, channelId);
+const nonce = await keyManager.connect(controllerAccount).getNonce(controllerAccount.address, channelId);
 
 const abiPayload = universalProfile.interface.encodeFunctionData(
   'execute(uint256,address,uint256,bytes)',
   [
     0, // Operation type: CALL
     '0x...', // Recipient address
-    web3.utils.toWei('1'), // Value
+    ethers.utils.parseUnits("1", "ether"), // Value
     '0x', // Data
   ],
 );
 
 const { chainId } = await provider.getNetwork(); // will be 2828 on L16
 
-let encodedMessage = web3.utils.encodePacked(
-  { value: LSP6_VERSION, type: 'uint256' },
-  { value: chainId, type: 'uint256' },
-  { value: nonce, type: 'uint256' },
-  { value: msgValue, type: 'uint256' },
-  { value: abiPayload, type: 'bytes' },
+let encodedMessage = ethers.utils.solidityPack(
+    ["uint256", "uint256", "uint256", "uint256", "bytes"],
+    [LSP6_VERSION, chainId, nonce, msgValue, abiPayload]
 );
 
 let eip191Signer = new EIP191Signer();

--- a/docs/guides/key-manager/get-controllers.md
+++ b/docs/guides/key-manager/get-controllers.md
@@ -31,7 +31,7 @@ import Web3 from 'web3';
 
 // setup
 const myUniversalProfileAddress = '0xC26508178c4D7d3Ad43Dcb9F9bb1fab9ceeD58B5';
-const RPC_ENDPOINT = 'https://rpc.l16.lukso.network';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 
 // step 1 - setup erc725.js
 const web3 = new Web3(RPC_ENDPOINT);
@@ -144,7 +144,7 @@ import Web3 from 'web3';
 
 // setup
 const myUniversalProfileAddress = '0xC26508178c4D7d3Ad43Dcb9F9bb1fab9ceeD58B5';
-const RPC_ENDPOINT = 'https://rpc.l16.lukso.network';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 
 const web3 = new Web3(RPC_ENDPOINT);
 

--- a/docs/guides/key-manager/give-permissions.md
+++ b/docs/guides/key-manager/give-permissions.md
@@ -148,7 +148,7 @@ To get started you would need the following:
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 const myUniversalProfileAddress = '0x...';
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 ```
@@ -161,7 +161,7 @@ const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 const myUniversalProfileAddress = '0x...';
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 ```
@@ -286,7 +286,7 @@ import { ERC725 } from '@erc725/erc725.js';
 import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 const myUniversalProfileAddress = '0x...';
 
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
@@ -362,11 +362,11 @@ import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 const myUniversalProfileAddress = '0x...';
 
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 const myEOA = new ethers.Wallet(privateKey).connect(provider);
 
 const erc725 = new ERC725(

--- a/docs/guides/key-manager/upgrade-lsp6.md
+++ b/docs/guides/key-manager/upgrade-lsp6.md
@@ -66,7 +66,7 @@ import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProf
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 
 const privateKey = '0x...';
 const universalProfileAddress = '0x...';
@@ -81,7 +81,7 @@ import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProf
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 
 const privateKey = '0x...';
 const universalProfileAddress = '0x...';
@@ -170,11 +170,10 @@ await newKeyManager
   <TabItem value="ethersjs" label="ethers.js">
 
 ```js title="Deploy a new Key Manager"
-const keyManagerFactory = new ethers.ContractFactory(
+const newKeyManager = await new ethers.ContractFactory(
   LSP6KeyManager.abi,
   LSP6KeyManager.bytecode,
-);
-const newKeyManager = await keyManagerFactory.deploy(universalProfileAddress);
+).connect(account).deploy(universalProfileAddress);
 ```
 
   </TabItem>
@@ -267,11 +266,10 @@ The upgrade has been completed successfully.
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 
 const privateKey = '0x...';
 const universalProfileAddress = '0x...';
-const keyManagerAddress = '0x...';
 
 const upgradeLSP6 = async () => {
   // Initialize the controller account
@@ -324,11 +322,10 @@ import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProf
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://rpc.l16.lukso.network');
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
 
 const privateKey = '0x...';
 const universalProfileAddress = '0x...';
-const keyManagerAddress = '0x...';
 
 const upgradeLSP6 = async () => {
   // Initialize the controller account
@@ -338,11 +335,10 @@ const upgradeLSP6 = async () => {
   const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfile.abi);
 
   // Deploy a new LSP6 Key Manager
-  const keyManagerFactory = new ethers.ContractFactory(
+  const newKeyManager = await new ethers.ContractFactory(
     LSP6KeyManager.abi,
     LSP6KeyManager.bytecode,
-  );
-  const newKeyManager = await keyManagerFactory.deploy(universalProfileAddress);
+  ).connect(account).deploy(universalProfileAddress);
 
   // Transfer the ownership of your Universal Profile from the current LSP6 Key Manager to a new LSP6 Key Manager
   await universalProfile
@@ -380,10 +376,9 @@ import LSP0ERC725YAccount from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Y
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
 
-const web3 = new Web3('https://rpc.l16.lukso.network');
+const web3 = new Web3('https://rpc.testnet.lukso.network');
 
 const universalProfileAddress = '0x...';
-const keyManagerAddress = '0x...';
 
 const testLSP6 = async () => {
   const universalProfile = new web3.eth.Contract(LSP0ERC725YAccount.abi, universalProfileAddress);


### PR DESCRIPTION
### What does this PR introduce?

The changes update the code to work with the new LUKSO Testnet.
Additionally **Execute Relay Transactions** & **Upgrade LSP6 Key Manager** have been tested.
**Get controller addresses** & **Grant Permissions to 3rd parties** have to be tested after _erc725.js_ repository is updated to the latest version of _lsp-smart-contracts_