### PR TITLE
Fix grammar and styling for FAQ

### DIFF
--- a/docs/faq/lukso/general-information.md
+++ b/docs/faq/lukso/general-information.md
@@ -42,6 +42,6 @@ Please look at our official [Network Migration](https://medium.com/lukso/the-lyx
 
 ## What's the difference between LYXt, LYXe, and LYX?
 
-- **LYXt** is the currency for developers used on our official LUKSO Testnet without monetary value. LYXt can be required for free using the [Testnet Faucet](https://faucet.testnet.lukso.network/). The Testnet is maintained by a set of whitepisted node operators to ensure stability.
+- **LYXt** is the currency for developers used on our official LUKSO Testnet without monetary value. LYXt can be acquired for free using the [Testnet Faucet](https://faucet.testnet.lukso.network/). The Testnet is maintained by a set of whitelisted node operators to ensure stability.
 - **LYXe** is the LUKSO token on the Ethereum Blockchain, used to start off the LUKSO Mainnet in a distributed way. It was created in 2020 during the [rICO](https://medium.com/lukso/re-launching-the-reversible-ico-5289989ce7ed) of LUKSO and started as main token before the mainnet was released. It acted as the preliminary representation of LYX on Ethereum. However, the [distribution changed](https://medium.com/lukso/its-happening-the-genesis-validators-are-coming-ce5e07935df6) and additional LYXe was burnt. You can see the LYXe token on [Etherscan](https://etherscan.io/token/0xA8b919680258d369114910511cc87595aec0be6D).
 - **LYX** is the official coin of the LUKSO Blockchain, similar to ETH on Ethereum. People that acquired LYXe before the mainnet launch can migrate their LYXe to LYX using the [LUKSO Migration Bridge](https://migrate.lukso.network/).

--- a/docs/faq/lukso/project-differentiation.md
+++ b/docs/faq/lukso/project-differentiation.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Project Differentiation
 
-## How does Universal Profile differ from ENS?
+## How do Universal Profiles differ from ENS?
 
 The [Ethereum Name Service](https://docs.ens.domains/) (ENS) and Universal Profiles serve different purposes but can complement each other in the blockchain ecosystem. While they might look similar from the outside, they **differ in their tech stack and target**.
 

--- a/docs/faq/network/peer-connection.md
+++ b/docs/faq/network/peer-connection.md
@@ -11,7 +11,7 @@ You can maximize the peer count for both the execution and consensus clients **w
 
 If you just started your node, it might take multiple hours to synchronize with the network and build stable connections. If the number stays low, make sure you **open the ports** that are needed for the blockchain clients to transfer data. Often, the issues stem from the firewall or hosting provider settings.
 
-Another issue could be that your **Public IP** was not set within the node configuration. The IP address should be exposed so other peers can find and connect to your node. The LUKSO CLI automatically asks to put the public IP during the initialization. However, your public IP might change over time, resulting in your node dropping peers. Therefore, keep your public IP updated or configure a Dynamic DNS address for your node. You can find further information about the topic within the [Extended Node Guide](https://docs.luksoverse.io/docs/) written by community members.
+Another issue could be that your **Public IP** was not set within the node configuration. The IP address should be exposed so other peers can find and connect to your node. The LUKSO CLI automatically asks to put the public IP during the initialization. However, your public IP might change over time, resulting in your node dropping peers. Therefore, keep your public IP updated or configure a Dynamic DNS address for your node. You can find further information about the topic within the [Extended Node Guide](https://docs.luksoverse.io/docs/mainnet/complete-node-guide/blockchain-clients/peer-discovery) written by community members.
 
 ## What is the ideal peer count for my node?
 

--- a/docs/faq/onboarding/lukso-standards.md
+++ b/docs/faq/onboarding/lukso-standards.md
@@ -11,9 +11,9 @@ LUKSO Standard Proposals, often abbreviated as [LSPs](../../standards/introducti
 
 With LSPs, the mission is to have standards that facilitate using tools that abstract the blockchain complexity, effectively minimizing the technical problems users may encounter. The goal is to **make blockchain technology as user-friendly and accessible** as standard Web 2.0 technologies. This ease of use paves the way for broader acceptance and integration of blockchain systems in everyday digital interactions.
 
-## Who can utilize [LUKSO Standard Proposals](../../standards/introduction.md)?
+## Who can utilize LUKSO Standard Proposals?
 
-LSPs are a public good and are entirely open source. They can be implemented directly on any EVM blockchain. While LSPs are implemented in Solidity by default, LUKSO ensures that the standardizations are kept platform-independent and can be rewritten in other languages for other blockchain architecture.
+[LSPs](../../standards/introduction.md) are a public good and are entirely open source. They can be implemented directly on any EVM blockchain. While LSPs are implemented in Solidity by default, LUKSO ensures that the standardizations are kept platform-independent and can be rewritten in other languages for other blockchain architecture.
 
 ## What are the main features of LSPs?
 
@@ -43,9 +43,9 @@ LUKSO has quite the advantage with first implementation as the whole user base w
 
 Thanks to the LSP4-DigitalAsset-Metadata standard that is included in the [LSP7](../../standards/nft-2.0/LSP7-Digital-Asset) Token and [LSP8](../../standards/nft-2.0/LSP8-Identifiable-Digital-Asset) NFT standards, **assets can hold unlimited metadata** including images, videos, gifs, and text.
 
-## When using the [LSP9](../../standards/universal-profile/lsp9-vault.md) Vault, is the NFT stored on-chain?
+## When using the LSP9 Vault, is the NFT stored on-chain?
 
-Yes, The vault is a subcontract of a UP. While the NFT contract is stored on-chain, some of its metadata will rely on a **storage solution link** that is specified in its **JSON schema**. This link can point to anything including centralized and decentralized storage solutions.
+Yes, the [LSP9 Vault](../../standards/universal-profile/lsp9-vault.md) is a subcontract of a UP. While the NFT contract is stored on-chain, some of its metadata will rely on a **storage solution link** that is specified in its **JSON schema**. This link can point to anything including centralized and decentralized storage solutions.
 
 ## Do LSPs specify a storage solution for contract data?
 


### PR DESCRIPTION
Community members and I found some minor issues around grammar and styling. 

I would like to suggest proofreading the FAQ pages again now that they got released. There might be further grammar issues down the line that were missed due to the huge PR size. 😁

IMO, we should also not use links within headings and rather put them in the text right under them. The bold blue clickable headlines make it hard to navigate across on mobile phones and conquer the unified look and feel.