### PR TITLE
fixes broken link

### DIFF
--- a/docs/tools/partners.md
+++ b/docs/tools/partners.md
@@ -39,7 +39,7 @@ Here is a list of services and projects that integrated the LUKSO network and re
   </tr>
     <tr>
     <td style={{ maxWidth: "30rem" }}><a class="imageLink" href="https://envio.dev/" target="_blank" rel="noopener noreferrer"><img src="/img/tools/envio_logo.png"/></a></td>
-    <td><b>Data Indexer & Tooling</b><br />Envio is a feature-rich indexing framework and data infrastructure provider speed-optimized for querying real-time and historical data.<br /><br /><li><a href="https://docs.envio.dev/docs/quickstart" target="_blank" rel="noopener noreferrer">Quickstart</a></li>
+    <td><b>Data Indexer & Tooling</b><br />Envio is a feature-rich indexing framework and data infrastructure provider speed-optimized for querying real-time and historical data.<br /><br /><li><a href="https://docs.envio.dev/docs/getting-started" target="_blank" rel="noopener noreferrer">Quickstart</a></li>
     <li><a href="https://docs.envio.dev/docs/hypersync/" target="_blank" rel="noopener noreferrer">Envio HyperSync</a></li>    <li><a href="https://docs.envio.dev/docs/contract-import/" target="_blank" rel="noopener noreferrer">Contract Import</a></li><li><a href="https://docs.envio.dev/docs/hosted-service" target="_blank" rel="noopener noreferrer">Hosted Service</a></li></td>
   </tr>
 </table>


### PR DESCRIPTION
Changes the Quickstart link
from https://docs.envio.dev/docs/quickstart (broken link), 
to https://docs.envio.dev/docs/getting-started