### PR TITLE
Fix network button + update styles

### DIFF
--- a/src/components/AddNetworkButton/AddNetworkButton.module.scss
+++ b/src/components/AddNetworkButton/AddNetworkButton.module.scss
@@ -3,11 +3,11 @@
   transition: box-shadow 0.3s;
 
   box-sizing: border-box;
-  border: 0 solid #f2f2f2;
+  border: none;
   font-size: 100%;
   font-weight: inherit;
   line-height: inherit;
-  margin: 15px 0;
+  margin: 15px 0px 30px 0px;
   text-transform: none;
   background-color: transparent;
   background-image: none;
@@ -26,5 +26,6 @@
 
   &:hover {
     box-shadow: 0 0 11px rgba(33, 33, 33, 0.7);
+    border: 0 solid #fe005b;
   }
 }

--- a/src/components/AddNetworkButton/index.js
+++ b/src/components/AddNetworkButton/index.js
@@ -21,16 +21,36 @@ export default function AddNetworkButton({ networkName }) {
     try {
       await ethereum.request({
         method: 'wallet_switchEthereumChain',
-        params: [{ chainId: LUKSO_NETWORK_CONFIGS[networkName].chainId }],
+        params: [
+          {
+            chainId:
+              '0x' +
+              BigInt(LUKSO_NETWORK_CONFIGS[networkName].chainId).toString(16),
+          },
+        ],
       });
-      alert('Your extension is now connected to LUKSO network.');
+      alert(
+        `Your extension is now connected to LUKSO ${
+          networkName == 'mainnet' ? 'Mainnet' : 'Testnet'
+        }`,
+      );
     } catch (switchError) {
       // This error code indicates that the chain has not been added to MetaMask.
       if (switchError.code === 4902) {
         try {
           await ethereum.request({
             method: 'wallet_addEthereumChain',
-            params: [LUKSO_NETWORK_CONFIGS[networkName]],
+            params: [
+              {
+                chainId:
+                  '0x' +
+                  BigInt(LUKSO_NETWORK_CONFIGS[networkName].chainId).toString(
+                    16,
+                  ),
+                chainName: LUKSO_NETWORK_CONFIGS[networkName].chainName,
+                rpcUrls: LUKSO_NETWORK_CONFIGS[networkName].rpcUrls,
+              },
+            ],
           });
         } catch (addError) {
           alert(addError.message);
@@ -43,7 +63,7 @@ export default function AddNetworkButton({ networkName }) {
 
   return (
     <button className={styles.button} onClick={addNetwork}>
-      Add LUKSO {networkName}
+      ADD LUKSO {networkName.toUpperCase()}
     </button>
   );
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 export const LUKSO_NETWORK_CONFIGS = {
   mainnet: {
-    chainId: '0x2A', // 42
-    chainName: 'LUKSO',
+    chainId: '42',
+    chainName: 'LUKSO Mainnet',
     nativeCurrency: {
       name: 'LYX',
       symbol: 'LYX',
@@ -11,8 +11,8 @@ export const LUKSO_NETWORK_CONFIGS = {
     blockExplorerUrls: ['https://explorer.execution.mainnet.lukso.network'],
   },
   testnet: {
-    chainId: '0x1069', // 4201
-    chainName: 'Testnet',
+    chainId: '4201',
+    chainName: 'LUKSO Testnet',
     nativeCurrency: {
       name: 'LYXt',
       symbol: 'LYXt',


### PR DESCRIPTION
## Previously

The "Add Network" button didn't work across some wallet extensions (incl. Universal Profile Browser Extension and Coinbase Wallet)

## Updated Behavior

- Updated the chain ID parameters of the `wallet_switchEthereumChain` method to the standardized way as described in [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326), **used across all wallet providers**
- Updated the alerts & button value to **show the network type accordingly**
- Styling: Fixed border and element spacing