### PR TITLE
Remove assertions from guides

### DIFF
--- a/docs/learn/dapp-developer/mint-lsp7-token.md
+++ b/docs/learn/dapp-developer/mint-lsp7-token.md
@@ -26,7 +26,7 @@ npm install ethers @lukso/lsp-smart-contracts
 At this point, the `LPS7Mintable` contract is being prepared for the following interaction. You construct an instance of a contract, using its _ABI_ and the _contract address_.
 
 ```javascript
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json' assert { type: 'json' };
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
 import { ethers } from 'ethers';
 
 const privateKey = '0x...';
@@ -68,7 +68,7 @@ let mintTxn = await myToken.mint(signer.address, 1, true, '0x', {
 
 ```javascript
 import { ethers } from 'hardhat';
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json' assert { type: 'json' };
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
 
 const privateKey = '0x..';
 const myTokenAddress = '0x..';

--- a/docs/learn/dapp-developer/read-profile-data.md
+++ b/docs/learn/dapp-developer/read-profile-data.md
@@ -74,7 +74,7 @@ The [`getData()`](../../tools/erc725js/classes/ERC725.md#getdata) function allow
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json' assert { type: 'json' };
+import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(lsp3ProfileSchema, '<myProfileAddress>', 'https://rpc.testnet.lukso.gateway.fm',
   {
@@ -96,7 +96,7 @@ console.log(profileData);
 
 ```js
 import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
-import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json' assert { type: 'json' };
+import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(lsp3ProfileSchema as ERC725JSONSchema[], '<myProfileAddress>', 'https://rpc.testnet.lukso.gateway.fm',
   {

--- a/docs/learn/dapp-developer/siwe.md
+++ b/docs/learn/dapp-developer/siwe.md
@@ -53,7 +53,7 @@ If you need further explanation on the `SiweMessage` properties, please have a l
 
 <!-- prettier-ignore-start -->
 ```js
-import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { SiweMessage } from 'siwe';
 
 const myUniversalProfileContract = new web3.eth.Contract(

--- a/docs/learn/dapp-developer/standard-detection.md
+++ b/docs/learn/dapp-developer/standard-detection.md
@@ -43,7 +43,7 @@ Similar to the [Read Profile Data Guide](./read-profile-data.md), you can use th
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json' assert { type: 'json' };
+import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(lsp3ProfileSchema, '<myProfileAddress>', 'https://rpc.testnet.lukso.gateway.fm',
   {
@@ -65,7 +65,7 @@ console.log(isLSP3);
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import lsp9VaultSchema from '@erc725/erc725.js/schemas/LSP9Vault.json' assert { type: 'json' };
+import lsp9VaultSchema from '@erc725/erc725.js/schemas/LSP9Vault.json';
 
 const erc725js = new ERC725(
   lsp9VaultSchema,
@@ -90,7 +90,7 @@ console.log(isLSP9);
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json' assert { type: 'json' };
+import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 
 const erc725js = new ERC725(
   lsp3ProfileSchema,
@@ -133,7 +133,7 @@ A **[Universal Profile](../../standards/universal-profile/lsp3-profile-metadata.
 <!--prettier-ignore-start-->
 
 ```javascript
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { INTERFACE_IDS } from '@lukso/lsp-smart-contracts/dist/constants.cjs.js';
 import Web3 from 'web3';
 

--- a/docs/learn/dapp-developer/transfer-lsp7-token.md
+++ b/docs/learn/dapp-developer/transfer-lsp7-token.md
@@ -52,7 +52,7 @@ As the initial step, you have to set up the Universal Profile and LSP7 Token. Bo
 import Web3 from 'web3';
 
 // Import schemas and ABI
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json' assert { type: 'json' };
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
 
 const web3 = new Web3(window.ethereum);
 
@@ -84,7 +84,7 @@ await myToken.methods
 import { ethers } from 'ethers';
 
 // Import schemas and ABI
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json' assert { type: 'json' };
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
 
 await provider.send("eth_requestAccounts", []);
 

--- a/docs/learn/expert-guides/accept-reject-assets.md
+++ b/docs/learn/expert-guides/accept-reject-assets.md
@@ -139,7 +139,7 @@ Then we will initialize the controller address.
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports, Constants & EOA"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import Web3 from 'web3';
 
@@ -159,7 +159,7 @@ const EOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports, Constants & EOA"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { ethers } from 'ethers';
 
@@ -252,7 +252,7 @@ await universalProfile
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Update the Universal Profile URD"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import Web3 from 'web3';
 
@@ -286,7 +286,7 @@ await universalProfile.methods
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Update the Universal Profile URD"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { ethers } from 'ethers';
 

--- a/docs/learn/expert-guides/interact-with-contracts.md
+++ b/docs/learn/expert-guides/interact-with-contracts.md
@@ -98,8 +98,8 @@ You can quickly compile and get a contract's ABI in [Remix IDE](https://remix.et
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import TargetContractABI from './TargetContractABI.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -122,8 +122,8 @@ const targetContract = new web3.eth.Contract(
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import TargetContractABI from './TargetContractABI.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -258,8 +258,8 @@ await universalProfile
 <!-- prettier-ignore-start -->
 
 ```typescript title="Final code"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import TargetContractABI from './TargetContractABI.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -301,8 +301,8 @@ await universalProfile.methods
 
 
 ```typescript title="Final code"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import TargetContractABI from './TargetContractABI.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(

--- a/docs/learn/expert-guides/key-manager/execute-relay-transactions.md
+++ b/docs/learn/expert-guides/key-manager/execute-relay-transactions.md
@@ -67,8 +67,8 @@ To encode a transaction, we need the address of the Universal Profile smart cont
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
 import Web3 from 'web3';
 
@@ -89,8 +89,8 @@ const controllerAccount = web3.eth.accounts.wallet.add(controllerPrivateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { ethers } from 'ethers';
 
@@ -397,8 +397,8 @@ You can find more information about the [LSP6KeyManager `executeRelayCall` here]
   <TabItem value="web3js" label="web3.js">
 
 ```javascript title="Final code"
-import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
 import Web3 from 'web3';
 
@@ -483,8 +483,8 @@ const executeRelayCallTransaction = await keyManager.methods
   <TabItem value="ethersjs" label="ethers.js">
 
 ```javascript title="Final code"
-import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import KeyManagerContract from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
 import { ethers } from 'ethers';
 

--- a/docs/learn/expert-guides/key-manager/get-controller-permissions.md
+++ b/docs/learn/expert-guides/key-manager/get-controller-permissions.md
@@ -32,7 +32,7 @@ The first step is to set up both and _web3.js_ and _erc725.js_, and connect to t
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json' assert { type: 'json' };
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import Web3 from 'web3';
 
 // setup
@@ -145,7 +145,7 @@ console.log(
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json' assert { type: 'json' };
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import Web3 from 'web3';
 
 // setup

--- a/docs/learn/expert-guides/key-manager/grant-permissions.md
+++ b/docs/learn/expert-guides/key-manager/grant-permissions.md
@@ -70,7 +70,7 @@ The first step is to initialize the erc725.js library with a JSON schema specifi
 
 ```js
 import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json' assert { type: 'json' };
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 
 // step 1 -initialize erc725.js with the ERC725Y permissions data keys from LSP6 Key Manager
 const erc725 = new ERC725(
@@ -151,7 +151,7 @@ To get started you would need the following:
   <TabItem value="web3js" label="web3.js">
 
 ```javascript title="Load account from a private key"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -166,7 +166,7 @@ const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 <!-- prettier-ignore-start -->
 
 ```javascript title="Load account from a private key"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
@@ -321,9 +321,9 @@ You can then try to do again the **Edit our Universal Profile** guide, using thi
 <!-- prettier-ignore-start -->
 
 ```js
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json' assert { type: 'json' };
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -398,9 +398,9 @@ grantPermissions();
   <TabItem value="ethersjs" label="ethers.js">
 
 ```js
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json' assert { type: 'json' };
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 import Web3 from 'web3';
 

--- a/docs/learn/expert-guides/key-manager/upgrade-key-manager.md
+++ b/docs/learn/expert-guides/key-manager/upgrade-key-manager.md
@@ -67,8 +67,8 @@ Create a JavaScript file and add the following imports on the top of the file:
   <TabItem value="web3js" label="web3.js">
 
 ```js title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -82,8 +82,8 @@ const universalProfileAddress = '0x...';
   <TabItem value="ethersjs" label="ethers.js">
 
 ```js title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -272,8 +272,8 @@ The upgrade has been completed successfully.
 <!-- prettier-ignore-start -->
 
 ```javascript title="upgrade-lsp6.js"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
 const web3 = new Web3('https://rpc.testnet.lukso.network');
 
@@ -327,8 +327,8 @@ await upgradeLSP6();
 <!-- prettier-ignore-start -->
 
 ```js title="upgrade-lsp6.js"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider('https://rpc.testnet.lukso.network');
@@ -381,8 +381,8 @@ node test-new-lsp6.js
 <!-- prettier-ignore-start -->
 
 ```javascript title="test-new-lsp6.js"
-import LSP0ERC725YAccount from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725YAccount.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
+import LSP0ERC725YAccount from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725YAccount.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');

--- a/docs/learn/expert-guides/read-asset-data.md
+++ b/docs/learn/expert-guides/read-asset-data.md
@@ -66,7 +66,7 @@ If using erc725.js in a NodeJS environment you may need to install and import [`
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json' assert { type: 'json' };
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
 import Web3 from 'web3';
 
 // Static variables
@@ -106,7 +106,7 @@ If using erc725.js in a NodeJS environment you may need to install and import [`
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json' assert { type: 'json' };
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
 import Web3 from 'web3';
 
 // Static variables
@@ -157,7 +157,7 @@ Using the Universal Receiver address, we can now call the `getAllRawValues()` fu
 
 ```javascript title="read_assets.js"
 // ABI for the Universal Receiver
-import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json' assert { type: 'json' };
+import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json';
 
 // ...
 
@@ -198,7 +198,7 @@ In this guide, we will use the `LSP4Metadata` key to read the asset metadata.
 
 ```javascript title="read_assets.js"
 // ABIs
-import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json' assert { type: 'json' };
+import LSP4schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 
 // ...
 
@@ -230,8 +230,8 @@ Below is the complete code snippet of this guide, with all the steps compiled to
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json' assert { type: 'json' };
-import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json' assert { type: 'json' };
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import Web3 from 'web3';
 
 // Static variables
@@ -295,10 +295,10 @@ console.log(ownedAssetsMetadata);
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json' assert { type: 'json' };
-import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json' assert { type: 'json' };
+import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import Web3 from 'web3';
-import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json' assert { type: 'json' };
+import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json';
 
 // Static variables
 const SAMPLE_PROFILE_ADDRESS = '0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e';

--- a/docs/learn/expert-guides/universal-profile/edit-profile.md
+++ b/docs/learn/expert-guides/universal-profile/edit-profile.md
@@ -195,7 +195,7 @@ Our [lsp-factory.js](../../../tools/lsp-factoryjs/getting-started.md) tool provi
 ```javascript title="main.js"
 import { LSPFactory } from '@lukso/lsp-factory.js';
 // reference to the previously created JSON file (LSP3Profile metadata)
-import jsonFile from './UniversalProfileMetadata.json' assert { type: 'json' };
+import jsonFile from './UniversalProfileMetadata.json';
 
 const provider = 'https://rpc.testnet.lukso.network'; // RPC provider url
 
@@ -315,7 +315,7 @@ The first step is to create an instance of the Universal Profile smart contract.
 
 ```javascript title="Create contracts instances and get the Key Manager address"
 import Web3 from 'web3';
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
 
@@ -390,9 +390,9 @@ import Web3 from 'web3';
 import { ERC725 } from '@erc725/erc725.js';
 import { LSPFactory } from '@lukso/lsp-factory.js';
 
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 
-import jsonFile from './UniversalProfileMetadata.json' assert { type: 'json' };
+import jsonFile from './UniversalProfileMetadata.json';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
 

--- a/docs/learn/expert-guides/universal-receiver/deploy-universal-receiver.md
+++ b/docs/learn/expert-guides/universal-receiver/deploy-universal-receiver.md
@@ -62,8 +62,8 @@ Then we will initialize the EOA that we will further use.
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports, Constants & EOA"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import {
   ERC725YDataKeys,
   PERMISSIONS,
@@ -85,8 +85,8 @@ const EOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports, Constants & EOA"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import {
   ERC725YDataKeys,
   PERMISSIONS,
@@ -546,8 +546,8 @@ await updateUniversalProfileURD(universalProfileURDAddress);
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import {
   ERC725YDataKeys,
   PERMISSIONS,
@@ -651,8 +651,8 @@ await updateUniversalProfileURD(universalProfileURDAddress);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import {
   ERC725YDataKeys,
   PERMISSIONS,

--- a/docs/learn/expert-guides/vault/create-a-vault.md
+++ b/docs/learn/expert-guides/vault/create-a-vault.md
@@ -60,7 +60,7 @@ For the constants we will need the _private key_ and _the address of the vault r
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports & Constants"
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -76,7 +76,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports & Constants"
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -170,7 +170,7 @@ You need to have LYXt in your EOA in order to pay for the transaction fees. Visi
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Deploying the vault"
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -201,7 +201,7 @@ await myVault
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Deploying the vault"
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(

--- a/docs/learn/expert-guides/vault/edit-vault-data.md
+++ b/docs/learn/expert-guides/vault/edit-vault-data.md
@@ -54,9 +54,9 @@ Then we will initialize the EOA that we will further use.
   <TabItem value="web3js" label="web3.js">
 
 ```typescript
-import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import Web3 from 'web3';
 
@@ -74,9 +74,9 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript
-import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import { ethers } from 'ethers';
 
@@ -408,9 +408,9 @@ await updateVaultURD(vaultURDAddress);
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Deploy new Vault URD and update Vault's URD"
-import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import Web3 from 'web3';
 
@@ -486,9 +486,9 @@ await updateVaultURD(vaultURDAddress);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript
-import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json' assert { type: 'json' };
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import { ethers } from 'ethers';
 

--- a/docs/learn/expert-guides/vault/grant-vault-permissions.md
+++ b/docs/learn/expert-guides/vault/grant-vault-permissions.md
@@ -73,7 +73,7 @@ Finally, we will need a private key with the proper _permissions_, in our case [
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports, Constants & EOA initialization"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { encodeKey } from '@erc725/erc725.js/build/main/src/lib/utils.js';
 import Web3 from 'web3';
@@ -94,7 +94,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports, Constants & EOA initialization"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { encodeKey } from '@erc725/erc725.js/build/main/src/lib/utils.js';
 import { ethers } from 'ethers';
@@ -251,7 +251,7 @@ await universalProfile
 <!-- prettier-ignore-start -->
 
 ```typescript title="Setting Allowed Addresses for the 3rd party address"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { encodeKey } from '@erc725/erc725.js/build/main/src/lib/utils.js';
 import Web3 from 'web3';
@@ -307,7 +307,7 @@ await universalProfile.methods.setData(
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Setting Allowed Addresses for the 3rd party address"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
 import { encodeKey } from '@erc725/erc725.js/build/main/src/lib/utils.js';
 import { ethers } from 'ethers';

--- a/docs/learn/expert-guides/vault/interact-with-contracts.md
+++ b/docs/learn/expert-guides/vault/interact-with-contracts.md
@@ -85,9 +85,9 @@ You can quickly compile and get a contract's ABI in [**Remix IDO**](https://remi
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
+import TargetContractABI from './TargetContractABI.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -105,9 +105,9 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
+import TargetContractABI from './TargetContractABI.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.JsonRpcProvider(
@@ -288,9 +288,9 @@ await universalProfile
   <TabItem value="web3js" label="web3.js">
 
 ```typescript title="Interacting with other contracts through the vault"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
+import TargetContractABI from './TargetContractABI.json';
 import Web3 from 'web3';
 
 const web3 = new Web3('https://rpc.testnet.lukso.network');
@@ -339,9 +339,9 @@ await universalProfile.methods.execute(0, vaultAddress, 0, vaultCalldata).send({
   <TabItem value="ethersjs" label="ethers.js">
 
 ```typescript title="Interacting with other contracts through the vault"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
-import TargetContractABI from './TargetContractABI.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
+import TargetContractABI from './TargetContractABI.json';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(

--- a/docs/learn/smart-contract-developers/create-lsp7-token.md
+++ b/docs/learn/smart-contract-developers/create-lsp7-token.md
@@ -118,7 +118,7 @@ Create the script that will deploy the contract as your Universal Profile.
 import hre from 'hardhat';
 import { ethers } from 'hardhat';
 import * as dotenv from 'dotenv';
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json' assert { type: 'json' };
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json';
 
 // load env vars
 dotenv.config();

--- a/docs/tools/erc725js/schemas.md
+++ b/docs/tools/erc725js/schemas.md
@@ -41,8 +41,8 @@ LSP17ContractExtension.json
 You can import them from:
 
 ```js
-import LSP3 from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json' assert { type: 'json' };
-import LSP5 from '@erc725/erc725.js/schemas/LSP5ReceivedAssets.json' assert { type: 'json' };
+import LSP3 from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
+import LSP5 from '@erc725/erc725.js/schemas/LSP5ReceivedAssets.json';
 // ...
 
 // Later use them on instantiation

--- a/docs/tools/lsp-smart-contracts/contracts-abi.md
+++ b/docs/tools/lsp-smart-contracts/contracts-abi.md
@@ -9,9 +9,9 @@ You can import the [LUKSO smart contracts](../../contracts/introduction.md) ABIs
 <!-- prettier-ignore-start -->
 
 ```javascript
-import LSP0ERC725Account from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json' assert { type: 'json' };
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json' assert { type: 'json' };
-import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json' assert { type: 'json' };
+import LSP0ERC725Account from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
+import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
 // etc.
 
 const accountContract = new web3.contract(LSP0ERC725Account.abi, "<contract-address>")


### PR DESCRIPTION
Previously added for **old** guides with #752, the JSON assertions will now be removed from **all the** guides.

> Assertions depend on how the bundler/build handles the imports. They are needed for executing regular node files, as within `lukso-playground`, but are not necessary within Webpack, HardHat, or most dApps as they use pre-configured modules and imports.

> We should keep the guides minimal and LUKSO-specific.

Context: 
<https://discord.com/channels/359064931246538762/859060198409109514/1179736260965847180>
<https://discord.com/channels/359064931246538762/859060198409109514/1179164063255765082>