### PR TITLE
Add Blockscout APIs for networks

### DIFF
--- a/docs/networks/mainnet/parameters.md
+++ b/docs/networks/mainnet/parameters.md
@@ -7,18 +7,19 @@ import AddNetworkButton from '../../../src/components/AddNetworkButton'
 
 # Network Parameters
 
-| Setting                  | Value                                                                                                |
-| ------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Network Name             | Mainnet                                                                                              |
-| Genesis Fork Version     | 0x42000001                                                                                           |
-| Chain ID / Network ID    | 42                                                                                                   |
-| Currency Symbol          | LYX                                                                                                  |
-| Execution Block Explorer | [https://explorer.execution.mainnet.lukso.network](https://explorer.execution.mainnet.lukso.network) |
-| Execution Status Page    | [https://stats.execution.mainnet.lukso.network](https://stats.execution.mainnet.lukso.network)       |
-| Consensus Block Explorer | [https://explorer.consensus.mainnet.lukso.network](https://explorer.consensus.mainnet.lukso.network) |
-| Consensus Status Page    | [https://stats.consensus.mainnet.lukso.network](https://stats.consensus.mainnet.lukso.network)       |
-| Launchpad                | [https://deposit.mainnet.lukso.network](https://deposit.mainnet.lukso.network)                       |
-| Checkpoints              | [https://checkpoints.mainnet.lukso.network](https://checkpoints.mainnet.lukso.network)               |
+| Setting                  | Value                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Network Name             | Mainnet                                                                                                      |
+| Genesis Fork Version     | 0x42000001                                                                                                   |
+| Chain ID / Network ID    | 42                                                                                                           |
+| Currency Symbol          | LYX                                                                                                          |
+| Execution Block Explorer | [https://explorer.execution.mainnet.lukso.network](https://explorer.execution.mainnet.lukso.network)         |
+| Blockscout API           | [https://explorer.execution.mainnet.lukso.network/api](https://explorer.execution.mainnet.lukso.network/api) |
+| Execution Status Page    | [https://stats.execution.mainnet.lukso.network](https://stats.execution.mainnet.lukso.network)               |
+| Consensus Block Explorer | [https://explorer.consensus.mainnet.lukso.network](https://explorer.consensus.mainnet.lukso.network)         |
+| Consensus Status Page    | [https://stats.consensus.mainnet.lukso.network](https://stats.consensus.mainnet.lukso.network)               |
+| Launchpad                | [https://deposit.mainnet.lukso.network](https://deposit.mainnet.lukso.network)                               |
+| Checkpoints              | [https://checkpoints.mainnet.lukso.network](https://checkpoints.mainnet.lukso.network)                       |
 
 The mainnet network configs are defined or the [`lukso-network/network-configs`](https://github.com/lukso-network/network-configs/tree/main/mainnet/shared) repo.
 

--- a/docs/networks/testnet/parameters.md
+++ b/docs/networks/testnet/parameters.md
@@ -9,21 +9,22 @@ The Public Testnet runs alongside the LUKSO mainnet for developers to test dApps
 
 ## Network Parameters
 
-| Setting                  | Value                                                                                                |
-| ------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Network Name             | Testnet                                                                                              |
-| Fork Version             | 0x42010001                                                                                           |
-| Chain ID / Network ID    | 4201                                                                                                 |
-| Currency Symbol          | LYXt                                                                                                 |
-| RPC URL                  | [https://rpc.testnet.lukso.network](https://rpc.testnet.lukso.network)                               |
-| Websocket RPC URL        | [wss://ws-rpc.testnet.lukso.network](wss://ws-rpc.testnet.lukso.network)                             |
-| Execution Block Explorer | [https://explorer.execution.testnet.lukso.network](https://explorer.execution.testnet.lukso.network) |
-| Execution Status Page    | [https://stats.execution.testnet.lukso.network](https://stats.execution.testnet.lukso.network)       |
-| Consensus Block Explorer | [https://explorer.consensus.testnet.lukso.network](https://explorer.consensus.testnet.lukso.network) |
-| Consensus Status Page    | [https://stats.consensus.testnet.lukso.network](https://stats.consensus.testnet.lukso.network)       |
-| Faucet                   | [https://faucet.testnet.lukso.network](https://faucet.testnet.lukso.network)                         |
-| Launchpad                | [https://deposit.testnet.lukso.network](https://deposit.testnet.lukso.network)                       |
-| Checkpoints              | [https://checkpoints.testnet.lukso.network](https://checkpoints.testnet.lukso.network)               |
+| Setting                  | Value                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Network Name             | Testnet                                                                                                      |
+| Fork Version             | 0x42010001                                                                                                   |
+| Chain ID / Network ID    | 4201                                                                                                         |
+| Currency Symbol          | LYXt                                                                                                         |
+| RPC URL                  | [https://rpc.testnet.lukso.network](https://rpc.testnet.lukso.network)                                       |
+| Websocket RPC URL        | [wss://ws-rpc.testnet.lukso.network](wss://ws-rpc.testnet.lukso.network)                                     |
+| Execution Block Explorer | [https://explorer.execution.testnet.lukso.network](https://explorer.execution.testnet.lukso.network)         |
+| Blockscout API           | [https://explorer.execution.testnet.lukso.network/api](https://explorer.execution.testnet.lukso.network/api) |
+| Execution Status Page    | [https://stats.execution.testnet.lukso.network](https://stats.execution.testnet.lukso.network)               |
+| Consensus Block Explorer | [https://explorer.consensus.testnet.lukso.network](https://explorer.consensus.testnet.lukso.network)         |
+| Consensus Status Page    | [https://stats.consensus.testnet.lukso.network](https://stats.consensus.testnet.lukso.network)               |
+| Faucet                   | [https://faucet.testnet.lukso.network](https://faucet.testnet.lukso.network)                                 |
+| Launchpad                | [https://deposit.testnet.lukso.network](https://deposit.testnet.lukso.network)                               |
+| Checkpoints              | [https://checkpoints.testnet.lukso.network](https://checkpoints.testnet.lukso.network)                       |
 
 The testnet network configs are defined or the [`lukso-network/network-configs`](https://github.com/lukso-network/network-configs/tree/main/testnet/shared) repo.
 


### PR DESCRIPTION
This PR adds the Blockscout APIs to the network parameters. 

These links are already publically available within the `lsp-smart-contracts` repository.

### Why?
- Useful for all SC devs to verify contracts (Hardhat or Foundry )

Closes #733 