### PR TITLE
LSP8 standard page typo/redirect fix

### DIFF
--- a/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
+++ b/docs/standards/tokens/LSP8-Identifiable-Digital-Asset.md
@@ -151,7 +151,7 @@ When transferring or minting tokens, it is advised to set the `force` boolean to
 
 It is expected in the LUKSO's ecosystem to use **smart contract based accounts** to interact on the blockchain. This includes sending and receiving tokens. EOAs can receive tokens, but should be used mainly to control these accounts, not to interact on the network or hold tokens.
 
-To ensure a **safe asset transfer**, an additional boolean parameter was added to the [`transfer(...)``](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#transfer) and `_mint(...)` functions:
+To ensure a **safe asset transfer**, an additional boolean parameter was added to the [`transfer(...)`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md#transfer) and [`_mint(...)`](../../contracts/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md#_mint) functions:
 
 - If set to `false`, the transfer will only pass if the recipient is a smart contract that implements the **[LSP1-UniversalReceiver](../generic-standards/lsp1-universal-receiver.md)** standard.
 


### PR DESCRIPTION
This PR contains a simple typo correction and redirect addition in the LSP8 standard page.

before: 
![image](https://github.com/lukso-network/docs/assets/9093326/4c7274e2-623d-4d0d-b497-359bd0ab5997)

after:
![image](https://github.com/lukso-network/docs/assets/9093326/5d511dfd-e24b-446b-b661-d11f26a90c95)
