### PR TITLE
chore: make standards cards 3 column layout + full card clickable

### DIFF
--- a/src/components/StandardsGallery/StandardsGallery.module.scss
+++ b/src/components/StandardsGallery/StandardsGallery.module.scss
@@ -1,6 +1,6 @@
 @media (min-width: 997px) {
   .legoCard {
-    max-width: 23%;
+    max-width: 31%;
   }
 }
 
@@ -9,6 +9,10 @@
   transition: box-shadow 0.3s ease-in-out;
   border-radius: 0.5rem;
   margin-left: 1rem;
+
+  h3 {
+    margin: 1em 0;
+  }
 }
 
 .legoCard:hover {

--- a/src/components/StandardsGallery/index.tsx
+++ b/src/components/StandardsGallery/index.tsx
@@ -29,7 +29,7 @@ const STANDARDS = [
     name: 'Profile Metadata',
     link: '/standards/universal-profile/lsp3-profile-metadata',
 
-    text: 'Set of ERC725Y data keys to describe a smart contract based blockchain profile.',
+    text: 'Set of ERC725Y data keys describing a smart contract based blockchain profile.',
   },
   {
     title: '🔍 LSP4',
@@ -133,7 +133,7 @@ const STANDARDS = [
 
 function StandardCard({ link, title, name, text }) {
   return (
-    <div className={`col col--3 margin-bottom--lg ${styles.legoCard}`}>
+    <div className={`col col--4 margin-bottom--lg ${styles.legoCard}`}>
       <div>
         <Link
           to={link}
@@ -141,12 +141,12 @@ function StandardCard({ link, title, name, text }) {
             borderWidth: '1px',
           }}
         >
-          <h3 className="flex items-center font-jakarta">
+          <h2 className="flex items-center font-jakarta">
             <div>{title}</div>
-          </h3>
-          <h4 className="flex items-center font-jakarta">
+          </h2>
+          <h3 className="flex items-center font-jakarta">
             <div className={styles.standardName}>{name}</div>
-          </h4>
+          </h3>
           <p className="mb-0 text-sm text-zinc-400">{text}</p>
         </Link>
       </div>
@@ -158,17 +158,22 @@ export default function StandardsGallery() {
   return (
     <div className="container">
       <div className="row flex flex-col items-center justify-between">
-        {STANDARDS.slice(0, 4).map((standard) => (
+        {STANDARDS.slice(0, 3).map((standard) => (
           <StandardCard {...standard} key={standard.title} />
         ))}
       </div>
       <div className="row flex flex-col items-center justify-between">
-        {STANDARDS.slice(4, 8).map((standard) => (
+        {STANDARDS.slice(3, 6).map((standard) => (
           <StandardCard {...standard} key={standard.title} />
         ))}
       </div>
       <div className="row flex flex-col items-center justify-between">
-        {STANDARDS.slice(8, 12).map((standard) => (
+        {STANDARDS.slice(6, 9).map((standard) => (
+          <StandardCard {...standard} key={standard.title} />
+        ))}
+      </div>
+      <div className="row flex flex-col items-center justify-between">
+        {STANDARDS.slice(9, 12).map((standard) => (
           <StandardCard {...standard} key={standard.title} />
         ))}
       </div>

--- a/src/components/StandardsGallery/index.tsx
+++ b/src/components/StandardsGallery/index.tsx
@@ -140,11 +140,9 @@ function StandardCard({ link, title, name, text }) {
         borderWidth: '1px',
       }}
     >
-      <h2 className="flex items-center font-jakarta">
-        <div>{title}</div>
-      </h2>
-      <h3 className="flex items-center font-jakarta">
-        <div className={styles.standardName}>{name}</div>
+      <h2 className="flex items-center font-jakarta">{title}</h2>
+      <h3 className={`flex items-center font-jakarta ${styles.standardName}`}>
+        {name}
       </h3>
       <p className="mb-0 text-sm text-zinc-400">{text}</p>
     </Link>

--- a/src/components/StandardsGallery/index.tsx
+++ b/src/components/StandardsGallery/index.tsx
@@ -133,24 +133,21 @@ const STANDARDS = [
 
 function StandardCard({ link, title, name, text }) {
   return (
-    <div className={`col col--4 margin-bottom--lg ${styles.legoCard}`}>
-      <div>
-        <Link
-          to={link}
-          style={{
-            borderWidth: '1px',
-          }}
-        >
-          <h2 className="flex items-center font-jakarta">
-            <div>{title}</div>
-          </h2>
-          <h3 className="flex items-center font-jakarta">
-            <div className={styles.standardName}>{name}</div>
-          </h3>
-          <p className="mb-0 text-sm text-zinc-400">{text}</p>
-        </Link>
-      </div>
-    </div>
+    <Link
+      className={`col col--4 margin-bottom--lg ${styles.legoCard}`}
+      to={link}
+      style={{
+        borderWidth: '1px',
+      }}
+    >
+      <h2 className="flex items-center font-jakarta">
+        <div>{title}</div>
+      </h2>
+      <h3 className="flex items-center font-jakarta">
+        <div className={styles.standardName}>{name}</div>
+      </h3>
+      <p className="mb-0 text-sm text-zinc-400">{text}</p>
+    </Link>
   );
 }
 


### PR DESCRIPTION
Adjust the style and large padding of the cards + make the link clickable for the full card (whole `<div>`), not only the text.

## After

<img width="1029" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/032edcf0-7fda-4a59-89f3-d9f7a7134d47">

## Before

<img width="1056" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/45c4f936-ede7-47a0-a5b7-f27c3de80ce5">
