### PR TITLE
Update LSP8 and LSP1 old code + change `JSONURL` to `VerifiableURI`

### DIFF
--- a/docs/contracts/overview/DigitalAssets.md
+++ b/docs/contracts/overview/DigitalAssets.md
@@ -121,36 +121,6 @@ Each NFT is identified with a tokenId, based on **[ERC721](https://github.com/Op
 
 A **bytes32** value is used for tokenId to allow many uses of token identification, including numbers, contract addresses, and hashed values (i.e., serial numbers).
 
-### Checking if the Metadata of a tokenId changed
-
-Because LSP8 uses [ERC725Y](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store) under the hood, the URI pointing to the metadata of a specific tokenId can be changed inside the ERC725Y storage.
-
-This can be done via the functions [`setData(bytes32,bytes)`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#setdata) or [`setDataBatch(bytes32[],bytes[])`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#setdata). 
-
-Since this function emits the [`DataChanged`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#datachanged) event, you can listen for this event in the LSP8 contract to check if the URI pointing of the tokenId metadata has changed. You can do so by filtering the first parameter `dataKey` with:
-
-```
-LSP8MetadataTokenURI:<first 20 bytes of tokenId>
-``` 
-
-If your LSP8 contract uses a specific URI for each tokenId.
-
-<details>
-    <summary>Example of filtering with <code>LSP8MetadataTokenURI:tokenId</code></summary>
-
-Using the following `tokenId` as an example: `0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff`
-
-`LSP8MetadataTokenURI` data key prefix = `0x0x4690256ef7e93288012f0000`
-
-You can filter the `DataChanged` event with the following `dataKey`:
-
-```
-  | LSP8MetadataTokenURI |      first 20 bytes of tokenId        |
-0x4690256ef7e93288012f00001111222233334444555566667777888899990000
-```
-
-</details>
-
 ### Setting metadata for one or multiple tokenIds
 
 The function [`setDataBatchForTokenIds(...)`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#setdatabatchfortokenids) can be used to set multiple data key-value pairs at once for one or multiple tokenIds.
@@ -365,6 +335,15 @@ async function setMultipleDataForSingleTokenId(
   </TabItem>
 
 </Tabs>
+
+### Checking if the Metadata of a tokenId changed
+
+Since LSP8 uses [ERC725Y](../../standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store) under the hood, the URI pointing to the metadata of a specific tokenId can be changed inside the ERC725Y storage of the LSP8 contract.
+
+We have seen in the previous section [**how to set metadata for one or multiple tokenIds**](#setting-metadata-for-one-or-multiple-tokenids). 
+
+The two functions `setDataForTokenId(...)` and `setDataBatchForTokenIds(...)` emit a [`TokenIdDataChanged`](../contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#tokeniddatachanged) event. You can listen for this event in the LSP8 contract from your dApp, filtering for the `LSP4Metadata` data key to check if the metadata of a tokenId has been changed. You can do so by filtering the first parameter with the `tokenId` and the second parameter with the [bytes32 value of the `LSP4Metadata` data key](../../standards/tokens/LSP4-Digital-Asset-Metadata.md#lsp4metadata).
+
 
 ## Note on LSP7 and LSP8 implementations
 

--- a/docs/contracts/type-ids.md
+++ b/docs/contracts/type-ids.md
@@ -4,7 +4,36 @@ title: Universal Receiver Type IDs
 
 # Universal Receiver Type IDs
 
+The **LSP1 type Ids** listed below correspond to unique identifiers used across the LSP standards.
+
+They are used by various smart contracts to notify sender and recipients contracts implementing LSP1 about various incoming or outgoing information.
+For instance, notify a sender that some LSP7 tokens are being transferred from its balance, or a recipient about receiving some LSP7 tokens.
+
+The type Ids listed below cna be exported and accessed from the `@lukso/lsp-smart-contracts` package as follow:
+
+```js
+import { LSP1_TYPE_IDS } from "@lukso/lsp-smart-contracts";
+
+// access the typeId related to being notified when receiving LYX (= native tokens)
+LSP1_TYPE_IDS.
+
+// access the typeId related to being notified when receiving LSP7 tokens
+LSP1_TYPE_IDS.
+
+
+```
+
 ## LSP0 - ERC725 Account
+
+### `LSP0ValueReceived`
+
+|   |   |
+|---|---|
+| **Name**  | `"LSP0ValueReceived"`  |
+| **Hash**  | `0x9c4705229491d365fb5434052e12a386d6771d976bea61070a8c694e8affea3d`  |
+| **Used in:**  | [`constructor(address)`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#constructor), [`receive()`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#receive), [`fallback(bytes)`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#fallback), [`execute(uint256,address,uint256,bytes)`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#execute), [`executeBatch(uint256[],address[],uint256[],bytes[])`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#executebatch), [`setData(bytes32,bytes)`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#setdata), [`setDataBatch(bytes32[],bytes[])`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#setdatabatch)  |
+| **Solidity constant:**  | `_TYPEID_LSP0_VALUE_RECEIVED`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP0ValueReceived`  |
 
 ### `LSP0OwnershipTransferStarted`
 
@@ -13,8 +42,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP0OwnershipTransferStarted"`  |
 | **Hash**  | `0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926`  |
 | **Used in:**  | [`transferOwnership(address)`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#transferownership)  |
-| **Solidity constant:**  | `LSP0OwnershipTransferStarted`  |
-
+| **Solidity constant:**  | `_TYPEID_LSP0_OwnershipTransferStarted`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP0OwnershipTransferStarted`  |
 
 ### `LSP0OwnershipTransferred_SenderNotification`
 
@@ -23,7 +52,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP0OwnershipTransferred_SenderNotification"`  |
 | **Hash**  | `0xa4e59c931d14f7c8a7a35027f92ee40b5f2886b9fdcdb78f30bc5ecce5a2f814`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#acceptownership) <br/> [`renounceOwnership()`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#renounceownership) |
-| **Solidity constant:**  | `LSP0OwnershipTransferred_SenderNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP0_OwnershipTransferred_SenderNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP0OwnershipTransferred_SenderNotification`  |
 
 ### `LSP0OwnershipTransferred_RecipientNotification`
 
@@ -32,7 +62,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP0OwnershipTransferred_RecipientNotification"`  |
 | **Hash**  | `0xceca317f109c43507871523e82dc2a3cc64dfa18f12da0b6db14f6e23f995538`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP0ERC725Account/LSP0ERC725Account.md#acceptownership) |
-| **Solidity constant:**  | `LSP0OwnershipTransferred_RecipientNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP0_OwnershipTransferred_RecipientNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP0OwnershipTransferred_RecipientNotification`  |
 
 ## LSP7 - Digital Asset
 
@@ -43,7 +74,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP7Tokens_SenderNotification"`  |
 | **Hash**  | `0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea`  |
 | **Used in:**  | [`_burn(address,uint256,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_burn), <br/> [`_transfer(address,address,uint256,bool,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_transfer) |
-| **Solidity constant:**  | `LSP7Tokens_SenderNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP7_TOKENSSENDER`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP7Tokens_SenderNotification`  |
 
 ### `LSP7Tokens_RecipientNotification`
 
@@ -52,7 +84,18 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP7Tokens_RecipientNotification"`  |
 | **Hash**  | `0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c`  |
 | **Used in:**  | [`_mint(address,uint256,bool,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_mint), <br/> [`_transfer(address,address,uint256,bool,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_transfer) |
-| **Solidity constant:**  | `LSP7Tokens_RecipientNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP7_TOKENSRECIPIENT`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification`  |
+
+### `LSP7Tokens_OperatorNotification`
+
+|   |   |
+|---|---|
+| **Name**  | `"LSP7Tokens_OperatorNotification"`  |
+| **Hash**  | `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`  |
+| **Used in:**  | [`authorizeOperator(address,uint256,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#authorizeoperator), [`revokeOperator(address,bool,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#revokeoperator), [`increaseAllowance(address,uint256,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#increaseallowance), [`decreaseAllowance(address,uint256,bytes)`](./contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#decreaseallowance) |
+| **Solidity constant:**  | `_TYPEID_LSP7_TOKENOPERATOR`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP7Tokens_OperatorNotification`  |
 
 ## LSP8 - Identifiable Digital Asset
 
@@ -63,7 +106,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP8Tokens_SenderNotification"`  |
 | **Hash**  | `0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00`  |
 | **Used in:**  | [`_burn(bytes32,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_burn), <br/> [`_transfer(address,address,bytes32,bool,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_transfer) |
-| **Solidity constant:**  | `LSP8Tokens_SenderNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP8_TOKENSSENDER`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP8Tokens_SenderNotification`  |
 
 ### `LSP8Tokens_RecipientNotification`
 
@@ -72,9 +116,31 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP8Tokens_RecipientNotification"`  |
 | **Hash**  | `0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d`  |
 | **Used in:**  | [`_mint(address,bytes32,bool,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_mint), <br/> [`_transfer(address,address,bytes32,bool,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#_transfer) |
-| **Solidity constant:**  | `LSP8Tokens_RecipientNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP8_TOKENSRECIPIENT`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification`  |
+
+### `LSP8Tokens_OperatorNotification`
+
+|   |   |
+|---|---|
+| **Name**  | `"LSP8Tokens_OperatorNotification"`  |
+| **Hash**  | `0x468cd1581d7bc001c3b685513d2b929b55437be34700410383d58f3aa1ea0abc`  |
+| **Used in:**  | [`authorizeOperator(address,bytes32,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#authorizeoperator), [`revokeOperator(address,bytes32,bool,bytes)`](./contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#revokeoperator) |
+| **Solidity constant:**  | `_TYPEID_LSP8_TOKENOPERATOR`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP8Tokens_OperatorNotification`  |
+
 
 ## LSP9 - Vault
+
+### `LSP9ValueReceived`
+
+|   |   |
+|---|---|
+| **Name**  | `"LSP9ValueReceived"`  |
+| **Hash**  | `0x468cd1581d7bc001c3b685513d2b929b55437be34700410383d58f3aa1ea0abc`  |
+| **Used in:**  | [`constructor(address)`](./contracts/LSP9Vault/LSP9Vault.md#constructor), [`receive()`](./contracts/LSP9Vault/LSP9Vault.md#receive), [`fallback(bytes)`](./contracts/LSP9Vault/LSP9Vault.md#fallback), [`execute(uint256,address,uint256,bytes)`](./contracts/LSP9Vault/LSP9Vault.md#execute), [`executeBatch(uint256[],address[],uint256[],bytes[])`](./contracts/LSP9Vault/LSP9Vault.md#executebatch)  |
+| **Solidity constant:**  | `_TYPEID_LSP9_VALUE_RECEIVED`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP9ValueReceived`  |
 
 ### `LSP9OwnershipTransferStarted`
 
@@ -83,7 +149,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP9OwnershipTransferStarted"`  |
 | **Hash**  | `0xaefd43f45fed1bcd8992f23c803b6f4ec45cf6b62b0d404d565f290a471e763f`  |
 | **Used in:**  | [`transferOwnership(address)`](./contracts/LSP9Vault/LSP9Vault.md#transferownership)  |
-| **Solidity constant:**  | `LSP9OwnershipTransferStarted`  |
+| **Solidity constant:**  | `_TYPEID_LSP9_OwnershipTransferStarted`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP9OwnershipTransferStarted`  |
 
 ### `LSP9OwnershipTransferred_SenderNotification`
 
@@ -92,7 +159,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP9OwnershipTransferred_SenderNotification"`  |
 | **Hash**  | `0x0c622e58e6b7089ae35f1af1c86d997be92fcdd8c9509652022d41aa65169471`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP9Vault/LSP9Vault.md#acceptownership) <br/> [`renounceOwnership()`](./contracts/LSP9Vault/LSP9Vault.md#renounceownership) |
-| **Solidity constant:**  | `LSP9OwnershipTransferred_SenderNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP9_OwnershipTransferred_SenderNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP9OwnershipTransferred_SenderNotification`  |
 
 ### `LSP9OwnershipTransferred_RecipientNotification`
 
@@ -101,7 +169,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP9OwnershipTransferred_RecipientNotification"`  |
 | **Hash**  | `0x79855c97dbc259ce395421d933d7bc0699b0f1561f988f09a9e8633fd542fe5c`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP9Vault/LSP9Vault.md#acceptownership) |
-| **Solidity constant:**  | `LSP9OwnershipTransferred_RecipientNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP9_OwnershipTransferred_RecipientNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP9OwnershipTransferred_RecipientNotification`  |
 
 ## LSP14 - Ownable 2-Step
 
@@ -112,7 +181,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP14OwnershipTransferStarted"`  |
 | **Hash**  | `0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0`  |
 | **Used in:**  | [`transferOwnership(address)`](./contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#transferownership)  |
-| **Solidity constant:**  | `LSP14OwnershipTransferStarted`  |
+| **Solidity constant:**  | `_TYPEID_LSP14_OwnershipTransferStarted`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP14OwnershipTransferStarted`  |
 
 #### `LSP14OwnershipTransferred_SenderNotification`
 
@@ -121,7 +191,8 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP14OwnershipTransferred_SenderNotification"`  |
 | **Hash**  | `0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#acceptownership) <br/> [`renounceOwnership()`](./contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#renounceownership) |
-| **Solidity constant:**  | `LSP14OwnershipTransferred_SenderNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP14_OwnershipTransferred_SenderNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP14OwnershipTransferred_SenderNotification`  |
 
 #### `LSP14OwnershipTransferred_RecipientNotification`
 
@@ -130,4 +201,5 @@ title: Universal Receiver Type IDs
 | **Name**  | `"LSP14OwnershipTransferred_RecipientNotification"`  |
 | **Hash**  | `0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c`  |
 | **Used in:**  | [`acceptOwnership()`](./contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#acceptownership) |
-| **Solidity constant:**  | `LSP14OwnershipTransferred_RecipientNotification`  |
+| **Solidity constant:**  | `_TYPEID_LSP14_OwnershipTransferred_RecipientNotification`  |
+| **Javascript constant:**  | `LSP1_TYPE_IDS.LSP14OwnershipTransferred_RecipientNotification`  |

--- a/docs/learn/dapp-developer/read-profile-data.md
+++ b/docs/learn/dapp-developer/read-profile-data.md
@@ -233,7 +233,7 @@ console.log(profileMetaData);
 
 :::note get and fetch
 
-The [`getData(...)`](../../tools/erc725js/classes/ERC725#getdata) function only retrieves the data keys values from the smart contract. In comparison, [`fetchData(...)`](../../tools/erc725js/classes/ERC725#fetchdata) will download `JSONURL` and `AssetURL` content.
+The [`getData(...)`](../../tools/erc725js/classes/ERC725#getdata) function only retrieves the data keys values from the smart contract. In comparison, [`fetchData(...)`](../../tools/erc725js/classes/ERC725#fetchdata) will download and decode the content of a `VerifiableURI`, `JSONURL` and `AssetURL`.
 
 :::
 

--- a/docs/learn/expert-guides/universal-profile/edit-profile.md
+++ b/docs/learn/expert-guides/universal-profile/edit-profile.md
@@ -259,8 +259,8 @@ async function editProfileInfo() {
       name: 'LSP3Profile',
       key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
       keyType: 'Singleton',
-      valueContent: 'JSONURL',
       valueType: 'bytes',
+      valueContent: 'VerifiableURI',
     },
   ];
 
@@ -423,8 +423,8 @@ async function editProfileInfo() {
       name: 'LSP3Profile',
       key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
       keyType: 'Singleton',
-      valueContent: 'JSONURL',
       valueType: 'bytes',
+      valueContent: 'VerifiableURI',
     },
   ];
 

--- a/docs/learn/expert-guides/universal-receiver/create-universal-receiver.md
+++ b/docs/learn/expert-guides/universal-receiver/create-universal-receiver.md
@@ -205,9 +205,9 @@ contract LSP1URDForwarderMethod1 is
         }
 
         // extract data (we only need the amount that was transfered / minted)
-        (, , uint256 amount, ) = abi.decode(
+        (, , , uint256 amount, ) = abi.decode(
             data,
-            (address, address, uint256, bytes)
+            (address, address, address, uint256, bytes)
         );
 
         // CHECK that amount is not too low

--- a/docs/standards/generic-standards/lsp2-json-schema.md
+++ b/docs/standards/generic-standards/lsp2-json-schema.md
@@ -24,7 +24,7 @@ The storage of a smart contract consists of multiple **storage slots**. These sl
 > In summary, smart contracts understand only two languages: bytes and uint256.
 > Take the following key-value pair, for instance. It is not easy to infer the meaning of these data keys by reading them as **bytes**.
 
-```
+```text
 (key)                                                              => (value)
 0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1 => 0x4d7920546f6b656e20322e30
 ```

--- a/docs/standards/tokens/LSP4-Digital-Asset-Metadata.md
+++ b/docs/standards/tokens/LSP4-Digital-Asset-Metadata.md
@@ -103,11 +103,11 @@ The value attached to this data key repesents the type of token of the digital a
   "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
   "keyType": "Singleton",
   "valueType": "bytes",
-  "valueContent": "JSONURL"
+  "valueContent": "VerifiableURI"
 }
 ```
 
-The value attached to this data key is a [`JSONURL`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl). It represents a reference to a [JSON file describing the **Digital Asset**](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4metadata). The file can be stored on centralized or decentralized storage.
+The value attached to this data key is a [`VerifiableURI`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#verifiableuri). It represents a reference to a [JSON file describing the **Digital Asset**](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4metadata). The file can be stored on centralized or decentralized storage.
 
 ### `LSP4Creators`
 

--- a/docs/standards/tokens/LSP7-Digital-Asset.md
+++ b/docs/standards/tokens/LSP7-Digital-Asset.md
@@ -78,14 +78,15 @@ During an **LSP7 token transfer**, as well as updating the balances, both the se
 
 ![LSP7DigitalAsset Transfer](/img/standards/lsp7/lsp7-transfer.jpeg)
 
-In this way, users are **informed** about the token transfers and can decide how to **react on the transfer**, either by accepting or rejecting the tokens, or implementing a custom logic to run on each transfer with the help of **[LSP1-UniversalReceiverDelegate](../generic-standards/lsp1-universal-receiver-delegate.md)**.
+In this way, users are **informed** about the token transfers and approval and can decide how to **react on the transfer or approval**, either by accepting or rejecting the tokens, or implementing a custom logic to run on each transfer with the help of **[LSP1-UniversalReceiverDelegate](../generic-standards/lsp1-universal-receiver-delegate.md)**.
 
 If the sender and recipient are smart contracts that implement the LSP1 standard, the LSP7 token contract will notify them using the following `bytes32 typeIds` when calling their `universalReceiver(...)` function.
 
-| address notified       | `bytes32` typeId used                                                | description                                     |
-| ---------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
-| Token sender (`from`)  | `0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea` | `keccak256('LSP7Tokens_SenderNotification')`    |
-| Token recipient (`to`) | `0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c` | `keccak256('LSP7Tokens_RecipientNotification')` |
+| address notified            | `bytes32` typeId used                                                | description                                     |
+| --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
+| Token sender (`from`)       | `0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea` | `keccak256('LSP7Tokens_SenderNotification')`    |
+| Token recipient (`to`)      | `0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c` | `keccak256('LSP7Tokens_RecipientNotification')` |
+| Token Operator (`operator`) | `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc` | `keccak256('LSP7Tokens_OperatorNotification')`  |
 
 ### `force` mint and transfer
 

--- a/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
+++ b/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
@@ -134,10 +134,11 @@ In this way, users are **informed** about the NFT transfer and can decide how to
 
 If the sender and recipient are smart contracts that implement the LSP1 standard, the LSP8 token contract will notify them using the following `bytes32 typeIds` when calling their `universalReceiver(...)` function.
 
-| address notified       | `bytes32` typeId used                                                | description                                     |
-| ---------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
-| Token sender (`from`)  | `0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00` | `keccak256('LSP8Tokens_SenderNotification')`    |
-| Token recipient (`to`) | `0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d` | `keccak256('LSP8Tokens_RecipientNotification')` |
+| address notified            | `bytes32` typeId used                                                | description                                     |
+| --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
+| Token sender (`from`)       | `0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00` | `keccak256('LSP8Tokens_SenderNotification')`    |
+| Token recipient (`to`)      | `0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d` | `keccak256('LSP8Tokens_RecipientNotification')` |
+| Token Operator (`operator`) | `0x468cd1581d7bc001c3b685513d2b929b55437be34700410383d58f3aa1ea0abc` | `keccak256('LSP8Tokens_OperatorNotification')`  |
 
 ### `force` mint and transfer
 

--- a/docs/standards/universal-profile/lsp3-profile-metadata.md
+++ b/docs/standards/universal-profile/lsp3-profile-metadata.md
@@ -50,11 +50,11 @@ This data key is used to know if the contract contains some metadata to display 
   "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
   "keyType": "Singleton",
   "valueType": "bytes",
-  "valueContent": "JSONURL"
+  "valueContent": "VerifiableURI"
 }
 ```
 
-The value attached to this data key is a [JSONURL-encoded value](../../standards/generic-standards/lsp2-json-schema.md). It represents a reference to a [JSON file that describes the Profile MetaData](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md#lsp3profile). The file can be stored on a centralized or decentralized storage.
+The value attached to this data key is a [VerifiableURI-encoded value](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#verifiableuri). It represents a reference to a [JSON file that describes the Profile MetaData](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md#lsp3profile). The file can be stored on a centralized or decentralized storage.
 
 Inside the JSON file, the keys `profileImage` and `backgroundImage` can accept an array of images, defining an image with different dimensions, `width` and `height`. Picture scaling is helpful for client interfaces to download and serve the images with the most suitable dimensions instead of re-scale them afterward.
 


### PR DESCRIPTION
# What does this PR introduce?

- Change references from `JSONURL` to `VerifiableURI`.
- Add missing LSP1 type Ids for LSP7 + LSP8 related to operator approval
- Change LSP8 documentation related to the new event `TokenIdDataChanged` for the new methods introduced in latest release.