### PR TITLE
Fix outdated LSP6 Contract ABIs + move execute relaye call steps to LSP6 standard page

### DIFF
--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -75,7 +75,7 @@ Executes a payload on the linked **LSP0ERC725Account**.
 This payload must represent the abi-encoded function call of one of the functions on the linked **LSP0ERC725Account**:
 
 - **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
-- **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
+- **[`setDataBatch(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdatabatch)**.
 - **[`execute(uint256,address,uint256,bytes)`](./lsp0-erc725-account.md#execute)**.
 - **[`transferOwnership(address)`](./lsp0-erc725-account.md#transferownership)**.
 - **[`acceptOwnership()`](./lsp0-erc725-account.md#acceptownership)**.
@@ -105,7 +105,7 @@ Same than [`execute(bytes)`](#execute) but executes a batch of payloads on the l
 The payloads parameter must represent an array of abi-encoded function calls of one of the **LSP0ERC725Account** contract functions:
 
 - **[`setData(bytes32,bytes)`](./lsp0-erc725-account.md#setdata)**.
-- **[`setData(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdata-array)**.
+- **[`setDataBatch(bytes32[],bytes[])`](./lsp0-erc725-account.md#setdatabatch)**.
 - **[`execute(uint256,address,uint256,bytes)`](./lsp0-erc725-account.md#execute)**.
 - **[`transferOwnership(address)`](./lsp0-erc725-account.md#transferownership)**.
 - **[`acceptOwnership()`](./lsp0-erc725-account.md#acceptownership)**.
@@ -196,6 +196,7 @@ _Triggers the **[VerifiedCall](#verifiedcall)** event when a call is successfull
 function executeRelayCallBatch(
     bytes[] calldata signatures,
     uint256[] calldata nonces,
+    uint256[] calldata validityTimestamps,
     uint256[] calldata values,
     bytes[] calldata payloads
 ) public

--- a/docs/standards/smart-contracts/lsp6-key-manager.md
+++ b/docs/standards/smart-contracts/lsp6-key-manager.md
@@ -178,11 +178,12 @@ _Triggers the **[VerifiedCall](#verifiedcall)** event when a call is successfull
 
 #### Parameters:
 
-| Name        | Type      | Description                                       |
-| :---------- | :-------- | :------------------------------------------------ |
-| `signature` | `bytes`   | The bytes65 EIP191 signature.                     |
-| `nonce`     | `uint256` | The nonce of the address that signed the message. |
-| `_calldata` | `bytes`   | The payload to be executed.                       |
+| Name                 | Type      | Description                                                                                                                                              |
+| :------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signature`          | `bytes`   | The bytes65 EIP191 signature.                                                                                                                            |
+| `nonce`              | `uint256` | The nonce of the address that signed the message.                                                                                                        |
+| `validityTimestamps` | `uint256` | Two `uint128` timestamps concatenated together that describes when the relay transaction is valid "from" (left `uint128`) and "until" (right `uint128`). |
+| `_calldata`          | `bytes`   | The payload to be executed.                                                                                                                              |
 
 #### Return Value:
 
@@ -206,12 +207,13 @@ Same as [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall), but allows
 
 #### Parameters:
 
-| Name         | Type        | Description                                                   |
-| :----------- | :---------- | :------------------------------------------------------------ |
-| `signatures` | `bytes[]`   | An array of bytes65 EIP191 signatures.                        |
-| `nonces`     | `uint256[]` | An array of nonces of the addresses that signed the messages. |
-| `values`     | `uint256[]` | An array of values to be sent sent for each payload.          |
-| `payloads`   | `bytes[]`   | An array of payloads to be executed.                          |
+| Name                 | Type        | Description                                                                                                                                                |
+| :------------------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signatures`         | `bytes[]`   | An array of bytes65 EIP191 signatures.                                                                                                                     |
+| `nonces`             | `uint256[]` | An array of nonces of the addresses that signed the messages.                                                                                              |
+| `validityTimestamps` | `uint256[]` | An array of two `uint128` concatenated timestamps that describe when the relay transaction is valid "from" (left `uint128`) and "until" (right `uint128`). |
+| `values`             | `uint256[]` | An array of values to be sent sent for each payload.                                                                                                       |
+| `payloads`           | `bytes[]`   | An array of payloads to be executed.                                                                                                                       |
 
 #### Return Values:
 

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -743,6 +743,32 @@ Dapps can then leverage the relay execution features to create their own busines
 
 ### How to sign relay transactions?
 
+:::tip
+
+You can use our library [**eip191-signer.js**](https://github.com/lukso-network/tools-eip191-signer) to make it easier to sign an _EIP191 Execute Relay Call transaction_.
+
+See also our [step by step Javascript guide](../../guides/key-manager/execute-relay-transactions.md) to sign and execute relay transactions via the Key Manager.
+
+:::
+
+#### Overview
+
+To obtain a valid signature that can be used by anyone to execute a relayed transaction (= meta transaction) on behalf of someone else, we must do the following:
+
+1. Gather 4 things:
+   a. the **payload** (an abi-encoded function call) to be executed on the linked account.
+   b. the **chain id** of the blockchain where the `payload` will be executed.
+   c. the address of the [`LSP6KeyManager`](../../standards/smart-contracts/lsp6-key-manager.md) smart contract where the **payload** will be executed.
+   d. the Key Manager **nonce** of the controller.
+
+2. Once you have gathered these 4 information, you must **concatenate them all together**.
+
+3. Then you must get the `keccak256` hash of this data.
+
+4. After that you can sign the data to obtain a valid signature ready to be used via [`executeRelayCall(...)`](../smart-contracts/lsp6-key-manager.md#executerelaycall).
+
+#### Details
+
 The relay transactions are signed using the [**version 0 of EIP191**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-191.md#version-0x00). The relay call data that you want to sign **MUST** be the _keccak256 hash digest_ of the following elements _(bytes values)_ concatenated together.
 
 ```javascript
@@ -759,12 +785,6 @@ The relay transactions are signed using the [**version 0 of EIP191**](https://gi
 | `nonce`              | The unique [**nonce**](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md#getnonce) for the payload.                                                                                                    |
 | `value`              | The amount of **native tokens** that will be transferred to the [**ERC725 Account**](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) linked to the Key Manager that will execute the relay call. |
 | `payload`            | The payload that will be exeuted.                                                                                                                                                                                             |
-
-:::info
-
-If you want to sign an _EIP191 Execute Relay Call transaction_ you can use our library, [**eip191-signer.js**](https://github.com/lukso-network/tools-eip191-signer).
-
-:::
 
 ### Out of order execution
 

--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -755,13 +755,19 @@ See also our [step by step Javascript guide](../../guides/key-manager/execute-re
 
 To obtain a valid signature that can be used by anyone to execute a relayed transaction (= meta transaction) on behalf of someone else, we must do the following:
 
-1. Gather 4 things:
-   a. the **payload** (an abi-encoded function call) to be executed on the linked account.
-   b. the **chain id** of the blockchain where the `payload` will be executed.
-   c. the address of the [`LSP6KeyManager`](../../standards/smart-contracts/lsp6-key-manager.md) smart contract where the **payload** will be executed.
-   d. the Key Manager **nonce** of the controller.
+1. Gather 5 things:
 
-2. Once you have gathered these 4 information, you must **concatenate them all together**.
+   - 1. the **payload** (an abi-encoded function call) to be executed on the linked account.
+   - 2. the **chain id** of the blockchain where the `payload` will be executed.
+   - 3. the address of the [`LSP6KeyManager`](../../standards/smart-contracts/lsp6-key-manager.md) smart contract where the **payload** will be executed.
+        d. the Key Manager **nonce** of the controller.
+   - 4. the `validityTimestamps`, composed of 2 x `uint128` concatenated together, where:
+
+        4.1. the left-side `uint128` corresponds to the timestamp from which the relay call is valid from.
+
+        4.2. the right-side `uint128` corresponds to the timestamp from which the relay call is valid until.
+
+2. Once you have gathered these 5 information, you must **concatenate them all together**.
 
 3. Then you must get the `keccak256` hash of this data.
 


### PR DESCRIPTION
# What does this PR introduce?

- rename batch functions for execute and executeRelayCall
- change outdated event name from `Executed` to `VerifiedCall`
- move steps out of LSP6 contract ABI to the LSP6 Standard page, under an **overview** section.
- improve callouts and links between pages to LSP6 and eip191signer.js. Move callouts at the top above function definitions.

<img width="1014" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/66dc85f3-5175-4c72-967a-5ab60abc592c">

<img width="1014" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/4ea2c203-5c43-4d16-bfb4-51d06dcb6edd">
