### PR TITLE
Add/update checkpoint notices on guides

### DIFF
--- a/docs/networks/advanced-guides/switch-consensus-clients.md
+++ b/docs/networks/advanced-guides/switch-consensus-clients.md
@@ -157,12 +157,6 @@ If you are setting up a node for the testnet, add the `--testnet` flag to the st
 
 :::
 
-:::note
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version, please pass down the checkpoint flag as described in the [LUKSO CLI Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
 ```sh
 # Starting the Mainnet Node
 lukso start --checkpoint-sync
@@ -170,6 +164,12 @@ lukso start --checkpoint-sync
 # Starting the Mainnet Validator
 lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
 ```
+
+:::caution
+
+If you are experiencing issues with the `--checkpoint-sync` flag or are using a LUKSO CLI Version below version 0.7.0, the checkpoint synchronization can be [enabled manually](https://github.com/lukso-network/tools-lukso-cli/tree/main#checkpoints-with-lukso-cli-version-07-or-below).
+
+:::
 
   </TabItem>
   <TabItem value="regular-sync" label="Regular Synchronization">

--- a/docs/networks/advanced-guides/update-clients.md
+++ b/docs/networks/advanced-guides/update-clients.md
@@ -99,6 +99,12 @@ lukso start --checkpoint-sync
 lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
 ```
 
+:::caution
+
+If you are experiencing issues with the `--checkpoint-sync` flag or are using a LUKSO CLI Version below version 0.7.0, the checkpoint synchronization can be [enabled manually](https://github.com/lukso-network/tools-lukso-cli/tree/main#checkpoints-with-lukso-cli-version-07-or-below).
+
+:::
+
   </TabItem>
   <TabItem value="regular-sync" label="Regular Synchronization">
 

--- a/docs/networks/advanced-guides/update-the-node.md
+++ b/docs/networks/advanced-guides/update-the-node.md
@@ -307,6 +307,12 @@ lukso start --checkpoint-sync
 lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
 ```
 
+:::caution
+
+If you are experiencing issues with the `--checkpoint-sync` flag or are using a LUKSO CLI Version below version 0.7.0, the checkpoint synchronization can be [enabled manually](https://github.com/lukso-network/tools-lukso-cli/tree/main#checkpoints-with-lukso-cli-version-07-or-below).
+
+:::
+
   </TabItem>
   <TabItem value="regular-sync" label="Regular Synchronization">
 

--- a/docs/networks/mainnet/become-a-validator.md
+++ b/docs/networks/mainnet/become-a-validator.md
@@ -107,9 +107,9 @@ If you are setting up a node for the testnet, add the `--testnet` flag to the st
 
 :::
 
-:::note
+:::caution
 
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version, please pass down the checkpoint flag as described in the [LUKSO CLI Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
+If you are experiencing issues with the `--checkpoint-sync` flag or are using a LUKSO CLI Version below version 0.7.0, the checkpoint synchronization can be [enabled manually](https://github.com/lukso-network/tools-lukso-cli/tree/main#checkpoints-with-lukso-cli-version-07-or-below).
 
 :::
 

--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -104,7 +104,26 @@ If you want more convenience and your validator to operate quickly, you can also
 
 > After the synchronization is finalized, you will end up with the equal blockchain data. You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime. The shortcut is ideal for fresh installations, validator migration, or recovery.
 
-<Tabs>
+<Tabs>  
+  <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
+
+:::tip
+
+The shortcut is ideal for making installation, validator migration, or recovery much faster.
+
+:::
+
+:::caution
+
+If you are experiencing issues with the `--checkpoint-sync` flag or are using a LUKSO CLI Version below version 0.7.0, the checkpoint synchronization can be [enabled manually](https://github.com/lukso-network/tools-lukso-cli/tree/main#checkpoints-with-lukso-cli-version-07-or-below).
+
+:::
+
+```sh
+lukso start --checkpoint-sync
+```
+
+  </TabItem>
   <TabItem value="regular-sync" label="Regular Synchronization">
 
 :::info
@@ -118,25 +137,6 @@ lukso start
 ```
 
   </TabItem>  
-  <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
-
-:::tip
-
-The shortcut is ideal for making installation, validator migration, or recovery much faster.
-
-:::
-
-:::note
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version, please pass down the checkpoint flag as described in the [LUKSO CLI Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
-```sh
-lukso start --checkpoint-sync
-```
-
-  </TabItem>
 </Tabs>
 
 :::info


### PR DESCRIPTION
As the checkpoint synchronization is currently down, this puts a maintenance note on the guide pages where people can find further information. (linked to the CLI README)

-> Related PR: (CLI README) [Updated Checkpoint Commands](https://github.com/lukso-network/tools-lukso-cli/pull/220)