### PR TITLE
Add extended Checkpoint Sync Descriptions

### DIFF
--- a/docs/guides/network/switch-consensus-clients.md
+++ b/docs/guides/network/switch-consensus-clients.md
@@ -142,6 +142,10 @@ Wait 10 minutes after stopping your node so the network does not accuse you of s
 
 Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
 
+Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
+
+> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
+
 <Tabs>
 <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
 

--- a/docs/guides/network/update-the-node.md
+++ b/docs/guides/network/update-the-node.md
@@ -167,6 +167,10 @@ Wait 10 minutes after stopping your node so the network does not accuse you of s
 
 Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
 
+Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
+
+> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
+
 <Tabs>
 <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
 
@@ -320,6 +324,10 @@ Wait 10 minutes after stopping your node so the network does not accuse you of s
 
 Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
 
+Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
+
+> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
+
 <Tabs>
 <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
 
@@ -415,6 +423,10 @@ $ lukso update
 You can start your node as regular. If you run a validator, please adjust your flags or the recipient address.
 
 Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
+
+Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
+
+> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
 
 <Tabs>
 <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">

--- a/docs/networks/mainnet/become-a-validator.md
+++ b/docs/networks/mainnet/become-a-validator.md
@@ -77,7 +77,9 @@ As only genesis validators can run the validator on a node, you must select your
 
 Without specifying any flags, the node starts its normal synchronization process.
 
-If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis.
+If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running.
+
+> After the synchronization is finalized, you will end up with the equal blockchain data. You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime. The shortcut is ideal for fresh installations, validator migration, or recovery.
 
 <Tabs>
   <TabItem value="regular-sync" label="Regular Synchronization">

--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -180,7 +180,9 @@ The following command will spin up your execution and consensus client and conne
 
 Without specifying any flags, the node starts its normal synchronization process.
 
-If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis.
+If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running.
+
+> After the synchronization is finalized, you will end up with the equal blockchain data. You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime. The shortcut is ideal for fresh installations, validator migration, or recovery.
 
 <Tabs>
   <TabItem value="regular-sync" label="Regular Synchronization">


### PR DESCRIPTION
Added extended description about checkpoint synchronization to the node setups and guides. Content is intentionally duplicated, so people do not have to switch pages- as discussed with Fabian.