### PR TITLE
Add `increase/decreaseAllowance` functions to LSP7 Contract ABIs

### DIFF
--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -11,9 +11,19 @@ sidebar_position: 9
 
 :::
 
+:::caution
+The `LSP7DigitalAsset` contract is an `abstract` contract that is not deployable as it is. This is because it does not contain any public functions by default to manage token supply (_e.g: no public `mint(...)` or `burn(...)` functions_).
+
+In order to use the internal [`_mint(...)`](#_mint) and [`_burn(...)`](#_burn) functions, you can:
+
+- use `LSP7Mintable`, a preset contract that contains a public `mint(...)` function callable only by the contract's owner.
+- or extend the `LSP7DigitalAsset` contract and create custom methods that use the internal functions (to create your own supply mechanism).
+
+:::
+
 The **LSP7DigitalAsset** contract represents digital assets for either fungible or non-fungible tokens where minting and transferring are specified with an amount of tokens. It has some functions from **[ERC20](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol)** and **[ERC777](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC777/ERC777.sol)** with more upgraded features.
 
-This contract serves as a **Fungible Token Contract** when `isNonDivisible` bool is set to **false** in the `constructor(...)` and otherwise serves as a **Non-Fungible Token Contract**.
+This contract serves as a **Fungible Token Contract** when `isNonDivisible` bool is set to `false` in the [`constructor(...)`](#constructor) and otherwise serves as a **Non-Fungible Token Contract**.
 
 :::note
 _The LSP7DigitalAsset contract also contains the methods from_ [_ERC165_](https://eips.ethereum.org/EIPS/eip-165) :
@@ -56,15 +66,15 @@ The the `isNonDivisible` parameter specifies if the contract represents a fungib
 
 ### decimals
 
+:::info
+If the contract represents a **NFT** then **0** SHOULD be used, otherwise **18** is the common value.
+:::
+
 ```solidity
   function decimals() public view returns (uint256 value)
 ```
 
 Returns the number of decimals used to get its user representation.
-
-:::note
-If the contract represents a **NFT** then **0** SHOULD be used, otherwise **18** is the common value.
-:::
 
 #### Return Values:
 
@@ -109,10 +119,7 @@ Returns the number of existing tokens of the contract owned by the `tokenOwner` 
 ### authorizeOperator
 
 ```solidity
-function authorizeOperator(
-    address operator,
-    uint256 amount
-) public
+function authorizeOperator(address operator, uint256 amount) public
 ```
 
 Sets the `amount` of tokens to which the `operator` has access from the caller's tokens.
@@ -163,7 +170,72 @@ _Triggers the **[RevokedOperator](#revokedoperator)** event when an address get 
 
 :::
 
+### increaseAllowance
+
+:::info
+This is a non-standard function, not part of the `ILSP7DigitalAsset` interface. It exists to be used as a prevention mechanism against the double spending allowance vulnerability.
+:::
+
+```solidity
+function increaseAllowance(address operator, uint256 addedAmount) external nonpayable
+```
+
+Increase the allowance of `operator` by +`addedAmount`
+
+Atomically increases the allowance granted to `operator` by the caller.
+
+This is an alternative approach to [`authorizeOperator`](#authorizedoperator) that can be used as a mitigation for the double spending allowance problem.
+
+> **Requirements:**
+>
+> - `operator` cannot be the same address as `msg.sender`
+> - `operator` cannot be the zero address.
+
+> **Events Emitted**
+>
+> - `AuthorizedOperator` event indicating the updated allowance.
+
+#### Parameters
+
+| Name          | Type      | Description                                                                 |
+| ------------- | --------- | --------------------------------------------------------------------------- |
+| `operator`    | `address` | the operator to increase the allowance for `msg.sender`                     |
+| `addedAmount` | `uint256` | the additional amount to add on top of the current operator&#39;s allowance |
+
+### decreaseAllowance
+
+```solidity
+function decreaseAllowance(address operator, uint256 substractedAmount) external nonpayable
+```
+
+Decrease the allowance of `operator` by -`substractedAmount`
+
+Atomically decreases the allowance granted to `operator` by the caller.
+
+This is an alternative approach to [`authorizeOperator(...)`](#authorizedoperator) that can be used as a mitigation for the double spending allowance problem
+
+> **Requirements:**
+>
+> - `operator` cannot be the zero address.
+> - `operator` must have allowance for the caller of at least `substractedAmount`.
+
+> **Events Emitted**:
+>
+> - `AuthorizedOperator` event indicating the updated allowance after decreasing it.
+> - `RevokeOperator` event if `substractedAmount` is the full allowance, indicating `operator` does not have any allowance left for `msg.sender`.
+
+#### Parameters
+
+| Name                | Type      | Description                                                |
+| ------------------- | --------- | ---------------------------------------------------------- |
+| `operator`          | `address` | the operator to decrease allowance for `msg.sender`        |
+| `substractedAmount` | `uint256` | the amount to decrease by in the operator&#39;s allowance. |
+
 ### authorizedAmountFor
+
+:::info
+The tokenOwner is its own operator.
+:::
 
 ```solidity
 function authorizedAmountFor(
@@ -173,12 +245,6 @@ function authorizedAmountFor(
 ```
 
 Returns the amount of tokens to which the `operator` address has access from the `tokenOwner` contract. Operators can send and burn tokens on behalf of their owners.
-
-:::note
-
-The tokenOwner is its own operator.
-
-:::
 
 #### Parameters:
 
@@ -273,11 +339,6 @@ _Triggers the **[Transfer](#transfer-2)** event when tokens get successfully tra
 ## Internal Functions
 
 These internal functions can be extended via `override` to add some custom logic.
-
-:::info Warning
-By deploying an LSP7DigitalAsset contract, there will be no public mint or burn function.
-In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
-:::
 
 ### \_mint
 

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -177,7 +177,7 @@ This is a non-standard function, not part of the `ILSP7DigitalAsset` interface. 
 :::
 
 ```solidity
-function increaseAllowance(address operator, uint256 addedAmount) external nonpayable
+function increaseAllowance(address operator, uint256 addedAmount) external;
 ```
 
 Increase the allowance of `operator` by +`addedAmount`
@@ -209,7 +209,7 @@ This is a non-standard function, not part of the `ILSP7DigitalAsset` interface. 
 :::
 
 ```solidity
-function decreaseAllowance(address operator, uint256 substractedAmount) external nonpayable
+function decreaseAllowance(address operator, uint256 substractedAmount) external;
 ```
 
 Decrease the allowance of `operator` by -`substractedAmount`

--- a/docs/standards/smart-contracts/lsp7-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp7-digital-asset.md
@@ -11,7 +11,7 @@ sidebar_position: 9
 
 :::
 
-:::caution
+:::caution Warning
 The `LSP7DigitalAsset` contract is an `abstract` contract that is not deployable as it is. This is because it does not contain any public functions by default to manage token supply (_e.g: no public `mint(...)` or `burn(...)` functions_).
 
 In order to use the internal [`_mint(...)`](#_mint) and [`_burn(...)`](#_burn) functions, you can:
@@ -203,6 +203,10 @@ This is an alternative approach to [`authorizeOperator`](#authorizedoperator) th
 | `addedAmount` | `uint256` | the additional amount to add on top of the current operator&#39;s allowance |
 
 ### decreaseAllowance
+
+:::info
+This is a non-standard function, not part of the `ILSP7DigitalAsset` interface. It exists to be used as a prevention mechanism against the double spending allowance vulnerability.
+:::
 
 ```solidity
 function decreaseAllowance(address operator, uint256 substractedAmount) external nonpayable
@@ -562,7 +566,7 @@ event Transfer(
 )
 ```
 
-_**MUST** be fired when the **[transfer](#transfer)** function gets executed successfuly._
+_Fired when the **[transfer](#transfer)** function gets executed successfuly._
 
 #### Values:
 
@@ -585,7 +589,7 @@ event AuthorizedOperator(
 )
 ```
 
-_**MUST** be fired when the **[authorizeOperator](#authorizeoperator)** function gets successfully executed._
+_Fired when the **[authorizeOperator](#authorizeoperator)** function gets successfully executed._
 
 #### Values:
 
@@ -604,7 +608,7 @@ event RevokedOperator(
 )
 ```
 
-_**MUST** be fired when the **[revokeOperator](#revokeoperator)** function gets successfully executed._
+_Fired when the **[revokeOperator](#revokeoperator)** function gets successfully executed._
 
 #### Values:
 

--- a/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
+++ b/docs/standards/smart-contracts/lsp8-identifiable-digital-asset.md
@@ -11,6 +11,17 @@ sidebar_position: 10
 
 :::
 
+:::caution Warning
+
+The `LSP8IdentifiableDigitalAsset` contract is an `abstract` contract that is not deployable as it is. This is because it does not contain any public functions by default to manage token supply (_e.g: no public `mint(...)` or `burn(...)` functions_).
+
+In order to use the internal [`_mint(...)`](#_mint) and [`_burn(...)`](#_burn) functions, you can:
+
+- use `LSP8Mintable`, a preset contract that contains a public `mint(...)` function callable only by the contract's owner.
+- or extend the `LSP8DigitalAsset` contract and create custom methods that use the internal functions (to create your own supply mechanism).
+
+:::
+
 The **LSP8IdentifiableDigitalAsset** contract represents identifiable digital assets (NFTs) that can be uniquely traded and given metadata using the **[ERC725Y Standard](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y)**.
 Each NFT is identified with a tokenId, based on **[ERC721](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol)**.
 
@@ -197,6 +208,10 @@ _Triggers the **[RevokedOperator](#revokedoperator)** event when an address gets
 
 ### isOperatorFor
 
+:::info
+The tokenOwner is its own operator.
+:::
+
 ```solidity
 function isOperatorFor(
     address operator,
@@ -205,10 +220,6 @@ function isOperatorFor(
 ```
 
 Returns whether the `operator` address is an operator of the `tokenId`. Operators can send and burn tokens on behalf of their owners.
-
-:::note
-The tokenOwner is its own operator.
-:::
 
 #### Parameters:
 
@@ -219,9 +230,9 @@ The tokenOwner is its own operator.
 
 #### Return Values:
 
-| Name     | Type   | Description                                                               |
-| :------- | :----- | :------------------------------------------------------------------------ |
-| `result` | `bool` | TRUE if `operator` address is an operator for `tokenId`, false otherwise. |
+| Name     | Type   | Description                                                           |
+| :------- | :----- | :-------------------------------------------------------------------- |
+| `result` | `bool` | `true` if `operator` is an operator for `tokenId`, `false` otherwise. |
 
 :::note
 
@@ -341,11 +352,6 @@ _Triggers the **[Transfer](#transfer-2)** event when the tokens get successfully
 
 These internal functions can be extended via `override` to add some custom logic.
 
-:::info Warning
-By deploying an LSP8IdentifiableDigitalAsset contract, there will be no public mint or burn function.
-In order to use them you have to extend the smart contracts and create custom methods using the internal functions.
-:::
-
 ### \_mint
 
 ```solidity
@@ -455,7 +461,7 @@ function _beforeTokenTransfer(
 ) internal virtual
 ```
 
-Hook that is called before any token transfer. This includes minting and burning.
+Hook that is called before any token transfer, including minting and burning.
 
 #### Parameters:
 
@@ -464,16 +470,6 @@ Hook that is called before any token transfer. This includes minting and burning
 | `from`    | `address` | The sender address.    |
 | `to`      | `address` | The recipient address. |
 | `tokenId` | `bytes32` | The token to transfer. |
-
-:::note
-
-#### Notice:
-
-- When `from` and `to` are both non-zero, `from`'s `tokenId` will be transferred to `to`.
-- When `from` is zero, `tokenId` will be minted for `to`.
-- When `to` is zero, `from`'s `tokenId` will be burned.
-
-:::
 
 ### \_notifyTokenSender
 
@@ -574,7 +570,7 @@ event Transfer(
 )
 ```
 
-_**MUST** be fired when the **[transfer](#transfer)** function gets executed successfuly._
+_Fired when the **[transfer](#transfer)** function gets executed successfuly._
 
 #### Values:
 
@@ -597,7 +593,7 @@ event AuthorizedOperator(
 )
 ```
 
-_**MUST** be fired when the **[authorizeOperator](#authorizeoperator)** function gets successfully executed._
+_Fired when the **[authorizeOperator](#authorizeoperator)** function gets successfully executed._
 
 #### Values:
 
@@ -617,7 +613,7 @@ event RevokedOperator(
 )
 ```
 
-_**MUST** be fired when the **[revokeOperator](#revokeoperator)** function gets successfully executed._
+_Fired when the **[revokeOperator](#revokeoperator)** function gets successfully executed._
 
 #### Values:
 


### PR DESCRIPTION
# What does this PR introduce?

- add new non-standard functions `increaseAllowance` / `decreaseAllowance` to LSP7 contract ABIs.
- move callout to the top about LSP7/LSP8 not containing default public functions to mint and burn.
- change callouts colour from grey (note) to blue (info) for token owner being its own operator.
- remove word "MUST" from event descriptions.