### PR TITLE
add example to check if tokenId Metadata has changed

### DIFF
--- a/docs/contracts/overview/DigitalAssets.md
+++ b/docs/contracts/overview/DigitalAssets.md
@@ -106,6 +106,37 @@ Each NFT is identified with a tokenId, based on **[ERC721](https://github.com/Op
 
 A **bytes32** value is used for tokenId to allow many uses of token identification, including numbers, contract addresses, and hashed values (i.e., serial numbers).
 
+### Checking if the Metadata of a `tokenId` changed
+
+Because LSP8 uses [ERC725Y](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store) under the hood, the URI pointing to the metadata of a specific tokenId can be changed inside the ERC725Y storage.
+
+This can be done via the functions [`setData(bytes32,bytes)`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#setdata) or [`setDataBatch(bytes32[],bytes[])`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#setdata). 
+
+Since this function emits the [`DataChanged`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#datachanged) event, you can listen for this event in the LSP8 contract to check if the URI pointing of the tokenId metadata has changed. You can do so by filtering the first parameter `dataKey` with:
+
+```
+LSP8MetadataTokenURI:<first 20 bytes of tokenId>
+``` 
+
+If your LSP8 contract uses a specific URI for each tokenId.
+
+<details>
+    <summary>Example of filtering with <code>LSP8MetadataTokenURI:tokenId</code></summary>
+
+Using the following `tokenId` as an example: `0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff`
+
+`LSP8MetadataTokenURI` data key prefix = `0x0x4690256ef7e93288012f0000`
+
+You can filter the `DataChanged` event with the following `dataKey`:
+
+```
+  | LSP8MetadataTokenURI |      first 20 bytes of tokenId        |
+0x4690256ef7e93288012f00001111222233334444555566667777888899990000
+```
+
+</details>
+
+
 ## Note on LSP7 and LSP8 implementations
 
 `LSP7DigitalAsset.sol` and `LSP8IdentifiableDigitalAsset.sol` are `abstract` contracts that are not deployable as they are, because they do not contain any public functions by default to manage token supply (_e.g: no public `mint(...)` or `burn(...)` functions_). You can either:


### PR DESCRIPTION
Add example in "Contract" section to filter event `DataChanged` and see if the URI of the metadata of a specific `tokenId` has changed.

![image](https://github.com/lukso-network/docs/assets/31145285/de94d4c0-5a12-4bac-990e-79c02c1aba8d)
