### PR TITLE
fix incorrect `bytes4` value in tuple of `...Map` schemas

### DIFF
--- a/docs/standards/generic-standards/lsp2-json-schema.md
+++ b/docs/standards/generic-standards/lsp2-json-schema.md
@@ -164,7 +164,7 @@ Below are some examples of the **Mapping** key type.
   "name": "LSP5ReceivedAssetsMap:<address>",
   "key": "0x812c4334633eb816c80d0000cafecafecafecafecafecafecafecafecafecafe",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```

--- a/docs/standards/nft-2.0/LSP4-Digital-Asset-Metadata.md
+++ b/docs/standards/nft-2.0/LSP4-Digital-Asset-Metadata.md
@@ -102,7 +102,7 @@ This data key refers to the **address(es)** of the **creator(s)** of the digital
   "name": "LSP4CreatorsMap:<address>",
   "key": "0x6de85eaf5d982b4e5da00000<address>",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```

--- a/docs/standards/universal-profile/lsp10-received-vaults.md
+++ b/docs/standards/universal-profile/lsp10-received-vaults.md
@@ -61,7 +61,7 @@ The `LSP10VaultsMap` data key also helps prevent adding duplications to the arra
   "name": "LSP10VaultsMap:<address>",
   "key": "0x192448c3c0f88c7f238c0000<address>",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```

--- a/docs/standards/universal-profile/lsp12-issued-assets.md
+++ b/docs/standards/universal-profile/lsp12-issued-assets.md
@@ -53,7 +53,7 @@ This data key represents a map key holding both:
   "name": "LSP12IssuedAssetsMap:<address>",
   "key": "0x74ac2555c10b9349e78f0000<address>",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```

--- a/docs/standards/universal-profile/lsp3-profile-metadata.md
+++ b/docs/standards/universal-profile/lsp3-profile-metadata.md
@@ -128,7 +128,7 @@ The `LSP12IssuedAssetsMap:<address>` can then be used to know the asset type (_e
   "name": "LSP12IssuedAssetsMap:<address>",
   "key": "0x74ac2555c10b9349e78f0000<address>",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```

--- a/docs/standards/universal-profile/lsp5-received-assets.md
+++ b/docs/standards/universal-profile/lsp5-received-assets.md
@@ -65,7 +65,7 @@ The `LSP5ReceivedAssetsMap` data key also helps to prevent adding duplications t
   "name": "LSP5ReceivedAssetsMap:<address>",
   "key": "0x812c4334633eb816c80d0000<address>",
   "keyType": "Mapping",
-  "valueType": "(bytes4,bytes8)",
+  "valueType": "(bytes4,uint128)",
   "valueContent": "(Bytes4,Number)"
 }
 ```


### PR DESCRIPTION
The following data keys specify `bytes8` in the second tuple value (for the array length), but this was changed to `uint128`.

- `LSP4CreatorsMap:<address>`
- `LSP5ReceivedAssetsMap:<address>`
- `LSP5ReceivedAssetsMap:<address>`
- `LSP10VaultsMap:<address>`
- `LSP12IssuedAssetsMap:<address>`

See following PRs in LIP repos for reference:
- https://github.com/lukso-network/LIPs/pull/173
- https://github.com/lukso-network/LIPs/pull/233