### PR TITLE
fix: replace old `LSP3UniversalProfile` with `LSP3Profile`

### DIFF
--- a/docs/learn/dapp-developer/read-profile-data.md
+++ b/docs/learn/dapp-developer/read-profile-data.md
@@ -54,7 +54,7 @@ npm install @erc725/erc725.js
 
 <div>
 
-- `SupportedStandards:LSP3Profile` Verifies that the ERC725Y contract contains [LSP3UniversalProfile](../../standards/universal-profile/lsp3-profile-metadata) data keys
+- `SupportedStandards:LSP3Profile` Verifies that the ERC725Y contract contains [LSP3Profile](../../standards/universal-profile/lsp3-profile-metadata#supportedstandardslsp3profile) data keys
 - `LSP3Profile` contains the JSON file with profile descriptions and images
 - `LSP12IssuedAssets[]` contains assets the profile issued
 - `LSP5ReceivedAssets[]` contains assets the profile received

--- a/docs/learn/expert-guides/read-asset-data.md
+++ b/docs/learn/expert-guides/read-asset-data.md
@@ -66,7 +66,7 @@ If using erc725.js in a NodeJS environment you may need to install and import [`
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 import Web3 from 'web3';
 
 // Static variables
@@ -80,7 +80,7 @@ const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Fetch the LSP5 data of the Universal Profile to get its owned assets
 const profile = new ERC725(
-  UniversalProfileSchema,
+  LSP3ProfileSchema,
   SAMPLE_PROFILE_ADDRESS,
   provider,
   config,
@@ -106,7 +106,7 @@ If using erc725.js in a NodeJS environment you may need to install and import [`
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 import Web3 from 'web3';
 
 // Static variables
@@ -120,7 +120,7 @@ const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Fetch the LSP1 data of the Universal Profile to get its Universal Receiver
 const profile = new ERC725(
-  UniversalProfileSchema,
+  LSP3ProfileSchema,
   SAMPLE_PROFILE_ADDRESS,
   provider,
   config,
@@ -230,7 +230,7 @@ Below is the complete code snippet of this guide, with all the steps compiled to
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import Web3 from 'web3';
 
@@ -245,7 +245,7 @@ const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Fetch the LSP5 data of the Universal Profile to get its owned assets
 const profile = new ERC725(
-  UniversalProfileSchema,
+  LSP3ProfileSchema,
   SAMPLE_PROFILE_ADDRESS,
   provider,
   config,
@@ -295,7 +295,7 @@ console.log(ownedAssetsMetadata);
 ```javascript title="read_assets.js"
 // Import and network setup
 import { ERC725 } from '@erc725/erc725.js';
-import UniversalProfileSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import Web3 from 'web3';
 import LSP1MinimalABI from './lsp1_legacy_minimal_abi.json';
@@ -311,7 +311,7 @@ const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Fetch the LSP1 data of the Universal Profile to get its Universal Receiver
 const profile = new ERC725(
-  UniversalProfileSchema,
+  LSP3ProfileSchema,
   SAMPLE_PROFILE_ADDRESS,
   provider,
   config,

--- a/docs/standards/generic-standards/lsp2-json-schema.md
+++ b/docs/standards/generic-standards/lsp2-json-schema.md
@@ -137,7 +137,7 @@ The data being mapped can be words that have a specific meaning for the protocol
 
 Below are some examples of the **Mapping** key type.
 
-- mapping to **words:** `SupportedStandards:LSP3UniversalProfile`, `SupportedStandards:LSP4DigitalAsset`, `SupportedStandards:LSP{N}{StandardName}`, etc...
+- mapping to **words:** `SupportedStandards:LSP3Profile`, `SupportedStandards:LSP4DigitalAsset`, `SupportedStandards:LSP{N}{StandardName}`, etc...
 - mapping to **`<mixed type>`**, like an `address`: `LSP5ReceivedAssetsMap:<address>`
 - mapping to **`<mixed type>`**, like a `bytes32`: `LSP8MetadataAddress:<bytes32>`
 
@@ -145,8 +145,8 @@ Below are some examples of the **Mapping** key type.
 
 ```json
 {
-  "name": "SupportedStandards:LSP3UniversalProfile",
-  "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
+  "name": "SupportedStandards:LSP3Profile",
+  "key": "0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347",
   "keyType": "Mapping",
   "valueType": "bytes4",
   "valueContent": "0xabe425d6"

--- a/docs/standards/universal-profile/lsp3-profile-metadata.md
+++ b/docs/standards/universal-profile/lsp3-profile-metadata.md
@@ -28,19 +28,19 @@ Make sure to understand the **[ERC725Y Generic Key/Value Store](../lsp-backgroun
 
 :::
 
-### `SupportedStandards:LSP3UniversalProfile`
+### `SupportedStandards:LSP3Profile`
 
 ```json
 {
-  "name": "SupportedStandards:LSP3UniversalProfile",
-  "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
+  "name": "SupportedStandards:LSP3Profile",
+  "key": "0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347",
   "keyType": "Mapping",
   "valueType": "bytes4",
-  "valueContent": "0xabe425d6"
+  "valueContent": "0x5ef83ad9"
 }
 ```
 
-This data key is used to know if the contract represents a **Universal Profile**.
+This data key is used to know if the contract contains some metadata to display as a profile.
 
 ### `LSP3Profile`
 


### PR DESCRIPTION
Our docs, LSP3 standard page and guides contain old references to `SupportedStandards:LSP3UniversalProfile` :x:, including outdated imports to _erc725.js_

Replace these references with new `SupportedStandards:LSP3Profile` :white_checkmark: