### PR TITLE
Re add files in tokens folder

### DIFF
--- a/docs/standards/tokens/LSP4-Digital-Asset-Metadata.md
+++ b/docs/standards/tokens/LSP4-Digital-Asset-Metadata.md
@@ -1,0 +1,112 @@
+---
+sidebar_label: 'LSP4 - Digital Asset Metadata'
+sidebar_position: 2
+---
+
+# LSP4 - Digital Asset Metadata
+
+:::info Standard Document
+
+[LSP4 - Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)
+
+:::
+
+## Introduction
+
+The existing tokens and NFTs standards offer limited functionalities to attach information to the contracts themselves. As an example, the ERC20 and ERC721 standards only define a **`name()`**, **`symbol()`**, and **`tokenURI()`** functions. This makes it difficult to add information more specific to the asset (e.g., an icon, the asset creator(s) , the utility or motive of the token, the community behind it, etc...). Such information is crucial to make each token or NFT descriptive and customised.
+
+**LSP4-DigitalAsset-Metadata** solves this problem by defining a set of data keys to describe a **Digital Asset** using [ERC725Y](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725y) as a backbone. ERC725Y enables smart contracts to have very flexible and extensible storage. With ERC725Y, any information or metadata can be attached to the token or NFT.
+
+![LSP4 Digital Asset Metadata diagram](/img/standards/lsp4/lsp4-digital-asset-metadata-diagram.png)
+
+## ERC725Y Data Keys
+
+:::tip Recommendation
+
+Make sure to understand the **[ERC725Y Generic Key/Value Store](../lsp-background/erc725.md#erc725y---generic-data-keyvalue-store)** and **[LSP2 - ERC725YJSONSchema](../generic-standards/lsp2-json-schema.md)** Standards before going through the ERC725Y Data Keys.
+
+:::
+
+### `SupportedStandards:LSP4DigitalAsset`
+
+```json
+{
+  "name": "SupportedStandards:LSP4DigitalAsset",
+  "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
+  "keyType": "Mapping",
+  "valueType": "bytes4",
+  "valueContent": "0xa4d96624"
+}
+```
+
+This key is used to know if the contract represents a **Digital Asset**.
+
+### `LSP4TokenName`
+
+```json
+{
+  "name": "LSP4TokenName",
+  "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
+  "keyType": "Singleton",
+  "valueType": "string",
+  "valueContent": "String"
+}
+```
+
+The value attached to this data key represents the name of the digital asset.
+
+### `LSP4TokenSymbol`
+
+```json
+{
+  "name": "LSP4TokenSymbol",
+  "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
+  "keyType": "Singleton",
+  "valueType": "string",
+  "valueContent": "String"
+}
+```
+
+The value attached to this data key represents the symbol of the digital asset.
+
+### `LSP4Metadata`
+
+```json
+{
+  "name": "LSP4Metadata",
+  "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
+  "keyType": "Singleton",
+  "valueType": "bytes",
+  "valueContent": "JSONURL"
+}
+```
+
+The value attached to this data key is a [`JSONURL`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl). It represents a reference to a [JSON file describing the **Digital Asset**](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4metadata). The file can be stored on centralized or decentralized storage.
+
+### `LSP4Creators`
+
+This data key refers to the **address(es)** of the **creator(s)** of the digital asset. It can help to check the **asset authenticity** when combined with **[LSP12-IssuedAssets](../universal-profile/lsp12-issued-assets.md)**.
+
+```json
+{
+  "name": "LSP4Creators[]",
+  "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
+  "keyType": "Array",
+  "valueType": "address",
+  "valueContent": "Address"
+}
+```
+
+```json
+{
+  "name": "LSP4CreatorsMap:<address>",
+  "key": "0x6de85eaf5d982b4e5da00000<address>",
+  "keyType": "Mapping",
+  "valueType": "(bytes4,uint128)",
+  "valueContent": "(Bytes4,Number)"
+}
+```
+
+## References
+
+- [LUKSO Standards Proposals: LSP4 - Digital Asset Metadata (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md)

--- a/docs/standards/tokens/LSP7-Digital-Asset.md
+++ b/docs/standards/tokens/LSP7-Digital-Asset.md
@@ -1,0 +1,116 @@
+---
+sidebar_label: 'LSP7 - Digital Asset (Token)'
+sidebar_position: 3
+---
+
+# LSP7 - Digital Asset
+
+:::info Standard Document
+
+[LSP7 - Digital Asset](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md)
+
+:::
+
+## Introduction
+
+Fungible assets such as **[ERC20](https://eips.ethereum.org/EIPS/eip-20)**, **[ERC223](https://eips.ethereum.org/EIPS/eip-223)** or **[ERC777](https://eips.ethereum.org/EIPS/eip-777)** tokens have a lot of limitations in terms of metadata, secure transfers, and asset interaction. This causes problems for users seeking, **full control** over which assets they accept or not, and a **simple user experience** while creating, buying, and exchanging assets.
+
+**[LSP7-DigitalAsset](#)** is the standard that aims to solve all problems mentioned above by:
+
+- Allowing more secure transfers via **force boolean parameter**.
+- More asset metadata **via [LSP4-DigitalAssetMetadata](./LSP4-Digital-Asset-Metadata.md)**.
+- More interaction between the asset contract and the asset _sender/recipient_ **via token hooks**.
+
+![LSP7DigitalAsset features Introduction](/img/standards/lsp7/lsp7-intro.jpeg)
+
+## What does this Standard represent?
+
+### Specification
+
+**[LSP7-DigitalAsset](#)** is a standard that aims to describe fungible assets. The term _fungible_ means that these assets are **mutually interchangeable** (*e.g., *one token has the same value as another token).
+
+LSP7-DigitalAsset is an interface standard which describes a set of methods that fungible asset contracts should implement which other contracts and clients can call.
+
+This standard was based on **[ERC20](https://eips.ethereum.org/EIPS/eip-20)** and **[ERC777](https://eips.ethereum.org/EIPS/eip-777)** with additional features mentioned below:
+
+### Divisible _vs_ Non-Divisible
+
+When creating assets compliant with **LSP7-DigitalAsset** standard, it is possible to define the token as **divisible** or **non-divisible** in the constructor.
+
+- **Divisible** asset can have decimals (up to 18) and token amounts can be fractional. For instance, it is possible to mint or transfer less than one token (_e.g., 0.3 tokens_).
+- **Non-divisible** asset means that a token cannot be divided into fractional parts. For instance, you cannot transfer **1/10th** of a token, or 0.3 tokens, but only a whole token unit.
+
+**Tickets created as tokens** are a great example of a use case of **LSP7-DigitalAsset**. All tickets look the same, are **interchangeable** and have the same utility. Moreover, such tickets can be made as **non-divisible** as it is only possible to sell or give away a whole ticket.
+
+![LSP7DigitalAsset Non Divisible Assets](/img/standards/lsp7/lsp7-non-divisible.jpeg)
+
+### Unlimited Metadata
+
+:::tip Recommendation
+
+To mark the **asset authenticity**, it's advised to use a combination between **[LSP4-DigitalAssetMetadata](./LSP4-Digital-Asset-Metadata.md)** and **[LSP12-IssuedAssets](../universal-profile/lsp12-issued-assets.md)**.
+
+:::
+
+The current token standards don't enable attaching metadata to the contract in a generic and flexible way, they set the **name**, **symbol**, and **tokenURI**. This is limiting for a digital asset that may want to list the creators, the community behind it, and to have the ability to update the metadata of the token and the tokenIds over time depending on a certain logic (Evolving tokens).
+
+To ensure a flexible and generic asset representation, the token contract should use the **[LSP4-DigitalAsset-Metadata](./LSP4-Digital-Asset-Metadata.md)**. In this way, any information could be attached to the token contract.
+
+### LSP1 Token Hooks
+
+:::caution
+
+When LSP7 assets are transfered, the LSP7 contract will notify the token sender and recipient using [`_notifyTokenSender(...)`](../../contracts/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_notifytokensender) and [`_notifyTokenReceiver(...)`](../../contracts/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_notifytokenreceiver).
+
+**These methods will make external calls** to the [`universalReceiver(...)`](../../contracts/contracts/LSP0ERC725Account/LSP0ERC725Account.md#universalreceiver) functions of both the sender and recipient.
+
+This function could perform more complex logic, like delegating the call to the `LSP1UniversalReceiverDelegate` contract. This contract can contain custom logic for each user. For instance, a user could decide to re-transfer the tokens to another address once they are transferred to his UP.
+
+:::
+
+The current token standards act as **registry contracts** that keep track of each address's balance. They do not implement functionalities to **notify the recipient** that it has received some tokens or to **notify the sender** that it has sent some tokens.
+
+During an **ERC20 token transfer**, the sender's balance is decreased, and the recipient's balance is increased without further interaction.
+
+![ERC20 Transfer](/img/standards/lsp7/erc20-transfer.jpeg)
+
+During an **LSP7 token transfer**, as well as updating the balances, both the sender and recipient are informed of the transfer by calling their **[`universalReceiver(...)`](../generic-standards/lsp1-universal-receiver.md#lsp1---universal-receiver)** function (if these are both smart contracts).
+
+![LSP7DigitalAsset Transfer](/img/standards/lsp7/lsp7-transfer.jpeg)
+
+In this way, users are **informed** about the token transfers and can decide how to **react on the transfer**, either by accepting or rejecting the tokens, or implementing a custom logic to run on each transfer with the help of **[LSP1-UniversalReceiverDelegate](../generic-standards/lsp1-universal-receiver-delegate.md)**.
+
+If the sender and recipient are smart contracts that implement the LSP1 standard, the LSP7 token contract will notify them using the following `bytes32 typeIds` when calling their `universalReceiver(...)` function.
+
+| address notified       | `bytes32` typeId used                                                | description                                     |
+| ---------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
+| Token sender (`from`)  | `0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea` | `keccak256('LSP7Tokens_SenderNotification')`    |
+| Token recipient (`to`) | `0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c` | `keccak256('LSP7Tokens_RecipientNotification')` |
+
+### `force` mint and transfer
+
+:::success
+
+It is advised to set the `force` boolean to `false` when transferring or minting tokens to avoid sending them to the wrong address.
+
+For instance, if the wrong address was pasted by mistake by the user in the input field of a dApp.
+
+:::
+
+It is expected in the LUKSO's ecosystem to use **[smart contract-based accounts](../universal-profile/lsp0-erc725account.md)** to interact on the blockchain. This includes sending and receiving tokens. EOAs can receive tokens, but should be used mainly to control these accounts, not to interact on the network or hold tokens.
+
+To ensure a **safe asset transfer**, an additional boolean parameter was added to the [`transfer(...)``](../../contracts/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#transfer) and `_mint(...)` functions:
+
+- If set to `false`, the transfer will only pass if the recipient is a smart contract that implements the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard.
+
+![Token Force Boolean False](/img/standards/lsp7/tokens-force-false.jpeg)
+
+- If set to `true`, the transfer will not be dependent on the recipient, meaning **smart contracts** not implementing the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard and **EOAs** will be able to receive the tokens.
+
+![Token Force Boolean True](/img/standards/lsp7/tokens-force-true.jpeg)
+
+Implementing the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard will give a sign that the contract knows how to handle the tokens received.
+
+## References
+
+- [LUKSO Standards Proposals: LSP7 - Digital Asset (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md)

--- a/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
+++ b/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
@@ -1,0 +1,136 @@
+---
+sidebar_label: 'LSP8 - Identifiable Digital Asset (NFT)'
+sidebar_position: 4
+---
+
+# LSP8 - Identifiable Digital Asset
+
+:::info Standard Document
+
+[LSP8 - Identifiable Digital Asset](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-8-IdentifiableDigitalAsset.md)
+
+:::
+
+## Introduction
+
+Non-Fungible assets such as **[ERC721](https://eips.ethereum.org/EIPS/eip-721)** and **[ERC1155](https://eips.ethereum.org/EIPS/eip-1155)** tokens have a lot of limitations in terms of metadata, secure transfers, asset representation, and asset interaction. This causes problems for users seeking, **full control** over which assets they accept or not, **more complex NFT functionality**, and a **simple user experience** while creating, buying, and exchanging assets.
+
+**[LSP8-IdentifiableDigitalAsset](#)** is the standard that aims to solve all problems mentioned above by:
+
+- Allowing more secure transfers via **force boolean parameter**.
+- More asset metadata **via [LSP4-DigitalAssetMetadata](./LSP4-Digital-Asset-Metadata.md)**.
+- More asset representation **via bytes32 tokenIds**.
+- More interaction between the asset contract and the asset _sender/recipient_ **via token hooks**.
+
+![LSP8IdentifiableDigitalAsset features Introduction](/img/standards/lsp8/lsp8-intro.jpeg)
+
+## What does this Standard represent?
+
+### Specification
+
+**[LSP8-IdentifiableDigitalAsset](#)** is a standard that aims to describe _non-fungible_ assets. The term _Non-fungible_ means that each asset is **unique and different**. They are distinguishable from each other and therefore **not interchangeable**.
+
+This standard was based on **[ERC721](https://eips.ethereum.org/EIPS/eip-20)** and **[ERC1155](https://eips.ethereum.org/EIPS/eip-777)** with additional features mentioned below:
+
+### Bytes32 TokenId Type
+
+The current NFT standards such as **[ERC721](https://eips.ethereum.org/EIPS/eip-721)** and **[ERC1155](https://eips.ethereum.org/EIPS/eip-1155)** **lack asset representation** as they define the tokenIds **as Numbers** `(uint256)`. Each token from the NFT collection will be defined and queried based on this tokenId, which is normally incremental.
+
+![ERC721 TokenIds Representation](/img/standards/lsp8/erc721-tokenIds.jpeg)
+
+**[LSP8-IdentifiableDigitalAsset](#)** define the tokenIds as **bytes32**. The choice of **bytes32 tokenIds** allows a wide variety of applications including numbers, contract addresses, and hashed values (ie. serial numbers).
+
+The **bytes32 tokenId** can be interpreted as a:
+
+- <u><b>Number:</b></u>
+
+![LSP8 Number TokenIds Representation](/img/standards/lsp8/lsp8-tokenId-number.jpeg)
+
+- <u><b>Hashed Value:</b></u>:
+
+![LSP8 Hashed Value TokenIds Representation](/img/standards/lsp8/lsp8-tokenId-hashed.jpeg)
+
+- <u><b>Contract Address:</b></u>
+
+![LSP8 Address TokenIds Representation](/img/standards/lsp8/lsp8-tokenId-address.jpeg)
+
+TokenIds represented as **smart contract address** allow the creation of more **complex NFTs**. When each tokenId is a contract that have its own **[ERC725Y](../lsp-background//erc725.md#erc725y---generic-data-keyvalue-store)** storage. For instance in a video game, by changing the features and metadata of the tokenId based on the **game rules**.
+
+![LSP8 Game Nested NFTs TokenIds Representation](/img/standards/lsp8/lsp8-game.jpeg)
+
+### Unlimited Metadata
+
+:::tip Recommendation
+
+To mark the **asset authenticity**, it's advised to use a combination between **[LSP4-DigitalAssetMetadata](./LSP4-Digital-Asset-Metadata.md)** and **[LSP12-IssuedAssets](../universal-profile/lsp12-issued-assets.md)**.
+
+:::
+
+The current token standards don't enable attaching metadata to the contract in a generic and flexible way, they set the **name**, **symbol**, and **tokenURI**. This is limiting for a digital asset that may want to list the creators, the community behind it, and to have the ability to update the metadata of the token and the tokenIds over time depending on a certain logic (Evolving tokens).
+
+To ensure a flexible and generic asset representation, the token contract should use the **[LSP4-DigitalAsset-Metadata](./LSP4-Digital-Asset-Metadata.md)**. In this way, any information could be attached to the token contract.
+
+:::note Notice
+
+The Metadata defined by the **ERC725Y Data Keys** can be set for **each tokenId**, not just for the whole NFT collection. Check **[LSP8 ERC725Y Data Keys](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#erc725y-data-keys)** in the LSP8 Standard Document.
+
+:::
+
+### LSP1 Token Hooks
+
+:::caution
+
+When LSP8 assets are transfered, the LSP8 contract will notify the token sender and recipient using [`_notifyTokenSender(...)`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_notifytokensender) and [`_notifyTokenReceiver(...)`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_notifytokenreceiver).
+
+**These methods will make external calls** to the [`universalReceiver(...)`](../../contracts/contracts/LSP0ERC725Account/LSP0ERC725Account.md#universalreceiver) functions of both the sender and recipient.
+
+This function could perform more complex logic, like delegating the call to the `LSP1UniversalReceiverDelegate` contract. This contract can contain custom logic for each user. For instance, a user could decide to re-transfer the tokens to another address once they are transferred to his UP.
+
+:::
+
+The current NFTs standards act as **registry contracts** that keep track of the ownership of each tokenId. They do not implement functionalities to **notify the recipient** that it has received some tokens or to **notify the sender** that it has sent some tokens.
+
+During an **ERC721 token transfer**, the ownership of the tokenId is changed from the sender address to the recipient address without further interaction.
+
+![ERC721 Transfer](/img/standards/lsp8/erc721-transfer.jpeg)
+
+During an **LSP8 token transfer**, as well as updating the tokenId ownership, both the sender and recipient are informed of the transfer by calling the **[`universalReceiever(...)`](../generic-standards/lsp1-universal-receiver.md#lsp1---universal-receiver)** function on their profiles.
+
+![LSP8 Transfer](/img/standards/lsp8/lsp8-transfer.jpeg)
+
+In this way, users are **informed** about the NFT transfer and can decide how to **react on the transfer**, either by accepting or rejecting the NFT, or implementing a custom logic to run on each transfer with the help of **[LSP1-UniversalReceiverDelegate](../generic-standards/lsp1-universal-receiver-delegate.md)**.
+
+If the sender and recipient are smart contracts that implement the LSP1 standard, the LSP8 token contract will notify them using the following `bytes32 typeIds` when calling their `universalReceiver(...)` function.
+
+| address notified       | `bytes32` typeId used                                                | description                                     |
+| ---------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
+| Token sender (`from`)  | `0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00` | `keccak256('LSP8Tokens_SenderNotification')`    |
+| Token recipient (`to`) | `0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d` | `keccak256('LSP8Tokens_RecipientNotification')` |
+
+### `force` mint and transfer
+
+:::success
+
+It is advised to set the `force` boolean to `false` when transferring or minting tokens to avoid sending them to the wrong address.
+
+For instance, if the wrong address was pasted by mistake by the user in the input field of a dApp.
+
+:::
+
+It is expected in the LUKSO's ecosystem to use **smart contract based accounts** to interact on the blockchain. This includes sending and receiving tokens. EOAs can receive tokens, but should be used mainly to control these accounts, not to interact on the network or hold tokens.
+
+To ensure a **safe asset transfer**, an additional boolean parameter was added to the [`transfer(...)``](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#transfer) and `_mint(...)` functions:
+
+- If set to `false`, the transfer will only pass if the recipient is a smart contract that implements the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard.
+
+![Token Force Boolean False](/img/standards/lsp7/tokens-force-false.jpeg)
+
+- If set to `true`, the transfer will not be dependent on the recipient, meaning **smart contracts** not implementing the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard and **EOAs** will be able to receive the tokens.
+
+![Token Force Boolean True](/img/standards/lsp7/tokens-force-true.jpeg)
+
+Implementing the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard will give a sign that the contract knows how to handle the tokens received.
+
+## References
+
+- [LUKSO Standards Proposals: LSP8 - Identifiable Digital Asset (Standard Specification, GitHub)](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-8-IdentifiableDigitalAsset.md)

--- a/docs/standards/tokens/_category_.yml
+++ b/docs/standards/tokens/_category_.yml
@@ -1,0 +1,3 @@
+label: 'Tokens & NFT 2.0'
+collapsed: true
+position: 7

--- a/docs/standards/tokens/introduction.md
+++ b/docs/standards/tokens/introduction.md
@@ -1,0 +1,38 @@
+---
+sidebar_label: 'Introduction'
+sidebar_position: 1
+---
+
+# Tokens & NFT 2.0
+
+:::success Useful Tip
+
+The [guide section](../../guides/digital-assets/create-lsp7-digital-asset.md) will walk you through creating and deploying an LSP7 token or an LSP8 NFT on the [L14 test network](../../networks/l14-testnet.md).
+
+Check the [profile explorer](https://universalprofile.cloud/) to browse the deployed digital assets.
+
+:::
+
+## Introduction
+
+The current standards representing fungible and non-fungible tokens (NFTs) are limiting the NFTs and token industry as they lack standardization and many powering features.
+
+The lack of standardization can be seen through each NFT or token standard implementing its own interface with its own function names. This leads to having multiple token contracts deployed on networks, implementing different interfaces, and being non-interoperable between each other.
+
+As for features, these standards are just representing **incremental tokenIds** without proper metadata, asset representation, standard interaction between sender and receivers, and no security measurements to ensure safe asset transfers.
+
+**Tokens & NFT 2.0** is a collective name for the new token and NFT standards **[LSP7-DigitalAsset](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md)** and **[LSP8-IdentifiableDigitalAsset](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-8-IdentifiableDigitalAsset.md)**. These replace ERC20 and ERC721, which you would usually use on other networks.
+
+## Tokens & NFT 2.0
+
+| Standard                                                                    | Description                                                                                                                                                                                           |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[ LSP4 - DigitalAssetMetadata ](./LSP4-Digital-Asset-Metadata.md)**       | The standard used by both **LSP7** & **LSP8** to provide proper **metadata** to the asset with standard ERC725Y Data Keys.                                                                            |
+| **[LSP7 - DigitalAsset](./LSP7-Digital-Asset.md)**                          | Similar to ERC20 Standard, LSP7 represents **fungible tokens** standard with proper metadata, more secure transfers and more interactive transfer.                                                    |
+| **[LSP8 - IdentifiableDigitalAsset](./LSP8-Identifiable-Digital-Asset.md)** | Similar to ERC721 and ERC1155 Standard, LSP8 represents **non-fungible tokens (NFTs)** standard with proper metadata, more secure transfers, more asset representation and more interactive transfer. |
+
+![Tokens & NFT Standards LSP4, LSP7 and LSP8](/img/standards/LUKSO-Tokens-NFT-Standards.jpeg)
+
+## References
+
+- [NFT NYC - Building Blocks for the New Creative Economy (Fabian Vogelsteller, Youtube)](https://www.youtube.com/watch?v=skA4Y-vvt5s)


### PR DESCRIPTION
The articles in the folder `nft-2.0` which was renamed to `tokens` were missing - they were deleted in that commit:

https://github.com/lukso-network/docs/pull/687/commits/5f3539169bce9c24280f3511ba34fb8c696a8b0a#diff-a03e858a474474218d452588f65225cb5050ddda159c607281022340ff17a426

This is to add them again