### PR TITLE
Learn Section: Improvements and Transfer LYX Guide

### DIFF
--- a/docs/learn/dapp-developer/connect-profile.md
+++ b/docs/learn/dapp-developer/connect-profile.md
@@ -10,7 +10,7 @@ To allow your users to connect to your dApp with their [Universal Profile](../..
 - install the 🖥️ [Universal Profile Browser Extension](/install-up-browser-extension)
 - and ✨ [create a Universal Profile](https://my.universalprofile.cloud)
 
-:::note
+:::note Manual Deployment
 
 Optionally you can ⚒️ [deploy a Universal Profile programmatically](../../learn/expert-guides/create-profile.md) for your users, but then they will not benefit from free transactions through the LUKSO Transaction Relay Service.
 

--- a/docs/learn/dapp-developer/read-profile-data.md
+++ b/docs/learn/dapp-developer/read-profile-data.md
@@ -25,7 +25,7 @@ The full code of this example can be found in the 👾 [lukso-playground](https:
 
 :::
 
-:::tip Developer Library
+:::tip erc725.js
 
 By using the ⚒️ [erc725.js](../../tools/erc725js/getting-started/) library, reading profile data can be fetched and encoded easily.
 
@@ -69,10 +69,7 @@ npm install @erc725/erc725.js
 </div>
 </details>
 
-To read the profile data you simply instantiate the ⚒️ [erc725.js](https://www.npmjs.com/package/@erc725/erc725.js) library with your profile address, an RPC provider (`web3`, `ethereum`, `ethers`) or plain RPC URL, and an IPFS gateway. You can find RPC URLs for LUKSO networks on the network pages:
-
-- [LUKSO Mainnet Parameters](../../networks/mainnet/parameters.md)
-- [LUKSO Testnet Parameters](../../networks/testnet/parameters.md).
+To read the profile data you simply instantiate the ⚒️ [erc725.js](https://www.npmjs.com/package/@erc725/erc725.js) library with your profile address, an RPC provider (`web3`, `ethereum`, `ethers`) or plain RPC URL, and an IPFS gateway. You can find RPC URLs for LUKSO networks on the network pages: [mainnet](../../networks/mainnet/parameters.md) / [testnet](../../networks/testnet/parameters.md).
 
 The [`getData()`](../../tools/erc725js/classes/ERC725.md#getdata) function allows you to get all data keys that are stored on the profile smart contract and in your provided JSON schema.
 
@@ -173,7 +170,7 @@ You can give it a try with this profile address: [`<myProfileAddress> = 0xE1F684
 
 :::note ERC725Y JSON schemas
 
-The ⚒️ `erc725.js` library works with [ERC725Y JSON schemas](../../standards/generic-standards/lsp2-json-schema). These schemas are JSON structures that tell developers and programs how to decode and encode 🗂️ [ERC725Y data keys](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store). You need to load the required schemas of the data keys you want to fetch when initializing the `erc725.js` object. The most common schemas are [available](../../tools/erc725js/schemas.md) in the erc725.js library.
+erc725.js works with [ERC725Y JSON schemas](../../standards/generic-standards/lsp2-json-schema). These schemas are JSON structures that tell developers and programs how to decode and encode 🗂️ [ERC725Y data keys](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store). You need to load the required schemas of the data keys you want to fetch when initializing the `ERC725` class. The most common schemas are [available](../../tools/erc725js/schemas.md) in erc725.js.
 
 You can also create and load your own ERC725Y JSON schemas if you want to add custom data keys to the profile.
 

--- a/docs/learn/dapp-developer/read-profile-data.md
+++ b/docs/learn/dapp-developer/read-profile-data.md
@@ -25,21 +25,21 @@ The full code of this example can be found in the 👾 [lukso-playground](https:
 
 :::
 
-:::tip erc725.js
+:::tip Developer Library
 
-We are using 👉 [erc725.js](../../tools/erc725js/getting-started/) to make reading profile data easy.
+By using the ⚒️ [erc725.js](../../tools/erc725js/getting-started/) library, reading profile data can be fetched and encoded easily.
 
 :::
 
-:::tip Universal Profile directory
+:::tip Universal Profile Explorer
 
-[UniversalProfile.cloud](https://universalprofile.cloud/) indexes every Universal Profiles deployed on the LUKSO network. You can try the following examples with any Universal Profile address.
+The explorer on 🔮 [universalprofile.cloud](https://universalprofile.cloud/) indexes all deployed Universal Profiles on the LUKSO network. You can try out the following examples with any Universal Profile address.
 
 :::
 
 ## Setup
 
-To easily interact with a profile you should use [erc725.js](https://npmjs.com/package/@erc725/erc725.js). You can install it in your project using:
+To easily interact with a profile you should use the ⚒️ [erc725.js](https://npmjs.com/package/@erc725/erc725.js). You can install it in your project using:
 
 ```shell
 npm install @erc725/erc725.js
@@ -55,7 +55,7 @@ npm install @erc725/erc725.js
 
 <details>
 <summary>
-<a href="../../standards/universal-profile/lsp3-profile-metadata">LSP3 - Profile Metadata</a> describes the data in the Universal Profile contract <a href="../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store">ERC725Y data storage</a>. You can get the content of these data keys directly using <a href="../../tools/erc725js/classes/ERC725#getdata">erc725.js</a>. 👇
+<a href="../../standards/universal-profile/lsp3-profile-metadata">LSP3 - Profile Metadata</a> describes the data in the Universal Profile contract <a href="../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store">ERC725Y data storage</a>. You can get the content of these data keys directly using the ⚒️ <a href="../../tools/erc725js/classes/ERC725#getdata"> erc725.js</a>  library. 👇
 </summary>
 
 <div>
@@ -69,9 +69,12 @@ npm install @erc725/erc725.js
 </div>
 </details>
 
-To read the profile data you simply instantiate `erc725.js` with your profile address, an RPC provider (`web3`, `ethereum`, `ethers`) or plain RPC URL, and an IPFS gateway. You can find RPC URLs for LUKSO networks on the network pages: [mainnet](../../networks/mainnet/parameters.md) / [testnet](../../networks/testnet/parameters.md).
+To read the profile data you simply instantiate the ⚒️ [erc725.js](https://www.npmjs.com/package/@erc725/erc725.js) library with your profile address, an RPC provider (`web3`, `ethereum`, `ethers`) or plain RPC URL, and an IPFS gateway. You can find RPC URLs for LUKSO networks on the network pages:
 
-[`getData()`](../../tools/erc725js/classes/ERC725.md#getdata) allows you to get all data keys that are stored on the profile smart contract and in your provided JSON schema.
+- [LUKSO Mainnet Parameters](../../networks/mainnet/parameters.md)
+- [LUKSO Testnet Parameters](../../networks/testnet/parameters.md).
+
+The [`getData()`](../../tools/erc725js/classes/ERC725.md#getdata) function allows you to get all data keys that are stored on the profile smart contract and in your provided JSON schema.
 
 <Tabs>  
   <TabItem value="javascript" label="JavaScript">
@@ -170,7 +173,7 @@ You can give it a try with this profile address: [`<myProfileAddress> = 0xE1F684
 
 :::note ERC725Y JSON schemas
 
-`erc725.js` works with [ERC725Y JSON schemas](../../standards/generic-standards/lsp2-json-schema). These schemas are JSON structures that tell developers and programs how to decode and encode 🗂️ [ERC725Y data keys](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store). You need to load the required schemas of the data keys you want to fetch when initializing the `erc725.js` object. The most common schemas are [available](../../tools/erc725js/schemas.md) in the erc725.js library.
+The ⚒️ `erc725.js` library works with [ERC725Y JSON schemas](../../standards/generic-standards/lsp2-json-schema). These schemas are JSON structures that tell developers and programs how to decode and encode 🗂️ [ERC725Y data keys](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store). You need to load the required schemas of the data keys you want to fetch when initializing the `erc725.js` object. The most common schemas are [available](../../tools/erc725js/schemas.md) in the erc725.js library.
 
 You can also create and load your own ERC725Y JSON schemas if you want to add custom data keys to the profile.
 

--- a/docs/learn/dapp-developer/siwe.md
+++ b/docs/learn/dapp-developer/siwe.md
@@ -45,7 +45,7 @@ const accounts = await web3.eth.getAccounts();
 
 Once you have access to the Universal Profile address, you can request a signature. The UP Browser Extension will sign the message with the controller key used by the extension (a smart contract can't sign by itself).
 
-:::tip
+:::tip SIWE Specification
 
 If you need further explanation on the `SiweMessage` properties, please have a look at the [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) specification.
 

--- a/docs/learn/dapp-developer/transfer-lyx.md
+++ b/docs/learn/dapp-developer/transfer-lyx.md
@@ -21,7 +21,13 @@ import TabItem from '@theme/TabItem';
 
 :::tip Generic Transaction Handling
 
-This guide can be used to **transfer LYX** from controller keys and profiles. As LUKSO is EVM-compatible, all regular Ethereum providers can be used to execute transfers or contract calls.
+This guide can be used to **transfer LYX** from controller keys (EOA) and Universal Profiles. As LUKSO is EVM-compatible, all regular Ethereum providers can be used to execute transfers or contract calls.
+
+:::
+
+:::info
+
+The full code of this example can be found in the 👾 [lukso-playground](https://github.com/lukso-network/lukso-playground/tree/main/transfer-lyx/) repository and ⚡️ [StackBlitz](https://stackblitz.com/github/lukso-network/lukso-playground?file=transfer-lyx%2Fup-transaction.js).
 
 :::
 

--- a/docs/learn/dapp-developer/transfer-lyx.md
+++ b/docs/learn/dapp-developer/transfer-lyx.md
@@ -19,10 +19,11 @@ import TabItem from '@theme/TabItem';
 <br /><br />
 </div>
 
-In this guide, we will learn **how to transfer LYX** from your Universal Profile to any `address` (including another Universal Profile :up: ). We will cover:
+:::tip Generic Transaction Handling
 
-- `sendTransaction({from:, to, value, data: '0x', ....})`
-- Give example with Web3js v1 / Ethers -> <https://www.quicknode.com/guides/ethereum-development/transactions/how-to-send-a-transaction-in-ethersjs>
+This guide can be used to **transfer LYX** from controller keys and profiles. As LUKSO is EVM-compatible, all regular Ethereum providers can be used to execute transfers or contract calls.
+
+:::
 
 ## Setup
 
@@ -46,22 +47,148 @@ npm install ethers
 
 </Tabs>
 
-:::caution
+# Transfer LYX from Profile Controller Keys
 
-Note there is an example here: <https://github.com/lukso-network/universalprofile-test-dapp/blob/main/src/components/endpoints/SendTransaction.vue#L304>
+:::tip Recommendation
 
-```
-// using the promise
-web3.eth.sendTransaction({
-    from: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
-    to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
-    value: '1000000000000000'
-})
-.then(function(receipt){
-    ...
-});
-```
-
-https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#sendtransaction
+Sending LYX across EOAs is needed if you want to fund your own transactions instead of using an relay service. For regular value transfers, its recommended to store funds on the 👩‍🎤 [Universal Profiles](#transfer-between-universal-profiles) to improve overall security with exchangable keys and updatable permissions.
 
 :::
+
+If you want to send LYX directly from the controller key of a Univeral Profile, you can create regular blockchain transactions as described by the specifications of blockchain libraries as [web3](https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#sendtransaction) and [ethers](https://docs.ethers.org/v5/api/providers/provider/#Provider-sendTransaction).
+
+<Tabs>
+  
+  <TabItem value="web3js" label="web3.js">
+
+<!-- prettier-ignore-start -->
+
+```js
+const Web3 = require('web3');
+
+// Connect to the mainnet or testnet
+const provider = new Web3('https://rpc.testnet.lukso.gateway.fm');
+
+// Get the controller address of the Universal Profile
+const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+
+await provider.eth.sendTransaction({
+    from: accoutns[0],                        // active controller key
+    to: '0x...',                              // receiving address
+    value: web3.utils.toWei('0.001', 'ether') // amount in LYX
+})
+```
+<!-- prettier-ignore-end -->
+  </TabItem>
+
+  <TabItem value="ethersjs" label="ethers.js">
+
+<!-- prettier-ignore-start -->
+
+```js
+const { ethers } = require('ethers');
+
+// Connect to the mainnet or testnet
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.gateway.fm');
+
+// Get the controller address of the Universal Profile
+const signer = provider.getSigner();
+
+await signer.sendTransaction({
+    to: '0x...',                            // receiving address
+    value: ethers.utils.parseEther('0.001') // amount in LYX
+});
+```
+<!-- prettier-ignore-end -->
+
+  </TabItem>
+
+</Tabs>
+
+## Transfer between Universal Profiles
+
+:::tip Built-in security
+
+When acting on the Universal Profile, the 🔐 [Key Manager](../../standards/universal-profile/lsp6-key-manager.md) will automatically check if the calling controller key is authorized.
+
+:::
+
+You can send LYX from Universal Profiles by executing a call operation on the Universal Profile's smart contract. The controller key of the Universal Profile Extension will be used to sign the transaction.
+
+<Tabs>
+  
+  <TabItem value="web3js" label="web3.js">
+
+<!-- prettier-ignore-start -->
+
+```js
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+const Web3 = require('web3');
+
+// Connect to the mainnet or testnet
+const provider = new Web3('https://rpc.testnet.lukso.gateway.fm');
+
+// Instanciate Universal Profile
+const myUniversalProfile = new provider.eth.Contract(
+  UniversalProfile.abi, // contract ABI of Universal Profiles
+  '0x...',              // address of the user's profile
+);
+
+// Transaction Data
+const operation_type = 0;   // operation of type CALL
+const recipient = '0x...';  // address including profiles and vaults
+const data = '0x';          // executed payload, empty for regular transfer
+const amount = provider.utils.toWei('3'); // amount in LYX
+
+// Get the controller address of the Universal Profile
+const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+
+// Call the execute function of the profile to send the LYX transaction
+await myUniversalProfile.methods
+  .execute(operation_type, recipient, amount, data)
+  .send({
+      from: accounts[0],  // address of the active controller key
+      gasLimit: 300_000,  // gas limit of the transaction
+    });
+```
+<!-- prettier-ignore-end -->
+  </TabItem>
+
+  <TabItem value="ethersjs" label="ethers.js">
+
+<!-- prettier-ignore-start -->
+
+```js
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+const { ethers } = require('ethers');
+
+// Connect to the mainnet or testnet
+const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.gateway.fm');
+
+// Get the controller address of the Universal Profile
+const signer = provider.getSigner();
+
+// Instantiate Universal Profile
+const myUniversalProfile = new ethers.Contract(
+  '0x...', // address of the user's profile
+  UniversalProfile.abi, // contract ABI of Universal Profiles
+  signer, // address of the executing controller key
+);
+
+// Transaction Data
+const operation_type = 0;   // operation of type CALL
+const recipient = '0x...';  // address including profiles and vaults
+const data = '0x';          // executed payload, empty for regular transfer
+const amount = ethers.utils.parseEther('3'); // amount in LYX
+
+// Call the execute function of the profile to send the LYX transaction
+await myUniversalProfile
+  .execute(operation_type, recipient, amount, data,
+      { gasLimit: 300_000 } // gas limit of the transaction
+    );
+```
+<!-- prettier-ignore-end -->
+
+  </TabItem>
+
+</Tabs>

--- a/docs/learn/dapp-developer/transfer-lyx.md
+++ b/docs/learn/dapp-developer/transfer-lyx.md
@@ -75,9 +75,21 @@ await web3.eth.sendTransaction({
 <!-- prettier-ignore-start -->
 
 ```js
-const { ethers } = require('ethers'); // TODO: use import
+import { ethers } from 'ethers';
 
-const provider = new ethers // use window.ethereum here
+const provider = new ethers.providers.Web3Provider(window.ethereum);
+
+await provider.send("eth_requestAccounts", []);
+
+const signer = provider.getSigner();
+const account = await signer.getAddress();
+
+// Send transaction
+const tx = await signer.sendTransaction({
+    from: account,                        // The Universal Profile address
+    to: '0x...',                          // Receiving address, can be a UP or EOA
+    value: ethers.utils.parseEther('0.5') // 0.5 amount in ETH, in wei unit
+});
 ```
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
This PR introduces the following changes:

### Improvements
- Connect Profile Guide
- SIWE Guide
- Connect Profile Guide

### Transfer LYX Guide
- Transfer LYX across controller keys (EOAs)
- Transfer LYX across Universal Profiles (SCs)

Both snippets for `web3`/`ethers`

### Related Changes
- Playground Update: [Update Transfer Guides](https://github.com/lukso-network/lukso-playground/commit/82d5af8187062fce602153c43f2ab820e42cc9ec)