### PR TITLE
Fix image links / zoom

### DIFF
--- a/docs/tools/getting-started.md
+++ b/docs/tools/getting-started.md
@@ -14,22 +14,22 @@ sidebar_position: 1
   </tr>
   <tr>
     <td><a href="./lsp-smart-contracts/getting-started">lsp-smart-contracts</a></td>
-    <td style={{textAlign: 'center'}}><a href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"/></a></td>
     <td><a href="https://github.com/lukso-network/lsp-smart-contracts">lukso-network/lsp-smart-contracts</a></td>
   </tr>
   <tr>
     <td><a href="./erc725js/getting-started">erc725.js</a></td>
-    <td style={{textAlign: 'center'}}><a href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=%40erc725%2Ferc725.js"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=%40erc725%2Ferc725.js"/></a></td>
     <td><a href="https://github.com/ERC725Alliance/erc725.js">ERC725Alliance/erc725.js</a></td>
   </tr>
   <tr>
     <td><a href="./lsp-factoryjs/getting-started">lsp-factory.js</a></td>
-    <td style={{textAlign: 'center'}}><a href="https://www.npmjs.com/package/@lukso/lsp-factory.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-factory.js.svg?style=flat&label=%40lukso%2Flsp-factory.js"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-factory.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-factory.js.svg?style=flat&label=%40lukso%2Flsp-factory.js"/></a></td>
     <td><a href="https://github.com/lukso-network/tools-lsp-factory">lukso-network/tools-lsp-factory</a></td>
   </tr>
   <tr>
     <td><a href="./eip191-signerjs/getting-started">eip191-signer.js</a></td>
-    <td style={{textAlign: 'center'}}><a href="https://www.npmjs.com/package/@lukso/eip191-signer.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/eip191-signer.js.svg?style=flat&label=%40lukso%2Feip191-signer.js"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/eip191-signer.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/eip191-signer.js.svg?style=flat&label=%40lukso%2Feip191-signer.js"/></a></td>
     <td><a href="https://github.com/lukso-network/tools-eip191-signer">lukso-network/tools-eip191-signer</a></td>
   </tr>
 </table>

--- a/docs/tools/partners.md
+++ b/docs/tools/partners.md
@@ -14,26 +14,26 @@ Here is a list of services and projects that integrated the LUKSO network and re
     <th style={{ maxWidth: "30rem" }}>Description</th>
   </tr>
   <tr>
-    <td style={{ maxWidth: "30rem" }}><a href="https://gateway.fm/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/gatewayfm_logo.png"/></a></td>
+    <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://gateway.fm/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/gatewayfm_logo.png"/></a></td>
     <td><b>Network Provider:</b><br />Gateway FM provides public RPC endpoints. <br /><br /><li><a href="/networks/mainnet/parameters#3rd-party-rpc-providers">Mainnet Parameters</a></li>
     <li><a href="/networks/testnet/parameters#3rd-party-rpc-providers">Testnet Parameters</a></li></td>
   </tr>
   <tr>
-    <td style={{ maxWidth: "30rem" }}><a href="https://nownodes.io/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/nownodes_logo.png"/></a></td>
+    <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://nownodes.io/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/nownodes_logo.png"/></a></td>
     <td><b>Network Provider:</b><br />NOWNodes provides public RPC endpoints. <br /><br /><li><a href="/networks/mainnet/parameters#3rd-party-rpc-providers">Mainnet Parameters</a></li>
     <li><a href="/networks/testnet/parameters#3rd-party-rpc-providers">Testnet Parameters</a></li></td>
   </tr>
   <tr>
-    <td style={{ maxWidth: "30rem" }}><a href="https://thirdweb.com/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/thirdweb_logo.png"/></a></td>
+    <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://thirdweb.com/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/thirdweb_logo.png"/></a></td>
     <td><b>Network & Tooling:</b><br />Thirdweb provides public RPC endpoints, network statistics, as well as a network SDK integration for developers. <br /><br /><li><a href="/networks/mainnet/parameters#3rd-party-rpc-providers">Mainnet Parameters</a></li>
     <li><a href="/networks/testnet/parameters#3rd-party-rpc-providers">Testnet Parameters</a></li><li><a href="https://thirdweb.com/lukso" rel="noopener noreferrer">Network SDK</a></li></td>
   </tr>
   <tr>
-    <td style={{ maxWidth: "30rem" }}><a href="https://transak.com/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/transak_logo.png"/></a></td>
+    <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://transak.com/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/transak_logo.png"/></a></td>
     <td><b>Exchange & Tooling:</b><br />Transak provides a crypto marketplace that can be utilized from developers using their API and SDK integration. <br /><br /><li><a href="https://docs.transak.com/docs/integration-options" rel="noopener noreferrer">Onramp SDK</a></li></td>
   </tr>
   <tr>
-    <td style={{ maxWidth: "30rem" }}><a href="https://gateway.fm/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/dappnode_logo.png"/></a></td>
+    <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://gateway.fm/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/dappnode_logo.png"/></a></td>
     <td><b>Hardware & Nodes:</b><br />Dappnode provides physical node machines and client software images for easy validator onboarding and maintenance. <br /><br /><li><a href="https://dappnode.com/collections/all/products/lukso-home" target="_blank" rel="noopener noreferrer">LUKSO Node</a></li>
     <li><a href="https://docs.dappnode.io/docs/user/install/overview/" target="_blank" rel="noopener noreferrer">Dappnode Software</a></li>    <li><a href="https://github.com/dappnode/DAppNodePackage-lukso-geth" target="_blank" rel="noopener noreferrer">Geth Execution Image</a></li><li><a href="https://github.com/dappnode/DAppNodePackage-prysm-lukso" target="_blank" rel="noopener noreferrer">Prysm Consensus Image</a></li></td>
   </tr>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -119,7 +119,8 @@ html[data-theme='dark'] .faq .img {
   height: 100%;
 }
 
-.menu, .navbar__link {
+.menu,
+.navbar__link {
   font-family: var(--ifm-heading-font-family);
   font-weight: var(--ifm-font-weight-normal);
 }
@@ -150,4 +151,16 @@ html[data-theme='dark'] .faq .img {
   src: url('/static/fonts/Apax-Bold.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
+}
+
+a.imageLink {
+  display: inline-block;
+  position: relative;
+}
+
+a.imageLink img {
+  width: 100%; /* ensures image scales with anchor */
+  height: auto; /* maintain aspect ratio */
+  display: block; /* removes any default inline spacing */
+  pointer-events: none; /* disable default zoom */
 }


### PR DESCRIPTION
Adds two small CSS sets to:

- Disable default `pointer` Zoom
- Spreads `<a>` across whole image

Pages:

- tools/partners
- tools/getting-started