### PR TITLE
doc: Update Thirdweb and remove Gateway

### DIFF
--- a/docs/networks/mainnet/parameters.md
+++ b/docs/networks/mainnet/parameters.md
@@ -28,9 +28,8 @@ The mainnet network configs are defined or the [`lukso-network/network-configs`]
 
 Developers can use the services of the following 3rd party providers:
 
-- [Gateway.fm](https://gateway.fm/) RPC URL: `https://rpc.lukso.gateway.fm`
+- [Thirdweb](https://thirdweb.com/) RPC URL: `https://42.rpc.thirdweb.com`
 - [NowNodes](https://nownodes.io/) RPC URL: `https://lukso.nownodes.io` (requires API key)
-- [Thirdweb](https://thirdweb.com/) RPC URL: `https://lukso.rpc.thirdweb.com` (requires API key)
 - [Envio](https://envio.dev/) RPC URL: `https://lukso.rpc.hypersync.xyz` (optimized read-only)
 
 We recommend developers to use these RPC providers over our public RPC URL as they provide better performance and stability.

--- a/docs/networks/testnet/parameters.md
+++ b/docs/networks/testnet/parameters.md
@@ -35,9 +35,8 @@ The testnet network configs are defined or the [`lukso-network/network-configs`]
 
 Developers can use the services of the following 3rd party providers:
 
-- [Gateway.fm](https://gateway.fm/) RPC URL: `https://rpc.testnet.lukso.gateway.fm`
+- [Thirdweb](https://thirdweb.com/) RPC URL: `https://4201.rpc.thirdweb.com`
 - [NowNodes](https://nownodes.io/) RPC URL: `https://lukso-testnet.nownodes.io` (requires API key)
-- [Thirdweb](https://thirdweb.com/) RPC URL: `https://lukso-testnet.rpc.thirdweb.com` (requires API key)
 
 We recommend developers to use these RPC providers over our public RPC URL as they provide better performance and stability.
 


### PR DESCRIPTION
- remove gateway.fm from node list (they will shut down their nodes)
- update Thirdweb with correct public RPC urls (they are free, API keys are for SDK)