### PR TITLE
Update Docusaurus and Sass

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,7 @@ export default {
   url: 'https://docs.lukso.tech',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
   organizationName: 'lukso-network', // Usually your GitHub org/user name.

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "prettier": "prettier \"src/**/*.js\" \"docs/**/*.md\" --check"
   },
   "dependencies": {
-    "@docusaurus/core": "3.0.1",
-    "@docusaurus/plugin-client-redirects": "3.0.1",
-    "@docusaurus/plugin-google-gtag": "3.0.1",
-    "@docusaurus/preset-classic": "3.0.1",
+    "@docusaurus/core": "3.1.0",
+    "@docusaurus/plugin-client-redirects": "3.1.0",
+    "@docusaurus/plugin-google-gtag": "3.1.0",
+    "@docusaurus/preset-classic": "3.1.0",
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^8.1.0",
     "clsx": "^2.1.0",
@@ -31,12 +31,12 @@
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.69.6",
+    "sass": "^1.69.7",
     "url-loader": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1",
-    "@docusaurus/types": "3.0.1"
+    "@docusaurus/module-type-aliases": "3.1.0",
+    "@docusaurus/types": "3.1.0"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,9 +1843,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/core@npm:3.0.1"
+"@docusaurus/core@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/core@npm:3.1.0"
   dependencies:
     "@babel/core": ^7.23.3
     "@babel/generator": ^7.23.3
@@ -1857,13 +1857,13 @@ __metadata:
     "@babel/runtime": ^7.22.6
     "@babel/runtime-corejs3": ^7.22.6
     "@babel/traverse": ^7.22.8
-    "@docusaurus/cssnano-preset": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/mdx-loader": 3.0.1
+    "@docusaurus/cssnano-preset": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/mdx-loader": 3.1.0
     "@docusaurus/react-loadable": 5.5.2
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     "@slorber/static-site-generator-webpack-plugin": ^4.0.7
     "@svgr/webpack": ^6.5.1
     autoprefixer: ^10.4.14
@@ -1921,41 +1921,41 @@ __metadata:
     react-dom: ^18.0.0
   bin:
     docusaurus: bin/docusaurus.mjs
-  checksum: 56767f7e629edce4d23c19403abf4039daeea25db20c695fb7c3a1ce04a90f182f14ea1f70286afb221b8c1593823ebb0d28cbc2ca5d9d38d707a0338d544f64
+  checksum: 18f894912298bfb5fe0cba15542d7f73ff199183bbfe7db5d1cf4e154b6275cbea21e424ef26f83d5af0df8386484b0e242daa3bb920566d64a82da15133f60a
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/cssnano-preset@npm:3.0.1"
+"@docusaurus/cssnano-preset@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/cssnano-preset@npm:3.1.0"
   dependencies:
     cssnano-preset-advanced: ^5.3.10
     postcss: ^8.4.26
     postcss-sort-media-queries: ^4.4.1
     tslib: ^2.6.0
-  checksum: 3a04606d362c84398a5af9a98de4995958e2705086af83388479feaa157cbe3164281006e64036f9337e96b0cec62bd1362fc0f910075e6eeec930f0a519801d
+  checksum: 94b8bd2a6aba1b9be902ba053f548c2e7d7d050a4d7aa1156adf06b0cf43ddea46478c236b5e3ceaa1d5bf44a4bd3ba42e55a3a03e4ea459bf0b5e67a7f22fb3
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/logger@npm:3.0.1"
+"@docusaurus/logger@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/logger@npm:3.1.0"
   dependencies:
     chalk: ^4.1.2
     tslib: ^2.6.0
-  checksum: 4d4ffcd08f9c76c105d2d2b95974f5c33941e5346c5de1b19ee3f55a4f5011bb7db3875349e25da02750cea5fb357ba00be271ea24368c75b8e29189d04e9f7c
+  checksum: d5e4b4ecf7764a8a9dd575ce14fd7dc61a79846a65dbc597f6715d369ca468082db2cb134bce904acf46b443217988338e28c70e213b4ebe933e25c6e8b42180
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/mdx-loader@npm:3.0.1"
+"@docusaurus/mdx-loader@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/mdx-loader@npm:3.1.0"
   dependencies:
     "@babel/parser": ^7.22.7
     "@babel/traverse": ^7.22.8
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     "@mdx-js/mdx": ^3.0.0
     "@slorber/remark-comment": ^1.0.0
     escape-html: ^1.0.3
@@ -1980,16 +1980,16 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 8ba9774cd2cc7216f645d54a6f6f6cba34e39e371f0de09e56f60a27dde95a8e42ab92cf0a6f384dce01960c68a1e720868c56b6aa8929d23bafe9f523941151
+  checksum: 9b0fec71f50e0ac3df2fdb66efaab2f054742c5c2423ce535ab7bd6a6d9121e2f6b82430dc10dd337d28b45cbcbee9fafb13aa678fd8feaceb6341ed58bc601e
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/module-type-aliases@npm:3.0.1"
+"@docusaurus/module-type-aliases@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/module-type-aliases@npm:3.1.0"
   dependencies:
     "@docusaurus/react-loadable": 5.5.2
-    "@docusaurus/types": 3.0.1
+    "@docusaurus/types": 3.1.0
     "@types/history": ^4.7.11
     "@types/react": "*"
     "@types/react-router-config": "*"
@@ -1999,19 +1999,19 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 08895f8b100df772bb9c9a8fcf9cd3ee83f0deafeb76fb9b14efd5cdd3313abb4a02032868bd458cb3a5f345942fd9f4c44833ce5042279b2241d462a1bf4cc2
+  checksum: 067814b4a7f2b5cae3280f184ed732b20c3460a8e4fbe1ab25bed7a6da6b0461cb71c1744bf689a6729cca4a48b07f1b5dd12ac8be2f324b8fbfcbd47d058705
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-client-redirects@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-client-redirects@npm:3.0.1"
+"@docusaurus/plugin-client-redirects@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-client-redirects@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     eta: ^2.2.0
     fs-extra: ^11.1.1
     lodash: ^4.17.21
@@ -2019,21 +2019,21 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 7d65322d17d28945766e508d8bf276fd60a5d22a8b95cc761747a33d0f88b8a470db51fcf7303c2a979b32e29c5f390d8c12d7bd050972c208d1069c34e035bb
+  checksum: dadd05740d82e3731b8667a0e8314cce435f3362030a241b8c4736ea249ca2b90a6b5916adafefd15cdf485b6080d19dcfa4c0ebd5d913cc9c39759c2f48d4d2
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-content-blog@npm:3.0.1"
+"@docusaurus/plugin-content-blog@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-content-blog@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/mdx-loader": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/mdx-loader": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     cheerio: ^1.0.0-rc.12
     feed: ^4.2.2
     fs-extra: ^11.1.1
@@ -2047,21 +2047,21 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 20985fac48d2f77d560483d06d8fc21ea8c3a009be8d040da76bd4363279ad7fe8f98353bc6a50504403be3315508344faa62123ac3691912d27710fe3c6ec90
+  checksum: d8876e4052716cdeea8aeda473e1c52a1e3795af04b525509e75d8f95e0f34a2b37bae641e4bde676143462d2ec07845d0280eef8e9b2778740183e8ace6b7ab
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-content-docs@npm:3.0.1"
+"@docusaurus/plugin-content-docs@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-content-docs@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/mdx-loader": 3.0.1
-    "@docusaurus/module-type-aliases": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/mdx-loader": 3.1.0
+    "@docusaurus/module-type-aliases": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     "@types/react-router-config": ^5.0.7
     combine-promises: ^1.1.0
     fs-extra: ^11.1.1
@@ -2073,133 +2073,133 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: ee3a12a49df2db112798e8d080365c9cc2afc4959f28772abe03eb9c806b919a9837669354b04a1ff99bf473cab1aa3b8b6ad740947a440a6b9cae09823ef6b2
+  checksum: 88c25764dd7e573cfac405f729709766d75d6fa9a8c99581d2808f316067f29ccf2ff8c242b2d7177e77cd53286ae068ffdc3d287241d919040bbc1891071b2b
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-content-pages@npm:3.0.1"
+"@docusaurus/plugin-content-pages@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-content-pages@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/mdx-loader": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/mdx-loader": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     fs-extra: ^11.1.1
     tslib: ^2.6.0
     webpack: ^5.88.1
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 0a3bd568e4b9df11b5926c5be10f2ced08b241f1a6b8a08f556c57ce707ebb788b19937ec1d884474c4e275dc71affb91dd55a2965ad02a03545e3eae4976141
+  checksum: 70ff37aab8c0ad684fea02452fc369a65669ea8d1cca331d471dbe501842daa6686df7866b21730cf36a4b20c13b1a726d0f975b7296896b80b77c7be4330e1b
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-debug@npm:3.0.1"
+"@docusaurus/plugin-debug@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-debug@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
     fs-extra: ^11.1.1
     react-json-view-lite: ^1.2.0
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 419f2bb61aceca70ffbba03e5e885303cea72055a41328d09d78fa2e40e7d5feb0ee4d66f056d54ac01f8d2361e890a072da6570da16f290c84746ced1582823
+  checksum: a2e3049c96e2b93f416ff44fb2be7a50014ac300854ce54d37778d4a822c122303bab9a428fd141ffa525475fb2f7bd6b435034c44332b2345e15969a046e099
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.0.1"
+"@docusaurus/plugin-google-analytics@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 850930ed0860411142fe058562040f0b3a776be755670790273f48bfa37c7ee904d9107ec23d2ce210904610b72769ce0996a558c89414ac3687bd38bb50edf4
+  checksum: 7953e28cf6560a27e1f3de3a549ccb7cd4e0d278b9eb58dc1d4d84444376675427c613b6930af408981f35ec78567e5475739dd186e83b1007aebf30c435fff3
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.0.1"
+"@docusaurus/plugin-google-gtag@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     "@types/gtag.js": ^0.0.12
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 579a19a6dad3940801a170efc7e5c763c7f90b68d5ecdb2707b61311af321122e84cd0bb5ceb45669e76df712ea1747d6d30fa5a0574b69a7f337dd66b346a04
+  checksum: aebe3e90e3183f049360cab0863183bc8bf9b1d216922279da034b117499ead5bf464b414db40f255681be448ee8954068ef7a5315a61ab851bd670585e145a3
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.0.1"
+"@docusaurus/plugin-google-tag-manager@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 1e3faf9496f75d43a81a5ff2921e783c87ef13d852cf678b54275fa0f79d70efdc127df6ae9c90ddce58b81384f39ec62de75d7e64e34ae96ea938cf234268c0
+  checksum: 12eb03fd4f6e611ba68546412411ab4e2b5f25223ae4b2a1af2190c11059ef0ad627e6b9a642776567b949a7943847654b89b4106cd3bbaedf3f0497563f6ced
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/plugin-sitemap@npm:3.0.1"
+"@docusaurus/plugin-sitemap@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/plugin-sitemap@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     fs-extra: ^11.1.1
     sitemap: ^7.1.1
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 464359fa44143f3e686d02cd70f86741cdd4a74f29f212b83767617fc1dacbfddfa4321c16e0c253849ff41a75078fabbfdf8637d7a141fb1a0354360db2b2bb
+  checksum: 0fa7f908247387ff5c13c981a4b35be848e77509861ccd2cf68d69ebab61f9f6719a0167a9414a0b3fe7f944615ad38603d3a28c2e1996535cbd756f9d06007d
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/preset-classic@npm:3.0.1"
+"@docusaurus/preset-classic@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/preset-classic@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/plugin-content-blog": 3.0.1
-    "@docusaurus/plugin-content-docs": 3.0.1
-    "@docusaurus/plugin-content-pages": 3.0.1
-    "@docusaurus/plugin-debug": 3.0.1
-    "@docusaurus/plugin-google-analytics": 3.0.1
-    "@docusaurus/plugin-google-gtag": 3.0.1
-    "@docusaurus/plugin-google-tag-manager": 3.0.1
-    "@docusaurus/plugin-sitemap": 3.0.1
-    "@docusaurus/theme-classic": 3.0.1
-    "@docusaurus/theme-common": 3.0.1
-    "@docusaurus/theme-search-algolia": 3.0.1
-    "@docusaurus/types": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/plugin-content-blog": 3.1.0
+    "@docusaurus/plugin-content-docs": 3.1.0
+    "@docusaurus/plugin-content-pages": 3.1.0
+    "@docusaurus/plugin-debug": 3.1.0
+    "@docusaurus/plugin-google-analytics": 3.1.0
+    "@docusaurus/plugin-google-gtag": 3.1.0
+    "@docusaurus/plugin-google-tag-manager": 3.1.0
+    "@docusaurus/plugin-sitemap": 3.1.0
+    "@docusaurus/theme-classic": 3.1.0
+    "@docusaurus/theme-common": 3.1.0
+    "@docusaurus/theme-search-algolia": 3.1.0
+    "@docusaurus/types": 3.1.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 03e75324c92a70aea9980f29a993e79967e5ca85d2db1b18bcb00e6c3d8711fec1a1728f92247d4d35a119ae5c3fb5b5d728ea33591f36e8bd43fa6acb1c791c
+  checksum: 6f01570fac940834be93b63592c757a5f76c97571150a11a7789c7d81d58201a29a9c1cdadfe206035216fd028f2ecd60763bedc09deb64ef1a414fd5a29c921
   languageName: node
   linkType: hard
 
@@ -2215,22 +2215,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/theme-classic@npm:3.0.1"
+"@docusaurus/theme-classic@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/theme-classic@npm:3.1.0"
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/mdx-loader": 3.0.1
-    "@docusaurus/module-type-aliases": 3.0.1
-    "@docusaurus/plugin-content-blog": 3.0.1
-    "@docusaurus/plugin-content-docs": 3.0.1
-    "@docusaurus/plugin-content-pages": 3.0.1
-    "@docusaurus/theme-common": 3.0.1
-    "@docusaurus/theme-translations": 3.0.1
-    "@docusaurus/types": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/mdx-loader": 3.1.0
+    "@docusaurus/module-type-aliases": 3.1.0
+    "@docusaurus/plugin-content-blog": 3.1.0
+    "@docusaurus/plugin-content-docs": 3.1.0
+    "@docusaurus/plugin-content-pages": 3.1.0
+    "@docusaurus/theme-common": 3.1.0
+    "@docusaurus/theme-translations": 3.1.0
+    "@docusaurus/types": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     "@mdx-js/react": ^3.0.0
     clsx: ^2.0.0
     copy-text-to-clipboard: ^3.2.0
@@ -2247,21 +2247,21 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 86cef28b5f93d01f15cb134283b8d1006466d661cc39c09c585e56a6a98b09816f8e7cef24b164e8a378b6deb4ed8984fdc329d09fdcbe83fa51529091ccfad8
+  checksum: 82c0d31f5b22c7a12c021b6921f0afe65aaf66d1f6a5aa003beba1ae79c349e693547170415fa7993111937ecaf07358e433119c65e85c2a6f6cde984dc17b75
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/theme-common@npm:3.0.1"
+"@docusaurus/theme-common@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/theme-common@npm:3.1.0"
   dependencies:
-    "@docusaurus/mdx-loader": 3.0.1
-    "@docusaurus/module-type-aliases": 3.0.1
-    "@docusaurus/plugin-content-blog": 3.0.1
-    "@docusaurus/plugin-content-docs": 3.0.1
-    "@docusaurus/plugin-content-pages": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-common": 3.0.1
+    "@docusaurus/mdx-loader": 3.1.0
+    "@docusaurus/module-type-aliases": 3.1.0
+    "@docusaurus/plugin-content-blog": 3.1.0
+    "@docusaurus/plugin-content-docs": 3.1.0
+    "@docusaurus/plugin-content-pages": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-common": 3.1.0
     "@types/history": ^4.7.11
     "@types/react": "*"
     "@types/react-router-config": "*"
@@ -2273,22 +2273,22 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 99fb138fd2fb499d53ee81ae717768b5cb6556ddd337b6d1a399815cb428eed2c04d2823e2040fd4db27bc79681f6333ac1ea78d760ff7fc4475d16d1790552a
+  checksum: e979af32582d04a62584b9a25982293a228f3acb420f8b89cfec0b41aa7b336666fe48105ef57b962f17131821a4458c573968da2a148b89e22a9aaff9189a8b
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/theme-search-algolia@npm:3.0.1"
+"@docusaurus/theme-search-algolia@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/theme-search-algolia@npm:3.1.0"
   dependencies:
     "@docsearch/react": ^3.5.2
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/plugin-content-docs": 3.0.1
-    "@docusaurus/theme-common": 3.0.1
-    "@docusaurus/theme-translations": 3.0.1
-    "@docusaurus/utils": 3.0.1
-    "@docusaurus/utils-validation": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/plugin-content-docs": 3.1.0
+    "@docusaurus/theme-common": 3.1.0
+    "@docusaurus/theme-translations": 3.1.0
+    "@docusaurus/utils": 3.1.0
+    "@docusaurus/utils-validation": 3.1.0
     algoliasearch: ^4.18.0
     algoliasearch-helper: ^3.13.3
     clsx: ^2.0.0
@@ -2300,24 +2300,25 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 24a38dbd7085ea78c412e50c94dda7e0ecb80046dd18c1fdb515d81b21be5cdbc706705a5155600510b0814698abb234885a576d90e0db9cf3c5983d0bf51462
+  checksum: 6aaeb153cfcac01112584c557ebf4dde5ba75f2f2c404fa146a875617ae26a487ac407b64e36e8af336c2bca83947a9376dd2c2fc035e75a07fe2eb708a30567
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/theme-translations@npm:3.0.1"
+"@docusaurus/theme-translations@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/theme-translations@npm:3.1.0"
   dependencies:
     fs-extra: ^11.1.1
     tslib: ^2.6.0
-  checksum: a1df314ddaeb7f453867c5ee5424b36d31c6d6541f86b3927881b77333e997b87e720c0285f3be507283cb851537ff154ce0ddbd5e771c184c8aa10af721d7c2
+  checksum: ce3edda17bc9c802ecb09417187c349a399d6c9c23c2af86ec338136b72e5e7772fb014dd59d68f9ce61a26b2c6973d1350f7a787e1107b82d4388d9934ffc16
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/types@npm:3.0.1"
+"@docusaurus/types@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/types@npm:3.1.0"
   dependencies:
+    "@mdx-js/mdx": ^3.0.0
     "@types/history": ^4.7.11
     "@types/react": "*"
     commander: ^5.1.0
@@ -2329,13 +2330,13 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 1874e66435e986262ad06639b812d49aa5c81a29815b27d31370d055335cebdad77ee0276504497b1765c489e5c5faf9795df97e52649af931d1cf381c4afa77
+  checksum: 9aa554f2395031f974798b94bea8c8b32d3280d6512ae8f8052a14758507281d696b0ef7fd2c7daf7261f4216c1149ec6beeaa414745a248c83fa1b04bab3ff5
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/utils-common@npm:3.0.1"
+"@docusaurus/utils-common@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/utils-common@npm:3.1.0"
   dependencies:
     tslib: ^2.6.0
   peerDependencies:
@@ -2343,28 +2344,28 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: 7d4eb39258539d594cf1432d07be0325de5a02c2a00418e022b0cd2d4374788a7cc5dd3febad6f34744e5a1e76646ae909ffbdf2024284f31c579d1f1ff055d8
+  checksum: c9837e1bf78013239530958760825e55a509e9c4fbd6c3fd2812b7ebb187f13f7976f0e9c64bceff83444f696a6f0a58ba7e0d65fe9e493f3f31a7d1fbe8dd83
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/utils-validation@npm:3.0.1"
+"@docusaurus/utils-validation@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/utils-validation@npm:3.1.0"
   dependencies:
-    "@docusaurus/logger": 3.0.1
-    "@docusaurus/utils": 3.0.1
+    "@docusaurus/logger": 3.1.0
+    "@docusaurus/utils": 3.1.0
     joi: ^17.9.2
     js-yaml: ^4.1.0
     tslib: ^2.6.0
-  checksum: c52edd61906ee004cea95ca33f81ec10a40276cad29f1aef505220cea4b922c1734b765d9c55b0889822351876ea545a73f7f3a4fbbb574f625fe455f8387033
+  checksum: 10b05b6903f07d31beddb19bd5a4c40bc65add2c17bff494876549cc40d05bdab3766fe50809cd2b3ded1ec37a2541f9c28a4ddb934566d06e06e3dd9f4c76ea
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@docusaurus/utils@npm:3.0.1"
+"@docusaurus/utils@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@docusaurus/utils@npm:3.1.0"
   dependencies:
-    "@docusaurus/logger": 3.0.1
+    "@docusaurus/logger": 3.1.0
     "@svgr/webpack": ^6.5.1
     escape-string-regexp: ^4.0.0
     file-loader: ^6.2.0
@@ -2386,7 +2387,7 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: 5a8c5d8dd9cf1ad9ed1cecff3be3cbe041ebf8f51e2744af8aa006df67367f24d0888181566ed9ab2837b931a4fb135d943eadfde99708468f90f18795d413b5
+  checksum: 5e71e5fee219ba1999e62ef5a08940fb3475ce915fcf8c3f67bdeda07274da9e21024239e8cbaac762064c9a0129eb1c9d2440f646420c76fb776828750491ff
   languageName: node
   linkType: hard
 
@@ -7752,12 +7753,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "lukso-docs@workspace:."
   dependencies:
-    "@docusaurus/core": 3.0.1
-    "@docusaurus/module-type-aliases": 3.0.1
-    "@docusaurus/plugin-client-redirects": 3.0.1
-    "@docusaurus/plugin-google-gtag": 3.0.1
-    "@docusaurus/preset-classic": 3.0.1
-    "@docusaurus/types": 3.0.1
+    "@docusaurus/core": 3.1.0
+    "@docusaurus/module-type-aliases": 3.1.0
+    "@docusaurus/plugin-client-redirects": 3.1.0
+    "@docusaurus/plugin-google-gtag": 3.1.0
+    "@docusaurus/preset-classic": 3.1.0
+    "@docusaurus/types": 3.1.0
     "@mdx-js/react": ^3.0.0
     "@svgr/webpack": ^8.1.0
     clsx: ^2.1.0
@@ -7768,7 +7769,7 @@ __metadata:
     prism-react-renderer: ^2.3.1
     react: ^18.2.0
     react-dom: ^18.2.0
-    sass: ^1.69.6
+    sass: ^1.69.7
     url-loader: ^4.1.1
   languageName: unknown
   linkType: soft
@@ -10742,16 +10743,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.69.6":
-  version: 1.69.6
-  resolution: "sass@npm:1.69.6"
+"sass@npm:^1.69.7":
+  version: 1.69.7
+  resolution: "sass@npm:1.69.7"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 9e98eecd283ce6ca5d75ee233e4ec193cb00706d0e119ab6843c44236d3beed2ba28d0af0b4b6bdb4da76feadf426f559d364a69ae54c010467059d130238a36
+  checksum: c67cd32b69fb26a50e4535353e4145de8cbc8187db07c467cc335157fd56d03cae98754f86efe43b880b29f20c0a168ab972c7f74ebfe234e2bd2dfb868890cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Updated Libs

![Bildschirmfoto 2024-01-08 um 15 01 28](https://github.com/lukso-network/docs/assets/61689369/d4213750-1590-46d7-bd5a-3bff40ee093b)

## Updated Config

Added `onBrokenAnchors` as introduced within [Docusaurus 3.1](https://docusaurus.io/blog/releases/3.1)

```
onBrokenAnchors: 'warn'
```

**It's recommended to change `onBrokenAnchors` and `onBrokenMarkdownLinks` to `'throw'`**

## Related PRs

- Closes #815
- Closes #814
- Closes #813
- Closes #812
- Closes #811 