### PR TITLE
ci: move syncing of smart contracts docs to `develop` branch

### DIFF
--- a/scripts/contracts-sync.sh
+++ b/scripts/contracts-sync.sh
@@ -3,7 +3,7 @@
 # Pull lsp-smart-contracts repo
 mkdir tmpDocsSync 
 cd tmpDocsSync
-git clone --depth 1  --branch test-docs-sync https://github.com/lukso-network/lsp-smart-contracts.git
+git clone --depth 1  --branch develop https://github.com/lukso-network/lsp-smart-contracts.git
 
 # Copy Docs
 rsync -av --progress lsp-smart-contracts/docs/. ../docs/contracts/


### PR DESCRIPTION
Updating the CI, so that it now sync with the `develop` branch and fetches the latest contract ABIs changes from the lsp-smart-contract repository.