### PR TITLE
Update node guides

### DIFF
--- a/docs/networks/advanced-guides/switch-consensus-clients.md
+++ b/docs/networks/advanced-guides/switch-consensus-clients.md
@@ -3,9 +3,6 @@ sidebar_label: 'Switch Consensus Clients'
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Switching Consensus Clients
 
 Having a variety of clients in a blockchain network and improving our client diversity is critically important.
@@ -142,45 +139,13 @@ Wait 10 minutes after stopping your node so the network does not accuse you of s
 
 :::
 
-Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
-
-Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
-
-> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
-
-<Tabs>
-<TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
-
 :::info
 
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
 
-:::info
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version or run into issues, please pass down the checkpoint flag manually, as described in the [LUKSO CLI Checkpoint Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
-```sh
-# Starting the Mainnet Node
-lukso start --checkpoint-sync
-
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
-```
-
-  </TabItem>
-  <TabItem value="regular-sync" label="Regular Synchronization">
-
-:::caution
-
-The normal synchronization process will take multiple hours for the node to finalize. It is not recommended if you are running a validator.
-
-:::
-
-:::info
+:::note
 
 If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
 
@@ -194,10 +159,7 @@ lukso start
 lukso start --validator --transaction-fee-recipient "0x1234"
 ```
 
-  </TabItem>  
-</Tabs>
-
-:::info
+:::note
 
 After your node finalizes the synchronization with the network, you can remove the validator key folder and the old working directory.
 

--- a/docs/networks/advanced-guides/update-clients.md
+++ b/docs/networks/advanced-guides/update-clients.md
@@ -3,9 +3,6 @@ sidebar_label: 'Update the Clients'
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Update the Clients
 
 If you already use the **latest LUKSO CLI version** and **network configuration** but want to check for new blockchain client versions, you can update them separately.
@@ -76,45 +73,13 @@ lukso install ---teku-tag v23.10.0
 
 You can start your node as regular. If you run a validator, please adjust your flags or the recipient address.
 
-Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
-
-Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
-
-> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
-
-<Tabs>
-<TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
-
 :::info
 
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
 
-:::info
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version or run into issues, please pass down the checkpoint flag manually, as described in the [LUKSO CLI Checkpoint Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
-```sh
-# Starting the Mainnet Node
-lukso start --checkpoint-sync
-
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
-```
-
-  </TabItem>
-  <TabItem value="regular-sync" label="Regular Synchronization">
-
-:::caution
-
-The normal synchronization process will take multiple hours for the node to finalize. It is not recommended if you are running a validator.
-
-:::
-
-:::info
+:::note
 
 If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
 
@@ -127,6 +92,3 @@ lukso start
 # Starting the Mainnet Validator
 lukso start --validator --transaction-fee-recipient "0x1234"
 ```
-
-  </TabItem>  
-</Tabs>

--- a/docs/networks/advanced-guides/update-clients.md
+++ b/docs/networks/advanced-guides/update-clients.md
@@ -71,24 +71,10 @@ lukso install ---teku-tag v23.10.0
 
 ## Restart your Node
 
-You can start your node as regular. If you run a validator, please adjust your flags or the recipient address.
+You can [start your node as regular](../mainnet/running-a-node.md#start-the-clients).
 
 :::info
 
 If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
-
-:::note
-
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
-
-:::
-
-```bash
-# Starting the Mainnet Node
-lukso start
-
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234"
-```

--- a/docs/networks/advanced-guides/update-the-node.md
+++ b/docs/networks/advanced-guides/update-the-node.md
@@ -12,13 +12,11 @@ Updating your node and blockchain clients is of utmost importance. It is not jus
 
 ## Check your LUKSO CLI Version
 
-:::info Breaking Changes
+:::caution Breaking Changes
 
-Since the mainnet launch occurred, the LUKSO CLI had breaking changes from version `0.6` to `0.7`.
+Since the mainnet launch occurred, the LUKSO CLI had breaking changes. Please check your current LUKSO CLI version to determine your update process.
 
 :::
-
-Please check your current LUKSO CLI version to determine your update process.
 
 ```bash
 lukso version
@@ -28,7 +26,7 @@ This guide will lead you through updating the LUKSO CLI to the **latest version*
 
 ## Update the LUKSO CLI
 
-Updating your node is similar to the installing process, while keeping your previous keystore data. If you already have the **latest LUKSO CLI version** and **network configs**, you can also just update your [blockchain clients](./update-clients.md).
+Updating your node is similar to the installing process, while keeping your previous keystore data. If you already have the **latest LUKSO CLI version** and **network configs**, you can just [Update the Blockchain Clients](./update-clients.md).
 
 #### Stop your Node
 
@@ -90,7 +88,7 @@ sudo pkill teku
 </details>
 
 <Tabs>
-  <TabItem value="update-v6" label="Update from Version 0.6 or below">
+  <TabItem value="update-v07" label="Update from Version 0.7 or below">
 
 #### Create a new Working Directory
 
@@ -182,27 +180,7 @@ Keep your old working directory on your system until the new node setup fully sy
 :::
 
   </TabItem>
-  <TabItem value="update-v7" label="Update from Version 0.7">
-
-#### Remove outdated Blockchain Data
-
-If the processes have been stopped successfully, you can continue to remove the old network data.
-
-```bash
-# Remove Mainnet Data
-rm -rf mainnet-data
-
-# Remove Testnet Data
-rm -rf testnet-data
-```
-
-#### Backup outdated Configuration
-
-Next, you can rename your configuration folder to reload the latest network files later on.
-
-```bash
-mv configs/ configs-backup
-```
+  <TabItem value="update-v08" label="Update from Version 0.8 or above">
 
 #### Update the LUKSO CLI
 
@@ -218,63 +196,16 @@ Make sure to check the downloaded version again to ensure that the update was su
 lukso version
 ```
 
-#### Re-initialize the Working Directory
+Then continue to download the latest network configurations.
 
-Next, you can re-download the latest network configurations and genesis files.
+:::info
+
+The `lukso init` command will not overwrite any personal configurations.
+
+:::
 
 ```bash
 lukso init
-```
-
-#### Install the Latest Clients
-
-After updating the LUKSO CLI, we must install the updated blockchain clients.
-
-```bash
-lukso install
-```
-
-#### Apply Configurations
-
-In case you did any modifications to your configuration files, such as:
-
-- configuring a Dynamic DNS
-- connecting the blockchain explorer page
-- adding a node name or graffiti
-- adjusting your peer count
-
-Please add them once again and make sure that these are in the correct format before starting your node.
-
-You can follow the [extended node guide](https://github.com/fhildeb/lukso-node-guide/blob/main/6-blockchain-clients/README.md) or list of [further reads](../mainnet/running-a-node.md#further-reads) for more information.
-
-:::caution
-
-Wait 10 minutes after stopping your node so the network does not accuse you of slashing while using updated configurations.
-
-:::
-
-:::danger Backup
-
-Keep your old working directory on your system until the new node setup fully synchronizes within the next step. It will reference your previous configuration in case something goes wrong.
-
-:::
-
-  </TabItem>
-
-<TabItem value="update-v8-or-above" label="Update from Version 0.8 or above">
-
-#### Update the LUKSO CLI
-
-Re-install the LUKSO CLI to your system. You will be asked to overwrite the current version.
-
-```bash
-curl https://install.lukso.network | sh
-```
-
-Make sure to check the downloaded version again to ensure that the update was successful.
-
-```bash
-lukso version
 ```
 
   </TabItem>
@@ -284,45 +215,13 @@ lukso version
 
 You can start your node as regular. If you run a validator, please adjust your flags or the recipient address.
 
-Start up your node using checkpoint synchronization to reduce your downtime while synchronizing with the network significantly. Fast synchronization speeds are essential if you run a validator node to avoid losing stake.
-
-Your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running. After the synchronization is finalized, you will end up with the equal blockchain data.
-
-> You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime.
-
-<Tabs>
-<TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
-
 :::info
 
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
 
-:::info
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version or run into issues, please pass down the checkpoint flag manually, as described in the [LUKSO CLI Checkpoint Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
-```sh
-# Starting the Mainnet Node
-lukso start --checkpoint-sync
-
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
-```
-
-  </TabItem>
-  <TabItem value="regular-sync" label="Regular Synchronization">
-
-:::caution
-
-The normal synchronization process will take multiple hours for the node to finalize. It is not recommended if you are running a validator.
-
-:::
-
-:::info
+:::note
 
 If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
 
@@ -335,6 +234,3 @@ lukso start
 # Starting the Mainnet Validator
 lukso start --validator --transaction-fee-recipient "0x1234"
 ```
-
-  </TabItem>  
-</Tabs>

--- a/docs/networks/advanced-guides/update-the-node.md
+++ b/docs/networks/advanced-guides/update-the-node.md
@@ -88,7 +88,36 @@ sudo pkill teku
 </details>
 
 <Tabs>
-  <TabItem value="update-v07" label="Update from Version 0.7 or below">
+  <TabItem value="update-v08" label="Update from Version 0.8 or above">
+
+#### Update the LUKSO CLI
+
+Re-install the LUKSO CLI to your system. You will be asked to overwrite the current version.
+
+```bash
+curl https://install.lukso.network | sh
+```
+
+Make sure to check the downloaded version again to ensure that the update was successful.
+
+```bash
+lukso version
+```
+
+Then continue to download the latest network configurations.
+
+:::info
+
+The `lukso init` command will not overwrite any personal configurations.
+
+:::
+
+```bash
+lukso init
+```
+
+  </TabItem>
+    <TabItem value="update-v07" label="Update from Version 0.7 or below">
 
 #### Create a new Working Directory
 
@@ -178,35 +207,6 @@ Wait 10 minutes after stopping your node so the network does not accuse you of s
 Keep your old working directory on your system until the new node setup fully synchronizes within the next step. It will reference your previous configuration in case something goes wrong.
 
 :::
-
-  </TabItem>
-  <TabItem value="update-v08" label="Update from Version 0.8 or above">
-
-#### Update the LUKSO CLI
-
-Re-install the LUKSO CLI to your system. You will be asked to overwrite the current version.
-
-```bash
-curl https://install.lukso.network | sh
-```
-
-Make sure to check the downloaded version again to ensure that the update was successful.
-
-```bash
-lukso version
-```
-
-Then continue to download the latest network configurations.
-
-:::info
-
-The `lukso init` command will not overwrite any personal configurations.
-
-:::
-
-```bash
-lukso init
-```
 
   </TabItem>
 </Tabs>

--- a/docs/networks/advanced-guides/update-the-node.md
+++ b/docs/networks/advanced-guides/update-the-node.md
@@ -213,24 +213,10 @@ Keep your old working directory on your system until the new node setup fully sy
 
 #### Restart your Node
 
-You can start your node as regular. If you run a validator, please adjust your flags or the recipient address.
+You can [start your node as regular](../mainnet/running-a-node.md#start-the-clients).
 
 :::info
 
 If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
-
-:::note
-
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
-
-:::
-
-```bash
-# Starting the Mainnet Node
-lukso start
-
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234"
-```

--- a/docs/networks/mainnet/become-a-validator.md
+++ b/docs/networks/mainnet/become-a-validator.md
@@ -3,9 +3,6 @@ title: Become a Validator
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Become a validator
 
 ![Deposit Launchpad](/img/network/mainnet-launchpad.png)
@@ -18,27 +15,27 @@ As a validator, you need to import your validator deposit key files (`keystore-x
 
 :::
 
-## Starting a validator
+## Node Setup
 
 Similar to running a regular node, you have multiple options to start your validator. Please refer to the regular [Node Guide](./running-a-node.md) that explains the differences between those setups and how to get the correct network configurations.
 
 ### 📦 With Dappnode
 
-The [Dappnode tutorial](https://docs.dappnode.io/docs/user/staking/lukso/solo#2-creating-validator-keys-for-lukso) explains the process.
+The [Dappnode Tutorial](https://docs.dappnode.io/docs/user/staking/lukso/solo#2-creating-validator-keys-for-lukso) explains the process.
 
 ### 📟 With LUKSO CLI
 
 Set up your regular node using the LUKSO CLI as described in the [Node Guide](./running-a-node.md).
 
-#### Importing Validator Keys
+#### Import the Validator Keys
 
 :::tip
 
-The name of the directory `myLUKSOnode/` in the example below can be changed according to your preferences.4
+The name of the directory `myLUKSOnode` in the example below can be changed according to your preferences.
 
 :::
 
-If it is set up correctly and all clients are working, you can continue importing your validator keys into the validator wallet. You will be asked to set a new wallet password to store the imported deposit keys safely. Further, you will have to input your password for the deposit keys you want to import so that they can be encrypted and added to the wallet. The new keystore files will be stored under the `./myLUKSOnode/mainnet-keystore` directory.
+If the node is set up correctly and all clients are running fine, you can continue importing your validator keys into the validator wallet. You will be asked to set a new wallet password to store the imported deposit keys safely. Further, you will have to input your password for the deposit keys you want to import so that they can be encrypted and added to the wallet. The new keystore files will be stored under the `./myLUKSOnode/mainnet-keystore` directory.
 
 ```bash
 lukso validator import --validator-keys "./path/to/your/keys/folder"
@@ -56,70 +53,30 @@ If the imported deposit keys match the ones in the original folder, you can dele
 
 #### Starting the Validator
 
-After importing your keys, you can start the node with the validator functionality. If the node is already synced and running, the `lukso start` command will restart all clients automatically.
+After importing your keys, you can start the node with the validator functionality. If the node is already synchronized and running, the `lukso start` command will restart all clients automatically.
 
 To start the validator, you have to pass a minimum of 2 flags:
 
 - `--validator`: Will start the installed and configured clients, including the validator
 - `--transaction-fee-recipient`: Specifies your transaction fee recipient address, which will receive all block rewards and tips from transactions. The address can be any EOA address you have control over on a wallet like MetaMask, Ledger, or any other wallet with the functionality to connect with LUKSO or custom networks.
 
-> If you want to set custom flags to the start command, like the graffiti or a custom stat page connection, make sure to add them. You can find more information about passing options to the client on the official [LUKSO CLI Documentation](https://github.com/lukso-network/tools-lukso-cli).
-
-:::note
-
-The recipient fee address can also be different than the withdrawal credential you added to your validator key when you generated them. The withdrawal address is used to withdraw rewards and staked amounts connected to the consensus mechanism after the [Shapella](https://ethereum.org/en/history/) upgrade is implemented on the LUKSO blockchain. The feature is planned some months after the network launch.
-
-:::
-
-As only genesis validators can run the validator on a node, you must select your chosen initial supply for the LUKSO mainnet. More information can be found in the official [Mainnet Timeline](https://medium.com/lukso/lukso-mainnet-timeline-and-process-dd997fe811c8) article.
-
-Without specifying any flags, the node starts its normal synchronization process.
-
-If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running.
-
-> After the synchronization is finalized, you will end up with the equal blockchain data. You can use the flag on every startup. However, it shows the most significant effect when synchronizing from scratch or after an extended downtime. The shortcut is ideal for fresh installations, validator migration, or recovery.
-
-<Tabs>
-  <TabItem value="regular-sync" label="Regular Synchronization">
+> If you want to set custom flags to the start command, like the graffiti or a custom stat page connection, you can find more information in the official [LUKSO CLI Documentation](https://github.com/lukso-network/tools-lukso-cli).
 
 :::info
 
-The synchronization process will take multiple hours for the validator to participate in the consensus.
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add checkpoint synchronization](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
+
+:::
+
+:::note
+
+The recipient fee address can also be different than the withdrawal credential you added to your validator key when you generated them. The withdrawal address is used to withdraw rewards and staked amounts connected to the consensus mechanism.
 
 :::
 
 ```bash
 lukso start --validator --transaction-fee-recipient "0x1234..."
 ```
-
-  </TabItem>
-    <TabItem value="checkpoint-sync" label="Checkpoint Synchronization">
-
-:::tip
-
-The shortcut is ideal for making installation, validator migration, or recovery much faster.
-
-:::
-
-:::info
-
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
-
-:::
-
-:::info
-
-You will need the LUKSO CLI Version 0.8.0 or above in order to use the `--checkpoint-sync` command. If you are using an older version or run into issues, please pass down the checkpoint flag manually, as described in the [LUKSO CLI Checkpoint Documentation](https://github.com/lukso-network/tools-lukso-cli/tree/main#using-checkpoint-syncing).
-
-:::
-
-```sh
-# Starting the Mainnet Validator
-lukso start --validator --transaction-fee-recipient "0x1234" --checkpoint-sync
-```
-
-  </TabItem>
-</Tabs>
 
 #### Checking Validator Logs
 

--- a/docs/networks/mainnet/parameters.md
+++ b/docs/networks/mainnet/parameters.md
@@ -7,12 +7,6 @@ import AddNetworkButton from '../../../src/components/AddNetworkButton'
 
 # Network Parameters
 
-:::info
-
-The Mainnet of LUKSO started on Tuesday, 23rd May 2023 15:40:00 GMT (+ Genesis Delay -> 4:20pm GMT).
-
-:::
-
 | Setting                  | Value                                                                                                |
 | ------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Network Name             | Mainnet                                                                                              |

--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -64,7 +64,7 @@ curl https://install.lukso.network | sh
 
 :::tip
 
-The name of the directory `myLUKSOnode/` in the commands below can be changed according to your preferences.
+The name of the directory `myLUKSOnode` in the commands below can be changed according to your preferences.
 
 :::
 
@@ -98,7 +98,7 @@ lukso install
 
 The following command will spin up your execution and consensus client and connect to the mainnet.
 
-Without specifying any flags, the node starts its normal synchronization process.
+Without specifying any flags, the node starts the regular synchronization process.
 
 If you want more convenience and your validator to operate quickly, you can also use checkpoints. Checkpoint synchronization is a feature that significantly speeds up the initial sync time of the consensus client. If enabled, your node will begin syncing from a recently finalized consensus checkpoint instead of genesis. It will then download the rest of the blockchain data while your consensus is already running.
 
@@ -126,7 +126,7 @@ lukso start --checkpoint-sync
   </TabItem>
   <TabItem value="regular-sync" label="Regular Synchronization">
 
-:::info
+:::caution Sync Delay
 
 The synchronization process will take multiple hours for the node to finalize.
 
@@ -138,12 +138,6 @@ lukso start
 
   </TabItem>  
 </Tabs>
-
-:::info
-
-If you are setting up a node for the testnet, add the `--testnet` flag to the start command.
-
-:::
 
 #### Checking Processes
 

--- a/docs/networks/testnet/become-a-validator.md
+++ b/docs/networks/testnet/become-a-validator.md
@@ -11,7 +11,7 @@ If you want to become a whitelisted validator on our testnet, prepare your valid
 
 ![Testnet Launchpad](/img/network/testnet-launchpad.png)
 
-After you become whitelisted, visit the official [Testnet Deposit Launchpad](https://deposit.testnet.lukso.network/) and cautiously generate the specified number of keys you are allowed. Then continue depositing your LYXt to them.
+After you became whitelisted, visit the official [Testnet Deposit Launchpad](https://deposit.testnet.lukso.network/) and cautiously generate the specified number of keys you are allowed. Then continue depositing your LYXt to them.
 
 :::caution Validators
 
@@ -33,7 +33,7 @@ Please refer to the regular [Node Guide](./running-a-node.md) that explains the 
 
 Set up your regular node using the LUKSO CLI as described in the [Node Guide](./running-a-node.md).
 
-The instructions are the same as for mainnet nodes. Please refer to [Mainnet Validator Guide](../mainnet/become-a-validator.md#using-lukso-cli). You will simply have to add the `--testnet` flag to each commands. The commands will look like this:
+The instructions are the same as for mainnet nodes. Please refer to the [Mainnet Validator Setup Guide](../mainnet/become-a-validator.md#using-lukso-cli). You will simply have to add the `--testnet` flag to each command.
 
 #### Importing Validator Keys
 
@@ -45,13 +45,9 @@ lukso validator list --testnet
 
 #### Starting the Validator
 
-Without specifying any flags, the node starts its normal synchronization process.
-
-If you want more convenience and your validator to operate quickly, you can also use checkpoints. The instructions are the same as for mainnet nodes. Please refer to the [Mainnet Validator Guide](../mainnet/become-a-validator.md).
-
 :::info
 
-Without using checkpoints, the synchronization process will take multiple hours for the validator to participate in the consensus.
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add the checkpoint synchronization flag](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
 
 :::
 

--- a/docs/networks/testnet/running-a-node.md
+++ b/docs/networks/testnet/running-a-node.md
@@ -21,6 +21,12 @@ Difficulty: Medium 🌶️🌶️
 
 For the main information, please refer to the [mainnet version](../mainnet/running-a-node.md#-with-the-lukso-cli) of this article. The only difference to run a testnet node with the CLI is to append the `--testnet` flag to the commands:
 
+:::info
+
+If you are starting your node in a fresh working directory or after being offline for a while, make sure to [add the checkpoint synchronization flag](../mainnet/running-a-node.md#start-the-clients) to significantly speed up the synchronization during the startup.
+
+:::
+
 ```sh
 lukso start --testnet
 ```


### PR DESCRIPTION
This PR:

### Removed
- Removes duplicated content regarding `--checkpoint-sync` flag
- Removes outdated mainnet paragraph

### Features
- Unifies update guides for v0.6 and 0.7 into one section
- Minor guide sections updates
