### PR TITLE
Add details in LSP1 page of Contracts section

### DIFF
--- a/docs/contracts/overview/LSP1Delegate.md
+++ b/docs/contracts/overview/LSP1Delegate.md
@@ -10,3 +10,12 @@ There are two default implementations of the LSP1 Delegate contracts available, 
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | **[`LSP1UniversalReceiverDelegateUP.sol`](../contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.md)**          | Add feature to a `LSP0ERC725Account` to registered and un-register tokens (LSP7 and LSP8) and vaults (LSP9) received. |
 | **[`LSP1UniversalReceiverDelegateVault.sol`](../contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.md)** | Add feature to a `LSP9Vault` to register and un-register tokens (LSP7 and LSP8).                                      |
+
+
+## Routing
+
+The Universal Profile implementation allows for attaching multiple instances of Universal Receiver Delegate to it. This is due to LSP1 Routing. You could have a single General Purpose Unviersal Receiver Delegate and multiple instances of Specific Unviersal Receiver Delegate.
+
+A General Purpose Universal Receiver Delegate has its address stored under the [LSP1UniversalReceiverDelegate Singleton](../../standards//generic-standards/lsp1-universal-receiver-delegate.md#lsp1universalreceiverdelegate-singleton) data key. This contract will be called on any LSP1 hook, meaning that it can potentially react on any [TypeID](../type-ids.md#universal-receiver-type-ids).
+
+A Specific Universal Receiver Delegate has its address stored under the [LSP1UniversalReceiverDelegate Mapping](../../standards//generic-standards/lsp1-universal-receiver-delegate.md#lsp1universalreceiverdelegate-mapping) data key. This contract will be called on specific LSP1 hook, depending on the [TypeID](../type-ids.md#universal-receiver-type-ids) that was passed as a parameter in the hook, meaning that it only reacts on a single specific [TypeID](../type-ids.md#universal-receiver-type-ids).

--- a/docs/standards/generic-standards/lsp1-universal-receiver-delegate.md
+++ b/docs/standards/generic-standards/lsp1-universal-receiver-delegate.md
@@ -92,6 +92,32 @@ One of the possible scenarios is a token transfer between Alice and Bob. Alice w
 
 > For the UniversalReceiverDelegate to be able to call setData function on the UniversalProfile, it should be allowed by the logic of the owner through LSP20.
 
+## Data Keys
+
+### LSP1UniversalReceiverDelegate Singleton
+
+```json
+{
+  "name": "LSP1UniversalReceiverDelegate",
+  "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
+  "keyType": "Singleton",
+  "valueType": "address",
+  "valueContent": "Address"
+}
+```
+
+### LSP1UniversalReceiverDelegate Mapping
+
+```json
+{
+  "name": "LSP1UniversalReceiverDelegate:<bytes32>",
+  "key": "0x0cfc51aec37c55a4d0b10000<bytes32>",
+  "keyType": "Mapping",
+  "valueType": "address",
+  "valueContent": "Address"
+}
+```
+
 ## References
 
 - [LUKSO Standards Proposals: LSP1 - Universal Receiver (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-1-UniversalReceiver.md)


### PR DESCRIPTION
# What does this PR introduce?

In this PR the following changes are made:

- Added the LSP1 data keys in `LSP1Delegate.md` from the Contracts section.
- Added the Type IDs in `LSP1Delegate.md` from the Contracts section.
- Added details about LSP1 Routing in `LSP1Delegate.md` from the Contracts section.