### PR TITLE
Add `lsp-utils` to tools getting started, open github links in new page

### DIFF
--- a/docs/tools/getting-started.md
+++ b/docs/tools/getting-started.md
@@ -15,21 +15,26 @@ sidebar_position: 1
   <tr>
     <td><a href="./lsp-smart-contracts/getting-started">lsp-smart-contracts</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"/></a></td>
-    <td><a href="https://github.com/lukso-network/lsp-smart-contracts">lukso-network/lsp-smart-contracts</a></td>
+    <td><a href="https://github.com/lukso-network/lsp-smart-contracts" target="_blank" rel="noopener noreferrer">lukso-network/lsp-smart-contracts</a></td>
+  </tr>
+  <tr>
+    <td><a href="./lsp-utils/getting-started">lsp-utils</a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-utils" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-utils.svg?style=flat&label=%40lukso%2Flsp-utils"/></a></td>
+    <td><a href="https://github.com/lukso-network/lsp-utils" target="_blank" rel="noopener noreferrer">lukso-network/lsp-utils</a></td>
   </tr>
   <tr>
     <td><a href="./erc725js/getting-started">erc725.js</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=%40erc725%2Ferc725.js"/></a></td>
-    <td><a href="https://github.com/ERC725Alliance/erc725.js">ERC725Alliance/erc725.js</a></td>
+    <td><a href="https://github.com/ERC725Alliance/erc725.js" target="_blank" rel="noopener noreferrer">ERC725Alliance/erc725.js</a></td>
   </tr>
   <tr>
     <td><a href="./lsp-factoryjs/getting-started">lsp-factory.js</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-factory.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-factory.js.svg?style=flat&label=%40lukso%2Flsp-factory.js"/></a></td>
-    <td><a href="https://github.com/lukso-network/tools-lsp-factory">lukso-network/tools-lsp-factory</a></td>
+    <td><a href="https://github.com/lukso-network/tools-lsp-factory" target="_blank" rel="noopener noreferrer">lukso-network/tools-lsp-factory</a></td>
   </tr>
   <tr>
     <td><a href="./eip191-signerjs/getting-started">eip191-signer.js</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/eip191-signer.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/eip191-signer.js.svg?style=flat&label=%40lukso%2Feip191-signer.js"/></a></td>
-    <td><a href="https://github.com/lukso-network/tools-eip191-signer">lukso-network/tools-eip191-signer</a></td>
+    <td><a href="https://github.com/lukso-network/tools-eip191-signer" target="_blank" rel="noopener noreferrer">lukso-network/tools-eip191-signer</a></td>
   </tr>
 </table>


### PR DESCRIPTION
# What does this PR introduce?

- Add `@lukso/lsp-utils` to the table in 'Getting Started' page for the 'Tools'
- Open all GitHub links from 'Tools' table in a new page