### PR TITLE
Cleanup ethers / web3 tabs to have same names + have ethers code always as first tab

### DIFF
--- a/docs/learn/digital-assets/retrieve-token-type.md
+++ b/docs/learn/digital-assets/retrieve-token-type.md
@@ -40,7 +40,7 @@ npm install @erc725/erc725.js
 ```
 
   </TabItem>
-  <TabItem value="ethers.js" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```bash
 npm install ethers @lukso/lsp-smart-contracts
@@ -48,7 +48,7 @@ npm install ethers @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```bash
 npm install web3 @lukso/lsp-smart-contracts
@@ -85,7 +85,7 @@ console.log(tokenType);
 ```
 
   </TabItem>
-  <TabItem value="ethers.js" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js
 import { ethers } from 'ethers';
@@ -118,7 +118,7 @@ console.log(tokenType);
 
   </TabItem>
 
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js
 import Web3 from 'web3';

--- a/docs/learn/digital-assets/set-nft-metadata.md
+++ b/docs/learn/digital-assets/set-nft-metadata.md
@@ -21,14 +21,14 @@ The following code snippets require the installation of the following libraries:
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell
 npm install ethers @lukso/lsp-smart-contracts
@@ -42,7 +42,7 @@ npm install ethers @lukso/lsp-smart-contracts
 Import `web3.js`/`ethers`, the [`LSP8IdentifiableDigitalAsset`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md) ABI from [`@lukso/lsp-smart-contracts`](../../contracts/introduction.md) and create an instance of this contract with the `lsp8ContractAddress`.
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript
 import Web3 from 'web3';
@@ -59,7 +59,7 @@ const lsp8ContractAddress = '0x...';
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```javascript
 import { ethers } from 'ethers';
@@ -84,7 +84,7 @@ const lsp8ContractAddress = '0x...';
 Create an instance of the LSP8 collection contract as shown below:
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript
 const myToken = new web3.eth.Contract(
@@ -94,7 +94,7 @@ const myToken = new web3.eth.Contract(
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```javascript
 const lsp8Contract = new ethers.Contract(
@@ -158,7 +158,7 @@ You can also check the code snippet example in the LSP2 specs to learn in detail
 :::
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
@@ -182,7 +182,7 @@ await lsp8Contract.methods
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```javascript
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';

--- a/docs/learn/digital-assets/set-nft-metadata.md
+++ b/docs/learn/digital-assets/set-nft-metadata.md
@@ -21,13 +21,6 @@ The following code snippets require the installation of the following libraries:
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3" label="web3">
-
-```shell
-npm install web3 @lukso/lsp-smart-contracts
-```
-
-  </TabItem>
   <TabItem value="ethers" label="ethers">
 
 ```shell
@@ -35,6 +28,14 @@ npm install ethers @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
+  <TabItem value="web3" label="web3">
+
+```shell
+npm install web3 @lukso/lsp-smart-contracts
+```
+
+  </TabItem>
+
 </Tabs>
 
 ## Imports and constants
@@ -42,23 +43,6 @@ npm install ethers @lukso/lsp-smart-contracts
 Import `web3.js`/`ethers`, the [`LSP8IdentifiableDigitalAsset`](../../contracts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md) ABI from [`@lukso/lsp-smart-contracts`](../../contracts/introduction.md) and create an instance of this contract with the `lsp8ContractAddress`.
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3" label="web3">
-
-```javascript
-import Web3 from 'web3';
-
-// import smart contract ABI
-import LSP8IdentifiableDigitalAsset from '@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json';
-
-const web3 = new Web3(window.lukso);
-
-await web3.eth.requestAccounts();
-const accounts = await web3.eth.getAccounts();
-
-const lsp8ContractAddress = '0x...';
-```
-
-  </TabItem>
   <TabItem value="ethers" label="ethers">
 
 ```javascript
@@ -77,6 +61,24 @@ const lsp8ContractAddress = '0x...';
 ```
 
   </TabItem>
+  <TabItem value="web3" label="web3">
+
+```javascript
+import Web3 from 'web3';
+
+// import smart contract ABI
+import LSP8IdentifiableDigitalAsset from '@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json';
+
+const web3 = new Web3(window.lukso);
+
+await web3.eth.requestAccounts();
+const accounts = await web3.eth.getAccounts();
+
+const lsp8ContractAddress = '0x...';
+```
+
+  </TabItem>
+
 </Tabs>
 
 ## Instantiate the LSP8 contract
@@ -84,22 +86,22 @@ const lsp8ContractAddress = '0x...';
 Create an instance of the LSP8 collection contract as shown below:
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3" label="web3">
-
-```javascript
-const myToken = new web3.eth.Contract(
-  LSP8IdentifiableDigitalAsset.abi,
-  lsp8ContractAddress,
-);
-```
-
-  </TabItem>
   <TabItem value="ethers" label="ethers">
 
 ```javascript
 const lsp8Contract = new ethers.Contract(
   lsp8ContractAddress,
   LSP8IdentifiableDigitalAsset.abi,
+);
+```
+
+  </TabItem>
+  <TabItem value="web3" label="web3">
+
+```javascript
+const myToken = new web3.eth.Contract(
+  LSP8IdentifiableDigitalAsset.abi,
+  lsp8ContractAddress,
 );
 ```
 
@@ -158,6 +160,30 @@ You can also check the code snippet example in the LSP2 specs to learn in detail
 :::
 
 <Tabs groupId="web3-lib">
+
+  <TabItem value="ethers" label="ethers">
+
+```javascript
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
+
+// import and instantiate contract from previous steps
+
+// change this with the actual tokenId to update metadata for
+const tokenId =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+// change this with the actual VerifiableURI of the metadata uploaded somewhere (S3, IPFS, etc...)
+const metadataValue = '0x...';
+
+await lsp8Contract.setDataForTokenId(
+  tokenId,
+  ERC725YDataKeys.LSP4['LSP4Metadata'],
+  metadataValue,
+);
+```
+
+  </TabItem>
+  
   <TabItem value="web3" label="web3">
 
 ```javascript
@@ -182,26 +208,5 @@ await lsp8Contract.methods
 ```
 
   </TabItem>
-  <TabItem value="ethers" label="ethers">
 
-```javascript
-import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
-
-// import and instantiate contract from previous steps
-
-// change this with the actual tokenId to update metadata for
-const tokenId =
-  '0x0000000000000000000000000000000000000000000000000000000000000001';
-
-// change this with the actual VerifiableURI of the metadata uploaded somewhere (S3, IPFS, etc...)
-const metadataValue = '0x...';
-
-await lsp8Contract.setDataForTokenId(
-  tokenId,
-  ERC725YDataKeys.LSP4['LSP4Metadata'],
-  metadataValue,
-);
-```
-
-  </TabItem>
 </Tabs>

--- a/docs/learn/key-manager/execute-relay-transactions.md
+++ b/docs/learn/key-manager/execute-relay-transactions.md
@@ -202,15 +202,15 @@ const abiPayload = universalProfile.interface.encodeFunctionData('execute', [
 
     <TabItem value="web3" label="web3">
 
-<!-- prettier-ignore-start -->
-
 ```typescript
 // ...
 
 const channelId = 0;
 
 // Retrieve the nonce of the EOA controller
-const nonce = await keyManager.methods.getNonce(controllerAccount.address, channelId).call();
+const nonce = await keyManager.methods
+  .getNonce(controllerAccount.address, channelId)
+  .call();
 
 const validityTimestamps = 0; // No validity timestamp set
 const msgValue = 0; // Amount of native tokens to fund the UP with while calling
@@ -225,8 +225,6 @@ const abiPayload = universalProfile.methods
   )
   .encodeABI();
 ```
-
-<!-- prettier-ignore-end -->
 
   </TabItem>
 
@@ -251,8 +249,6 @@ The transaction message is constructed by signing the:
 - Amount of native tokens to fund the UP with while calling (`msgValue`)
 - The ABI Payload of operations that will be executed (`abiPayload`)
 
-<!-- prettier-ignore-start -->
-
 <Tabs groupId="provider-lib">
 
   <TabItem value="ethers" label="ethers">
@@ -270,34 +266,34 @@ const encodedMessage = ethers.solidityPacked(
   [
     // MUST be number `25`
     // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000019`
-    LSP25_VERSION,    
+    LSP25_VERSION,
 
     // e.g: `4201` for LUKSO Testnet
     // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000001069`
-    chainId,      
+    chainId,
 
     // e.g: nonce number 5 of the signing controller that wants to execute the payload
     // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000005`
-    nonce,          
-                      
+    nonce,
+
     // e.g: valid until 1st January 2025 at midnight (GMT).
     // Timestamp = 1735689600
     // Encoded value: `0x0000000000000000000000000000000000000000000000000000000067748580`
-    validityTimestamps,      
+    validityTimestamps,
 
     // e.g: not funding the contract with any LYX (0)
     // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000000`
-    msgValue,    
-           
+    msgValue,
+
     // e.g: send 3 LYX to address 0xcafecafecafecafecafecafecafecafecafecafe
     // by calling execute(uint256,address,uint256,bytes)
-    // Encoded value: `0x44c028fe00000000000000000000000000000000000000000000000000000000        
-    //                 00000000000000000000000000000000cafecafecafecafecafecafecafecafeca 
-    //                 fecafecafecafe00000000000000000000000000000000000000000000000029a2 
+    // Encoded value: `0x44c028fe00000000000000000000000000000000000000000000000000000000
+    //                 00000000000000000000000000000000cafecafecafecafecafecafecafecafeca
+    //                 fecafecafecafe00000000000000000000000000000000000000000000000029a2
     //                 241af62c0000000000000000000000000000000000000000000000000000000000
     //                 000000008000000000000000000000000000000000000000000000000000000000
     //                 00000000`
-    abiPayload,         
+    abiPayload,
   ],
 );
 
@@ -325,15 +321,15 @@ const chainId = await web3.eth.getChainId();
 const encodedMessage = web3.utils.encodePacked(
   // MUST be number `25`
   // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000019`
-  { value: LSP25_VERSION, type: 'uint256' },   
+  { value: LSP25_VERSION, type: 'uint256' },
 
   // e.g: `4201` for LUKSO Testnet
   // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000001069`
-  { value: chainId, type: 'uint256' },            
+  { value: chainId, type: 'uint256' },
 
   // e.g: nonce number 5 of the signing controller that wants to execute the payload
   // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000005`
-  { value: nonce, type: 'uint256' }, 
+  { value: nonce, type: 'uint256' },
 
   // e.g: not funding the contract with any LYX (0)
   // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000000`
@@ -341,13 +337,13 @@ const encodedMessage = web3.utils.encodePacked(
 
   // e.g: not funding the contract with any LYX (0)
   // Encoded value: `0x0000000000000000000000000000000000000000000000000000000000000000`
-  { value: msgValue, type: 'uint256' },   
+  { value: msgValue, type: 'uint256' },
 
   // e.g: send 3 LYX to address 0xcafecafecafecafecafecafecafecafecafecafe
   // by calling execute(uint256,address,uint256,bytes)
-  // Encoded value: `0x44c028fe00000000000000000000000000000000000000000000000000000000        
-  //                 00000000000000000000000000000000cafecafecafecafecafecafecafecafeca 
-  //                 fecafecafecafe00000000000000000000000000000000000000000000000029a2 
+  // Encoded value: `0x44c028fe00000000000000000000000000000000000000000000000000000000
+  //                 00000000000000000000000000000000cafecafecafecafecafecafecafecafeca
+  //                 fecafecafecafe00000000000000000000000000000000000000000000000029a2
   //                 241af62c0000000000000000000000000000000000000000000000000000000000
   //                 000000008000000000000000000000000000000000000000000000000000000000
   //                 00000000`
@@ -367,8 +363,6 @@ const { signature } = await eip191Signer.signDataWithIntendedValidator(
   </TabItem>
 
 </Tabs>
-
-<!-- prettier-ignore-end -->
 
 After the signature has been generated, it can be sent to the third party to execute the transaction using [`executeRelayCall`](../../contracts/contracts/LSP6KeyManager/LSP6KeyManager.md#executerelaycall) on the Key Manager of the profile. To verify all transaction parts, the third-party will need the following parameters:
 

--- a/docs/learn/key-manager/grant-permissions.md
+++ b/docs/learn/key-manager/grant-permissions.md
@@ -72,7 +72,7 @@ The first step is to initialize the erc725.js library with a JSON schema specifi
 import { ERC725 } from '@erc725/erc725.js';
 import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 
-// step 1 -initialize erc725.js with the ERC725Y permissions data keys from LSP6 Key Manager
+// step 1 - initialize erc725.js with the ERC725Y permissions data keys from LSP6 Key Manager
 const erc725 = new ERC725(
   LSP6Schema,
   myUniversalProfileAddress,
@@ -147,6 +147,21 @@ To get started you would need the following:
 - The address of the Universal Profile that you want to interact with.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```javascript title="Load account from a private key"
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import { ethers } from 'ethers';
+
+const provider = new ethers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
+const myUniversalProfileAddress = '0x...';
+const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -158,23 +173,6 @@ const web3 = new Web3('https://rpc.testnet.lukso.network');
 const myUniversalProfileAddress = '0x...';
 const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 ```
-
-  </TabItem>
-
-  <TabItem value="ethers" label="ethers">
-
-<!-- prettier-ignore-start -->
-
-```javascript title="Load account from a private key"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import { ethers } from 'ethers';
-
-const provider = new ethers.JsonRpcProvider('https://rpc.testnet.lukso.network');
-const myUniversalProfileAddress = '0x...';
-const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
-```
-
-<!-- prettier-ignore-end -->
 
   </TabItem>
 
@@ -192,18 +190,18 @@ The private key can be obtained depending on how you created your Universal Prof
 - UP created via the Browser extension: click on the _Settings_ icon (top right) > and _Export Private Key_
 
 <Tabs>
-  <TabItem value="web3" label="web3">
-
-```javascript title="Load account from a private key"
-const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
-```
-
-  </TabItem>
-
   <TabItem value="ethers" label="ethers">
 
 ```javascript title="Load account from a private key"
 const myEOA = new ethers.Wallet(privateKey).connect(provider);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```javascript title="Load account from a private key"
+const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
 ```
 
   </TabItem>
@@ -217,18 +215,6 @@ The next steps is to create an instance of our UP smart contract to interact wit
 You will need the address of your Universal Profile.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```js
-// step 1 - create instance of UniversalProfile contract
-const myUniversalProfile = new web3.eth.Contract(
-  UniversalProfile.abi,
-  myUniversalProfileAddress,
-);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -237,6 +223,18 @@ const myUniversalProfile = new web3.eth.Contract(
 const universalProfile = new ethers.Contract(
   universalProfileAddress,
   UniversalProfile.abi,
+);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js
+// step 1 - create instance of UniversalProfile contract
+const myUniversalProfile = new web3.eth.Contract(
+  UniversalProfile.abi,
+  myUniversalProfileAddress,
 );
 ```
 
@@ -253,38 +251,25 @@ We can easily access the data key-value pair from the encoded data obtained by e
 We will then encode this permission data keys in a `setData(...)` payload and interact via the Key Manager.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
 
-<!-- prettier-ignore-start -->
+  <TabItem value="ethers" label="ethers">
 
 ```js
 // step 3.3 - send the transaction
-await myUniversalProfile.methods.setData(
-  data.keys,
-  data.values,
-).send({
+await myUniversalProfile.connect(account).setData(data.keys, data.values);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js
+// step 3.3 - send the transaction
+await myUniversalProfile.methods.setData(data.keys, data.values).send({
   from: myEOA.address,
   gasLimit: 300_000,
 });
 ```
-
-<!-- prettier-ignore-end -->
-
-  </TabItem>
-
-  <TabItem value="ethers" label="ethers">
-
-<!-- prettier-ignore-start -->
-
-```js
-// step 3.3 - send the transaction
-await myUniversalProfile
-  .connect(account)
-  .setData(data.keys, data.values);
-```
-
-<!-- prettier-ignore-end -->
 
   </TabItem>
 
@@ -313,85 +298,6 @@ You can then try to do again the **Edit our Universal Profile** guide, using thi
 ## Final code
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-<!-- prettier-ignore-start -->
-
-```js
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import { ERC725 } from '@erc725/erc725.js';
-import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
-import Web3 from 'web3';
-
-const web3 = new Web3('https://rpc.testnet.lukso.network');
-const myUniversalProfileAddress = '0x...';
-
-const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
-const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
-
-const erc725 = new ERC725(
-  LSP6Schema,
-  myUniversalProfileAddress,
-  web3.currentProvider,
-);
-
-async function grantPermissions() {
-  // step 1 - create instance of UP contract
-  const myUniversalProfile = new web3.eth.Contract(
-    UniversalProfile.abi,
-    myUniversalProfileAddress,
-  );
-
-  // step 2 - setup the permissions of the beneficiary address
-  const beneficiaryAddress = '0xcafecafecafecafecafecafecafecafecafecafe'; // EOA address of an exemplary person
-  const beneficiaryPermissions = erc725.encodePermissions({
-    SETDATA: true,
-  });
-
-  // step 3.1 - encode the data key-value pairs of the permissions to be set
-  const addressPermissionsArray = await erc725.getData('AddressPermissions[]');
-  const controllers = addressPermissionsArray.value;
-
-  const data = erc725.encodeData([
-    // the permission of the beneficiary address
-    {
-      keyName: 'AddressPermissions:Permissions:<address>',
-      dynamicKeyParts: beneficiaryAddress,
-      value: beneficiaryPermissions,
-    },
-    // the new list controllers addresses (= addresses with permissions set on the UP)
-    // + the incremented `AddressPermissions[]` array length
-    {
-      keyName: 'AddressPermissions[]',
-      value: [...controllers, beneficiaryAddress],
-    },
-  ]);
-
-  // step 3.3 - send the transaction
-  await myUniversalProfile.methods.setDataBatch(
-    data.keys,
-    data.values,
-  ).send({
-    from: myEOA.address,
-    gasLimit: 300_000,
-  });
-
-  const result = await myUniversalProfile.methods['getData(bytes32)'](
-    data.keys[0],
-  ).call();
-  console.log(
-    `The beneficiary address ${beneficiaryAddress} has now the following permissions:`,
-    erc725.decodePermissions(result),
-  );
-}
-
-grantPermissions();
-```
-
-<!-- prettier-ignore-end -->
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -455,6 +361,78 @@ async function grantPermissions() {
   const result = await myUniversalProfile.['getData(bytes32)'](
     data.keys[0],
   );
+  console.log(
+    `The beneficiary address ${beneficiaryAddress} has now the following permissions:`,
+    erc725.decodePermissions(result),
+  );
+}
+
+grantPermissions();
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import { ERC725 } from '@erc725/erc725.js';
+import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
+import Web3 from 'web3';
+
+const web3 = new Web3('https://rpc.testnet.lukso.network');
+const myUniversalProfileAddress = '0x...';
+
+const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
+const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
+
+const erc725 = new ERC725(
+  LSP6Schema,
+  myUniversalProfileAddress,
+  web3.currentProvider,
+);
+
+async function grantPermissions() {
+  // step 1 - create instance of UP contract
+  const myUniversalProfile = new web3.eth.Contract(
+    UniversalProfile.abi,
+    myUniversalProfileAddress,
+  );
+
+  // step 2 - setup the permissions of the beneficiary address
+  const beneficiaryAddress = '0xcafecafecafecafecafecafecafecafecafecafe'; // EOA address of an exemplary person
+  const beneficiaryPermissions = erc725.encodePermissions({
+    SETDATA: true,
+  });
+
+  // step 3.1 - encode the data key-value pairs of the permissions to be set
+  const addressPermissionsArray = await erc725.getData('AddressPermissions[]');
+  const controllers = addressPermissionsArray.value;
+
+  const data = erc725.encodeData([
+    // the permission of the beneficiary address
+    {
+      keyName: 'AddressPermissions:Permissions:<address>',
+      dynamicKeyParts: beneficiaryAddress,
+      value: beneficiaryPermissions,
+    },
+    // the new list controllers addresses (= addresses with permissions set on the UP)
+    // + the incremented `AddressPermissions[]` array length
+    {
+      keyName: 'AddressPermissions[]',
+      value: [...controllers, beneficiaryAddress],
+    },
+  ]);
+
+  // step 3.3 - send the transaction
+  await myUniversalProfile.methods.setDataBatch(data.keys, data.values).send({
+    from: myEOA.address,
+    gasLimit: 300_000,
+  });
+
+  const result = await myUniversalProfile.methods['getData(bytes32)'](
+    data.keys[0],
+  ).call();
   console.log(
     `The beneficiary address ${beneficiaryAddress} has now the following permissions:`,
     erc725.decodePermissions(result),

--- a/docs/learn/key-manager/grant-permissions.md
+++ b/docs/learn/key-manager/grant-permissions.md
@@ -46,7 +46,7 @@ When granting permissions to a new address, we need to update three data keys in
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @erc725/erc725.js @lukso/lsp-smart-contracts
@@ -54,7 +54,7 @@ npm install web3 @erc725/erc725.js @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @erc725/erc725.js @lukso/lsp-smart-contracts
@@ -148,7 +148,7 @@ To get started you would need the following:
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript title="Load account from a private key"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -161,7 +161,7 @@ const PRIVATE_KEY = '0x...'; // your EOA private key (previously created)
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 <!-- prettier-ignore-start -->
 
@@ -192,7 +192,7 @@ The private key can be obtained depending on how you created your Universal Prof
 - UP created via the Browser extension: click on the _Settings_ icon (top right) > and _Export Private Key_
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript title="Load account from a private key"
 const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
@@ -200,7 +200,7 @@ const myEOA = web3.eth.accounts.wallet.add(PRIVATE_KEY);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```javascript title="Load account from a private key"
 const myEOA = new ethers.Wallet(privateKey).connect(provider);
@@ -218,7 +218,7 @@ You will need the address of your Universal Profile.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js
 // step 1 - create instance of UniversalProfile contract
@@ -230,7 +230,7 @@ const myUniversalProfile = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js
 // step 1 - create instance of UniversalProfile contract
@@ -254,7 +254,7 @@ We will then encode this permission data keys in a `setData(...)` payload and in
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -273,7 +273,7 @@ await myUniversalProfile.methods.setData(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 <!-- prettier-ignore-start -->
 
@@ -314,7 +314,7 @@ You can then try to do again the **Edit our Universal Profile** guide, using thi
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -393,7 +393,7 @@ grantPermissions();
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';

--- a/docs/learn/key-manager/upgrade-key-manager.md
+++ b/docs/learn/key-manager/upgrade-key-manager.md
@@ -38,7 +38,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts
@@ -46,7 +46,7 @@ npm install web3 @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
@@ -65,7 +65,7 @@ Create a JavaScript file and add the following imports on the top of the file:
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Imports & Constants"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -80,7 +80,7 @@ const universalProfileAddress = '0x...';
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Imports & Constants"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -105,7 +105,7 @@ In order to send any transaction on the blockchain you need an EOA. In our case 
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Initialise EOA"
 const account = web3.eth.accounts.wallet.add(privateKey);
@@ -113,7 +113,7 @@ const account = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Initialise EOA"
 const account = new ethers.Wallet(privateKey).connect(provider);
@@ -131,7 +131,7 @@ In order to transfer ownership of your Universal Profile, you need to initialize
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Create an instance of the old Key Manager"
 const universalProfile = new web3.eth.Contract(UniversalProfile.abi, universalProfileAddress);
@@ -139,7 +139,7 @@ const universalProfile = new web3.eth.Contract(UniversalProfile.abi, universalPr
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Create an instance of the old Key Manager"
 const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfile.abi);
@@ -157,7 +157,7 @@ Deploy a new LSP6 Key Manager with the latest updates.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Deploy a new Key Manager"
 const newKeyManager = new web3.eth.Contract(LSP6KeyManager.abi);
@@ -175,7 +175,7 @@ await newKeyManager
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Deploy a new Key Manager"
 const newKeyManager = await new ethers.ContractFactory(
@@ -198,7 +198,7 @@ Create a calldata for the [`transferOwnership(address)`](../../contracts/contrac
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Transfer ownership of the Universal Profile from the old Key Manager to the new one"
 await universalProfile.methods.transferOwnership(newKeyManager.address).send({
@@ -210,7 +210,7 @@ await universalProfile.methods.transferOwnership(newKeyManager.address).send({
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Transfer ownership of the Universal Profile from the old Key Manager to the new one"
 await universalProfile
@@ -230,7 +230,7 @@ Create a calldata for the [`acceptOwnership()`](../../contracts/contracts/LSP14O
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js title="Accept ownership of the Universal Profile via the new Key Manager"
 const acceptOwnershipCalldata = new web3.eth.Contract(UniversalProfile.abi).methods.acceptOwnership().encodeABI();
@@ -244,7 +244,7 @@ await newKeyManager.methods.execute(acceptOwnershipCalldata).send({
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```js title="Accept ownership of the Universal Profile via the new Key Manager"
 const acceptOwnershipCalldata = new ethers.Interface(UniversalProfile.abi).encodeFunctionData("acceptOwnership()");
@@ -268,7 +268,7 @@ The upgrade has been completed successfully.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -323,7 +323,7 @@ await upgradeLSP6();
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 <!-- prettier-ignore-start -->
 

--- a/docs/learn/key-manager/upgrade-key-manager.md
+++ b/docs/learn/key-manager/upgrade-key-manager.md
@@ -37,19 +37,19 @@ Make sure you have the following dependencies installed before beginning this tu
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```shell title="Install the dependencies"
-npm install web3 @lukso/lsp-smart-contracts
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```shell title="Install the dependencies"
+npm install web3 @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
@@ -64,21 +64,6 @@ Create a JavaScript file and add the following imports on the top of the file:
 - `universalProfileAddress`: address of your Universal Profile.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```js title="Imports & Constants"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
-import Web3 from 'web3';
-
-const web3 = new Web3('https://rpc.testnet.lukso.network');
-
-const privateKey = '0x...';
-const universalProfileAddress = '0x...';
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -96,6 +81,21 @@ const universalProfileAddress = '0x...';
 ```
 
   </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js title="Imports & Constants"
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
+import Web3 from 'web3';
+
+const web3 = new Web3('https://rpc.testnet.lukso.network');
+
+const privateKey = '0x...';
+const universalProfileAddress = '0x...';
+```
+
+  </TabItem>
 
 </Tabs>
 
@@ -104,19 +104,19 @@ const universalProfileAddress = '0x...';
 In order to send any transaction on the blockchain you need an EOA. In our case that account MUST have [**`CHANGEOWNER`**](../../standards/universal-profile/lsp6-key-manager.md#permissions) permission on the Universal Profile that will have its LSP6 Key Manager upgraded.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```js title="Initialise EOA"
-const account = web3.eth.accounts.wallet.add(privateKey);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
 ```js title="Initialise EOA"
 const account = new ethers.Wallet(privateKey).connect(provider);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js title="Initialise EOA"
+const account = web3.eth.accounts.wallet.add(privateKey);
 ```
 
   </TabItem>
@@ -127,35 +127,50 @@ const account = new ethers.Wallet(privateKey).connect(provider);
 
 In order to transfer ownership of your Universal Profile, you need to initialize the UP's contract.
 
-<!-- prettier-ignore-start -->
-
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```js title="Create an instance of the old Key Manager"
-const universalProfile = new web3.eth.Contract(UniversalProfile.abi, universalProfileAddress);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
 ```js title="Create an instance of the old Key Manager"
-const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfile.abi);
+const universalProfile = new ethers.Contract(
+  universalProfileAddress,
+  UniversalProfile.abi,
+);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```js title="Create an instance of the old Key Manager"
+const universalProfile = new web3.eth.Contract(
+  UniversalProfile.abi,
+  universalProfileAddress,
+);
 ```
 
   </TabItem>
 
 </Tabs>
 
-<!-- prettier-ignore-end -->
-
 ## Step 4 - Deploy the new LSP6 Key Manager
 
 Deploy a new LSP6 Key Manager with the latest updates.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```js title="Deploy a new Key Manager"
+const newKeyManager = await new ethers.ContractFactory(
+  LSP6KeyManager.abi,
+  LSP6KeyManager.bytecode,
+)
+  .connect(account)
+  .deploy(universalProfileAddress);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -175,19 +190,6 @@ await newKeyManager
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```js title="Deploy a new Key Manager"
-const newKeyManager = await new ethers.ContractFactory(
-  LSP6KeyManager.abi,
-  LSP6KeyManager.bytecode,
-)
-  .connect(account)
-  .deploy(universalProfileAddress);
-```
-
-  </TabItem>
-
 </Tabs>
 
 ## Step 5 - Upgrade your Key Manager
@@ -197,6 +199,16 @@ const newKeyManager = await new ethers.ContractFactory(
 Create a calldata for the [`transferOwnership(address)`](../../contracts/contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#transferownership) function and shift the ownership of your Universal Profile from your current LSP6 Key Manager.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```js title="Transfer ownership of the Universal Profile from the old Key Manager to the new one"
+await universalProfile
+  .connect(account)
+  .transferOwnership(newKeyManager.address);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -210,30 +222,34 @@ await universalProfile.methods.transferOwnership(newKeyManager.address).send({
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```js title="Transfer ownership of the Universal Profile from the old Key Manager to the new one"
-await universalProfile
-  .connect(account)
-  .transferOwnership(newKeyManager.address);
-```
-
-  </TabItem>
-
 </Tabs>
 
 ### Step 5.2 - Accept Ownership from your new Key Manager
 
 Create a calldata for the [`acceptOwnership()`](../../contracts/contracts/LSP14Ownable2Step/LSP14Ownable2Step.md#acceptownership) function and take the ownership of your Universal Profile from your new LSP6 Key Manager.
 
-<!-- prettier-ignore-start -->
-
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```js title="Accept ownership of the Universal Profile via the new Key Manager"
+const acceptOwnershipCalldata = new ethers.Interface(
+  UniversalProfile.abi,
+).encodeFunctionData('acceptOwnership()');
+
+await newKeyManager.connect(account).execute(acceptOwnershipCalldata);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
 ```js title="Accept ownership of the Universal Profile via the new Key Manager"
-const acceptOwnershipCalldata = new web3.eth.Contract(UniversalProfile.abi).methods.acceptOwnership().encodeABI();
+const acceptOwnershipCalldata = new web3.eth.Contract(
+  UniversalProfile.abi,
+).methods
+  .acceptOwnership()
+  .encodeABI();
 
 await newKeyManager.methods.execute(acceptOwnershipCalldata).send({
   from: account.address,
@@ -244,19 +260,7 @@ await newKeyManager.methods.execute(acceptOwnershipCalldata).send({
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```js title="Accept ownership of the Universal Profile via the new Key Manager"
-const acceptOwnershipCalldata = new ethers.Interface(UniversalProfile.abi).encodeFunctionData("acceptOwnership()");
-
-await newKeyManager.connect(account).execute(acceptOwnershipCalldata);
-```
-
-  </TabItem>
-
 </Tabs>
-
-<!-- prettier-ignore-end -->
 
 :::success 🥳
 
@@ -267,10 +271,58 @@ The upgrade has been completed successfully.
 ## Final code
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```js title="upgrade-lsp6.js"
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
+import { ethers } from 'ethers';
+
+const provider = new ethers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
+
+const privateKey = '0x...';
+const universalProfileAddress = '0x...';
+
+const upgradeLSP6 = async () => {
+  // Initialize the controller account
+  const account = new ethers.Wallet(privateKey).connect(provider);
+
+  // Initialize your current UP
+  const universalProfile = new ethers.Contract(
+    universalProfileAddress,
+    UniversalProfile.abi,
+  );
+
+  // Deploy a new LSP6 Key Manager
+  const newKeyManager = await new ethers.ContractFactory(
+    LSP6KeyManager.abi,
+    LSP6KeyManager.bytecode,
+  )
+    .connect(account)
+    .deploy(universalProfileAddress);
+
+  // Transfer the ownership of your Universal Profile from the current LSP6 Key Manager to a new LSP6 Key Manager
+  await universalProfile
+    .connect(account)
+    .transferOwnership(newKeyManager.address);
+
+  // Accept the ownership of your Universal Profile from the new LSP6 Key Manager
+  const acceptOwnershipCalldata = new ethers.Interface(
+    UniversalProfile.abi,
+  ).encodeFunctionData('acceptOwnership()');
+
+  await newKeyManager.connect(account).execute(acceptOwnershipCalldata);
+};
+
+await upgradeLSP6();
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
-
-<!-- prettier-ignore-start -->
 
 ```javascript title="upgrade-lsp6.js"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -286,18 +338,23 @@ const upgradeLSP6 = async () => {
   const account = web3.eth.accounts.wallet.add(privateKey);
 
   // Initialize your current UP
-  const universalProfile = new web3.eth.Contract(UniversalProfile.abi, universalProfileAddress);
+  const universalProfile = new web3.eth.Contract(
+    UniversalProfile.abi,
+    universalProfileAddress,
+  );
 
   // Deploy a new LSP6 Key Manager
   const newKeyManager = new web3.eth.Contract(LSP6KeyManager.abi);
-  await newKeyManager.deploy({
-    data: LSP6KeyManager.bytecode,
-    arguments: [universalProfileAddress],
-  }).send({
-    from: account.address,
-    gas: 3_000_000,
-    gasPrice: '1000000000',
-  });
+  await newKeyManager
+    .deploy({
+      data: LSP6KeyManager.bytecode,
+      arguments: [universalProfileAddress],
+    })
+    .send({
+      from: account.address,
+      gas: 3_000_000,
+      gasPrice: '1000000000',
+    });
 
   // Transfer the ownership of your Universal Profile from the current LSP6 Key Manager to a new LSP6 Key Manager
   await universalProfile.methods.transferOwnership(newKeyManager.address).send({
@@ -307,7 +364,11 @@ const upgradeLSP6 = async () => {
   });
 
   // Accept the ownership of your Universal Profile from the new LSP6 Key Manager
-  const acceptOwnershipCalldata = new web3.eth.Contract(UniversalProfile.abi).methods.acceptOwnership().encodeABI();
+  const acceptOwnershipCalldata = new web3.eth.Contract(
+    UniversalProfile.abi,
+  ).methods
+    .acceptOwnership()
+    .encodeABI();
 
   await newKeyManager.methods.execute(acceptOwnershipCalldata).send({
     from: account.address,
@@ -318,53 +379,6 @@ const upgradeLSP6 = async () => {
 
 await upgradeLSP6();
 ```
-
-<!-- prettier-ignore-end -->
-
-  </TabItem>
-
-  <TabItem value="ethers" label="ethers">
-
-<!-- prettier-ignore-start -->
-
-```js title="upgrade-lsp6.js"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
-import { ethers } from 'ethers';
-
-const provider = new ethers.JsonRpcProvider('https://rpc.testnet.lukso.network');
-
-const privateKey = '0x...';
-const universalProfileAddress = '0x...';
-
-const upgradeLSP6 = async () => {
-  // Initialize the controller account
-  const account = new ethers.Wallet(privateKey).connect(provider);
-
-  // Initialize your current UP
-  const universalProfile = new ethers.Contract(universalProfileAddress, UniversalProfile.abi);
-
-  // Deploy a new LSP6 Key Manager
-  const newKeyManager = await new ethers.ContractFactory(
-    LSP6KeyManager.abi,
-    LSP6KeyManager.bytecode,
-  ).connect(account).deploy(universalProfileAddress);
-
-  // Transfer the ownership of your Universal Profile from the current LSP6 Key Manager to a new LSP6 Key Manager
-  await universalProfile
-    .connect(account)
-    .transferOwnership(newKeyManager.address);
-
-  // Accept the ownership of your Universal Profile from the new LSP6 Key Manager
-  const acceptOwnershipCalldata = new ethers.Interface(UniversalProfile.abi).encodeFunctionData("acceptOwnership()");
-
-  await newKeyManager.connect(account).execute(acceptOwnershipCalldata);
-};
-
-await upgradeLSP6();
-```
-
-<!-- prettier-ignore-end -->
 
   </TabItem>
 
@@ -379,8 +393,6 @@ Create the following file with the name `test-new-lsp6.js` and run:
 node test-new-lsp6.js
 ```
 
-<!-- prettier-ignore-start -->
-
 ```javascript title="test-new-lsp6.js"
 import LSP0ERC725YAccount from '@lukso/lsp-smart-contracts/artifacts/LSP0ERC725YAccount.json';
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
@@ -391,22 +403,30 @@ const web3 = new Web3('https://rpc.testnet.lukso.network');
 const universalProfileAddress = '0x...';
 
 const testLSP6 = async () => {
-  const universalProfile = new web3.eth.Contract(LSP0ERC725YAccount.abi, universalProfileAddress);
+  const universalProfile = new web3.eth.Contract(
+    LSP0ERC725YAccount.abi,
+    universalProfileAddress,
+  );
 
   const universalProfileOwner = await universalProfile.methods.owner().call();
 
-  console.log(`The new owner of the Universal Profile is: ${universalProfileOwner}`);
+  console.log(
+    `The new owner of the Universal Profile is: ${universalProfileOwner}`,
+  );
   console.log(`The old LSP6 Key Manager is at address: ${keyManagerAdderss}`);
 
-  const keyManager = new web3.eth.Contract(LSP6KeyManager.abi, universalProfileOwner);
+  const keyManager = new web3.eth.Contract(
+    LSP6KeyManager.abi,
+    universalProfileOwner,
+  );
 
   const keyManagerTarget = await keyManager.methods.target().call();
 
-  console.log(`The address of the Universal Profile is: ${universalProfile._address}`);
+  console.log(
+    `The address of the Universal Profile is: ${universalProfile._address}`,
+  );
   console.log(`The target of the new LSP6 Key Manager: ${keyManagerTarget}`);
 };
 
 await testLSP6();
 ```
-
-<!-- prettier-ignore-end -->

--- a/docs/learn/universal-profile/connect-profile/connect-up.md
+++ b/docs/learn/universal-profile/connect-profile/connect-up.md
@@ -39,7 +39,37 @@ Using [EIP-6963 Provider Discovery](https://eips.ethereum.org/EIPS/eip-6963) is 
 
 You can listen to `eip6963:announceProvider` events following the [EIP-6963: Multi Injected Provider](https://eips.ethereum.org/EIPS/eip-6963) standardization to facilitate a more versatile connection to multiple wallet extensions. This method is beneficial for developers who require the ability to maintain low-level control over how different extensions are targeted and managed within their dApp.
 
+<Tabs groupId="provider-lib">
+  <TabItem value="ethers" label="ethers">
+
 ```js
+import { ethers } from 'ethers';
+
+let providers = [];
+
+window.addEventListener("eip6963:announceProvider", (event) => {
+  providers.push(event.detail);
+});
+
+// Request installed providers
+window.dispatchEvent(new Event("eip6963:requestProvider"));
+
+...
+
+// pick a provider to instantiate (providers[n].info)
+const provider = new ethers.BrowserProvider(providers[0].provider);
+
+const accounts = await provider.eth.requestAccounts();
+console.log('Connected with', accounts[0]);
+```
+
+  </TabItem>
+
+  <TabItem value="web3" label="web3">
+
+```js
+import Web3 from "web3";
+
 let providers = [];
 
 window.addEventListener("eip6963:announceProvider", (event) => {
@@ -58,6 +88,9 @@ const accounts = await provider.eth.requestAccounts();
 console.log('Connected with', accounts[0]);
 ```
 
+  </TabItem>
+</Tabs>
+
 :::tip Example Implementation
 
 If you want to implement _Injected Provider Discovery_ you can visit our [Example EIP-6963 Test dApp](https://github.com/lukso-network/example-eip-6963-test-dapp).
@@ -73,7 +106,7 @@ You can use third-party libraries to connect to various wallet extensions with e
 
 Both libraries come with built-in UI elements and allow you to support multiple extensions without them all supporting [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963).
 
-<Tabs groupId="wallet-lib">
+<Tabs groupId="provider-lib">
 <TabItem value="walletconnect" label="Wallet Connect" default>
 
 <table>
@@ -120,7 +153,7 @@ You can check out the implementation of both libraries within our [dApp Boilerpl
 
 ### Installation
 
-<Tabs groupId="wallet-lib">
+<Tabs groupId="provider-lib">
 <TabItem value="walletconnect" label="Wallet Connect" default>
 
 You can install the Web3 Modal using [different configurations](https://docs.walletconnect.com/web3modal/javascript/about). The default package utilizes the Ethers.js library, which will be used in this example:
@@ -145,7 +178,7 @@ npm i @web3-onboard/core @lukso/web3-onboard-config @web3-onboard/injected-walle
 
 After the installation, you can proceed to configure the library to support the LUKSO network and your dApp.
 
-<Tabs groupId="wallet-lib">
+<Tabs groupId="provider-lib">
 <TabItem value="walletconnect" label="Wallet Connect" default>
 
 ```js
@@ -330,7 +363,7 @@ const web3OnboardComponent: OnboardAPI = Onboard({
 
 ### Connect
 
-<Tabs groupId="wallet-lib">
+<Tabs groupId="provider-lib">
 <TabItem value="walletconnect" label="Wallet Connect">
 
 To set and access the Wallet Connect provider within your dApp, you can call the integrated `open()` method provided by the `createWeb3Modal` instance. The library will show a connection window with all supported wallets. You can then fetch the active account and set it as the default provider within your dApp.
@@ -419,7 +452,7 @@ if (connectedWallets.length > 0) {
 
 ### Disconnect
 
-<Tabs groupId="wallet-lib">
+<Tabs groupId="provider-lib">
 <TabItem value="walletconnect" label="Wallet Connect">
 
 To disconnect your wallet, you have to call the `disconnect()` method provided by the `createWeb3Modal` instance.

--- a/docs/learn/universal-profile/connect-profile/connect-up.md
+++ b/docs/learn/universal-profile/connect-profile/connect-up.md
@@ -336,7 +336,7 @@ const web3OnboardComponent: OnboardAPI = Onboard({
 To set and access the Wallet Connect provider within your dApp, you can call the integrated `open()` method provided by the `createWeb3Modal` instance. The library will show a connection window with all supported wallets. You can then fetch the active account and set it as the default provider within your dApp.
 
 <Tabs groupId="provider-lib">
-<TabItem value="ethersjs" label="ethers.js" default>
+<TabItem value="ethers" label="ethers" default>
 
 ```js
 // Trigger the connection process and screen
@@ -358,7 +358,7 @@ walletConnectInstance.subscribeProvider(
 ```
 
   </TabItem>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js
 // Trigger the connection process and screen
@@ -388,7 +388,7 @@ walletConnectInstance.subscribeProvider(
 To set and access the Web3-Onboard provider within your dApp, you can call the integrated `connectWallet()` method provided by the `@web3-onboard/core` library. The library will show a connection window with all supported wallets. You can then fetch the active account and set it as the default provider within your dApp.
 
 <Tabs groupId="provider-lib">
-<TabItem value="ethersjs" label="ethers.js" default>
+<TabItem value="ethers" label="ethers" default>
 
 ```js
 // Trigger the connection process and screen
@@ -400,7 +400,7 @@ if (connectedWallets.length > 0) {
 ```
 
   </TabItem>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```js
 // Trigger the connection process and screen
@@ -506,16 +506,14 @@ Alternatively to the `window.lukso`, the equivalent `window.ethereum` object can
   <TabItem value="ethers" label="ethers">
 
 ```js
-const providerObject = window.lukso || window.ethereum;
-const provider = new ethers.BrowserProvider(providerObject);
+const provider = new ethers.BrowserProvider(window.lukso || window.ethereum);
 ```
 
   </TabItem>
   <TabItem value="web3" label="web3">
 
 ```js
-const providerObject = window.lukso || window.ethereum;
-const provider = new Web3(providerObject);
+const provider = new Web3(window.lukso || window.ethereum);
 ```
 
   </TabItem>

--- a/docs/learn/universal-profile/interactions/interact-with-contracts.md
+++ b/docs/learn/universal-profile/interactions/interact-with-contracts.md
@@ -38,7 +38,7 @@ To complete this guide, we will need some initial constants values and install s
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
@@ -46,7 +46,7 @@ npm install web3 @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell
 npm install ethers @lukso/lsp-smart-contracts
@@ -77,7 +77,7 @@ Below you will find some examples to perform the following:
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="mintTokens.ts"
 import Web3 from 'web3';
@@ -115,7 +115,7 @@ console.log('🏦 Balance: ', balance.toString());
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="mintTokens.ts"
 import { ethers } from 'ethers';
@@ -165,7 +165,7 @@ console.log('🏦 Balance: ', balance.toString());
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="refineBurntPix.ts"
 import Web3 from 'web3';
@@ -217,7 +217,7 @@ await contract.methods.refine(BURNT_PIX_ID, "500").send({
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="refineBurntPix.ts"
 import { ethers } from 'ethers';

--- a/docs/learn/universal-profile/interactions/interact-with-contracts.md
+++ b/docs/learn/universal-profile/interactions/interact-with-contracts.md
@@ -37,19 +37,19 @@ To complete this guide, we will need some initial constants values and install s
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```shell
+npm install ethers @lukso/lsp-smart-contracts
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
-```
-
-  </TabItem>
-
-  <TabItem value="ethers" label="ethers.js">
-
-```shell
-npm install ethers @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
@@ -76,6 +76,41 @@ Below you will find some examples to perform the following:
 </div>
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="mintTokens.ts"
+import { ethers } from 'ethers';
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
+
+const TOKEN_CONTRACT_ADDRESS = '0x...';
+
+await ethers.provider.send('eth_requestAccounts', []);
+const universalProfile = await ethers.getSigner();
+
+const myToken = new ethers.Contract(TOKEN_CONTRACT_ADDRESS, LSP7Mintable.abi);
+
+// mint 100 tokens
+const amount = ethers.parseUnits('100', 'ether');
+
+const mintTxn = await myToken.mint(
+  universalProfile.address, // recipient address
+  amount, // token amount
+  true, // force parameter
+  '0x', // additional data
+  {
+    from: universalProfile,
+  },
+);
+console.log(mintTxn);
+
+// Waiting 10sec to make sure the minting transaction has been processed
+
+const balance = await myToken.balanceOf(signer.address);
+console.log('🏦 Balance: ', balance.toString());
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -114,41 +149,6 @@ console.log('🏦 Balance: ', balance.toString());
 ```
 
   </TabItem>
-  
-  <TabItem value="ethers" label="ethers.js">
-
-```typescript title="mintTokens.ts"
-import { ethers } from 'ethers';
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
-
-const TOKEN_CONTRACT_ADDRESS = '0x...';
-
-await ethers.provider.send('eth_requestAccounts', []);
-const universalProfile = await ethers.getSigner();
-
-const myToken = new ethers.Contract(TOKEN_CONTRACT_ADDRESS, LSP7Mintable.abi);
-
-// mint 100 tokens
-const amount = ethers.parseUnits('100', 'ether');
-
-const mintTxn = await myToken.mint(
-  universalProfile.address, // recipient address
-  amount, // token amount
-  true, // force parameter
-  '0x', // additional data
-  {
-    from: universalProfile,
-  },
-);
-console.log(mintTxn);
-
-// Waiting 10sec to make sure the minting transaction has been processed
-
-const balance = await myToken.balanceOf(signer.address);
-console.log('🏦 Balance: ', balance.toString());
-```
-
-  </TabItem>
 
 </Tabs>
 
@@ -164,6 +164,40 @@ console.log('🏦 Balance: ', balance.toString());
 </div>
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="refineBurntPix.ts"
+import { ethers } from 'ethers';
+
+// Constants:
+//  - BurntPix Registry contract to interact with
+const BURNT_PIX_REGISTRY_ADDRESS = "0x3983151E0442906000DAb83c8b1cF3f2D2535F82";
+
+//  - bytes32 ID of the BurntPix to refine
+const BURNT_PIX_ID "0x0000000000000000000000000a3c1ed77de72af03acfaeab282a06e6fbeed5a8";
+
+// 1. Connect to UP Browser Extension
+const provider = new ethers.BrowserProvider(window.lukso);
+
+const accounts = await provider.send('eth_requestAccounts', []);
+const universalProfile = accounts[0];
+
+// 2. Create an instance of the BurntPix Registry contract
+const burntPixRegistry = new ethers.Contract(
+  BURNT_PIX_REGISTRY_ADDRESS,
+  ["function refine(bytes32 tokenId, uint256 iterations) external"]
+);
+
+// Perform 500 iteration to refine a specific Burnt Pix
+await contract.refine(BURNT_PIX_ID, "500", {
+  from: universalProfile,
+  gasPrice: ethers.formatUnits("1", 'gwei'),
+  gasLimit: 15_000_000,
+});
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -211,40 +245,6 @@ const burntPixRegistry = new web3.eth.Contract(
 await contract.methods.refine(BURNT_PIX_ID, "500").send({
   from: universalProfile,
   gasPrice: web3.utils.fromWei("1000000000", 'gwei'),
-  gasLimit: 15_000_000,
-});
-```
-
-  </TabItem>
-  
-  <TabItem value="ethers" label="ethers.js">
-
-```typescript title="refineBurntPix.ts"
-import { ethers } from 'ethers';
-
-// Constants:
-//  - BurntPix Registry contract to interact with
-const BURNT_PIX_REGISTRY_ADDRESS = "0x3983151E0442906000DAb83c8b1cF3f2D2535F82";
-
-//  - bytes32 ID of the BurntPix to refine
-const BURNT_PIX_ID "0x0000000000000000000000000a3c1ed77de72af03acfaeab282a06e6fbeed5a8";
-
-// 1. Connect to UP Browser Extension
-const provider = new ethers.BrowserProvider(window.lukso);
-
-const accounts = await provider.send('eth_requestAccounts', []);
-const universalProfile = accounts[0];
-
-// 2. Create an instance of the BurntPix Registry contract
-const burntPixRegistry = new ethers.Contract(
-  BURNT_PIX_REGISTRY_ADDRESS,
-  ["function refine(bytes32 tokenId, uint256 iterations) external"]
-);
-
-// Perform 500 iteration to refine a specific Burnt Pix
-await contract.refine(BURNT_PIX_ID, "500", {
-  from: universalProfile,
-  gasPrice: ethers.formatUnits("1", 'gwei'),
   gasLimit: 15_000_000,
 });
 ```

--- a/docs/learn/universal-profile/interactions/transfer-lsp7-token.md
+++ b/docs/learn/universal-profile/interactions/transfer-lsp7-token.md
@@ -36,14 +36,14 @@ The following code snippets require the installation of the following libraries:
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell
 npm install ethers @lukso/lsp-smart-contracts
@@ -64,7 +64,7 @@ You will need:
 After setting up the contracts, you can set up the parameters for the LSP7 token [`transfer(...)`](https://docs.lukso.tech/contracts/contracts/LSP7DigitalAsset/#transfer) function.
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -96,7 +96,7 @@ await myToken.methods
 <!-- prettier-ignore-end -->
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 <!-- prettier-ignore-start -->
 

--- a/docs/learn/universal-profile/interactions/transfer-lsp7-token.md
+++ b/docs/learn/universal-profile/interactions/transfer-lsp7-token.md
@@ -36,17 +36,17 @@ The following code snippets require the installation of the following libraries:
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs groupId="web3-lib">
+  <TabItem value="ethers" label="ethers">
+
+```shell
+npm install ethers @lukso/lsp-smart-contracts
+```
+
+  </TabItem>
   <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
-```
-
-  </TabItem>
-  <TabItem value="ethers" label="ethers.js">
-
-```shell
-npm install ethers @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
@@ -64,9 +64,34 @@ You will need:
 After setting up the contracts, you can set up the parameters for the LSP7 token [`transfer(...)`](https://docs.lukso.tech/contracts/contracts/LSP7DigitalAsset/#transfer) function.
 
 <Tabs groupId="web3-lib">
-  <TabItem value="web3" label="web3">
+  <TabItem value="ethers" label="ethers">
 
-<!-- prettier-ignore-start -->
+```js
+import { ethers } from 'ethers';
+
+// Import smart contract ABI
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
+
+const provider = new ethers.BrowserProvider(window.lukso);
+
+await provider.send('eth_requestAccounts', []);
+
+const signer = await provider.getSigner();
+
+// Instanciate the token with an address
+const myToken = new ethers.Contract('0x...', LSP7Mintable.abi);
+
+await myToken.transfer(
+  signer.getAddress(), // sender address
+  '0x...', // recipient's address
+  15, // amount of tokens
+  false, // force flag
+  '0x', // data
+);
+```
+
+  </TabItem>
+  <TabItem value="web3" label="web3">
 
 ```js
 import Web3 from 'web3';
@@ -93,38 +118,6 @@ await myToken.methods
   .send({ from: accounts[0] });
 ```
 
-<!-- prettier-ignore-end -->
-
   </TabItem>
-  <TabItem value="ethers" label="ethers.js">
-
-<!-- prettier-ignore-start -->
-
-```js
-import { ethers } from 'ethers';
-
-// Import smart contract ABI
-import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json';
-
-const provider = new ethers.BrowserProvider(window.lukso);
-
-await provider.send("eth_requestAccounts", []);
-
-const signer = await provider.getSigner();
-
-// Instanciate the token with an address
-const myToken = new ethers.Contract('0x...', LSP7Mintable.abi);
-
-await myToken.transfer(
-  signer.getAddress(), // sender address
-  '0x...', // recipient's address
-  15, // amount of tokens
-  false, // force flag
-  '0x', // data
-);
-```
-
-<!-- prettier-ignore-end -->
-
-  </TabItem>
+  
 </Tabs>

--- a/docs/learn/universal-profile/interactions/transfer-lyx.md
+++ b/docs/learn/universal-profile/interactions/transfer-lyx.md
@@ -36,18 +36,18 @@ No need to make contract calls to instruct the smart contract of the Universal P
 
 <Tabs groupId="web3-lib">
   
-  <TabItem value="web3" label="web3">
-
-```shell
-npm install web3@v1
-```
-
-  </TabItem>
-
   <TabItem value="ethers" label="ethers">
 
 ```shell
 npm install ethers
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```shell
+npm install web3@v1
 ```
 
   </TabItem>
@@ -57,10 +57,30 @@ npm install ethers
 ## Code Examples
 
 <Tabs groupId="web3-lib">
+
+ <TabItem value="ethers" label="ethers">
+
+```js
+import { ethers } from 'ethers';
+
+const provider = new ethers.BrowserProvider(window.lukso);
+
+await provider.send('eth_requestAccounts', []);
+
+const signer = await provider.getSigner();
+const account = await signer.getAddress();
+
+// Send transaction
+const tx = await signer.sendTransaction({
+  from: account, // The Universal Profile address
+  to: '0x...', // Receiving address, can be a UP or EOA
+  value: ethers.parseEther('0.5'), // 0.5 amount in ETH, in wei unit
+});
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
-
-<!-- prettier-ignore-start -->
 
 ```js
 import Web3 from 'web3';
@@ -71,37 +91,11 @@ await web3.eth.requestAccounts();
 const accounts = await web3.eth.getAccounts();
 
 await web3.eth.sendTransaction({
-    from: accounts[0],                      // The Universal Profile address
-    to: '0x...',                            // receiving address, can be a UP or EOA
-    value: web3.utils.toWei('0.5', 'ether') // 0.5 amount in ETH, in wei unit
-})
-```
-<!-- prettier-ignore-end -->
-
-  </TabItem>
-
-  <TabItem value="ethers" label="ethers">
-
-<!-- prettier-ignore-start -->
-
-```js
-import { ethers } from 'ethers';
-
-const provider = new ethers.BrowserProvider(window.lukso);
-
-await provider.send("eth_requestAccounts", []);
-
-const signer = await provider.getSigner();
-const account = await signer.getAddress();
-
-// Send transaction
-const tx = await signer.sendTransaction({
-    from: account,                        // The Universal Profile address
-    to: '0x...',                          // Receiving address, can be a UP or EOA
-    value: ethers.parseEther('0.5') // 0.5 amount in ETH, in wei unit
+  from: accounts[0], // The Universal Profile address
+  to: '0x...', // receiving address, can be a UP or EOA
+  value: web3.utils.toWei('0.5', 'ether'), // 0.5 amount in ETH, in wei unit
 });
 ```
-<!-- prettier-ignore-end -->
 
   </TabItem>
 

--- a/docs/learn/universal-profile/interactions/transfer-lyx.md
+++ b/docs/learn/universal-profile/interactions/transfer-lyx.md
@@ -36,7 +36,7 @@ No need to make contract calls to instruct the smart contract of the Universal P
 
 <Tabs groupId="web3-lib">
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3@v1
@@ -44,7 +44,7 @@ npm install web3@v1
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell
 npm install ethers
@@ -58,7 +58,7 @@ npm install ethers
 
 <Tabs groupId="web3-lib">
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -80,7 +80,7 @@ await web3.eth.sendTransaction({
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 <!-- prettier-ignore-start -->
 

--- a/docs/learn/universal-profile/metadata/read-profile-data.md
+++ b/docs/learn/universal-profile/metadata/read-profile-data.md
@@ -9,6 +9,16 @@ import TabItem from '@theme/TabItem';
 
 # Read Data from your Universal Profile
 
+:::success 💡 Tips
+
+Take advantage of our [ERC725 inspect](https://erc725-inspect.lukso.tech) tool!
+
+You can retrieve data from your Universal Profile easily with the [🔍 Data Fetcher](https://erc725-inspect.lukso.tech/data-fetcher) or [🔎 Inspector](https://erc725-inspect.lukso.tech/data-fetcher) tools.
+
+Simply paste your Universal Profile address in the search field and choose the data key to retrieve data from. The value stored will be returned both as encoded and decoded.
+
+:::
+
 ## Install [erc725.js](https://npmjs.com/package/@erc725/erc725.js) library
 
 ```shell
@@ -32,50 +42,19 @@ The parameters to provide to the erc725 instance are:
 - Univeral Profile address: the address of the Universal Profile you want to retrieve data from.
 - Optional only for retrieving decoded data: RPC provider (web3, ethereum, ethers) or plain RPC url of [mainnet](../../../networks/mainnet/parameters.md) or [testnet](../../../networks/testnet/parameters.md) networks.
 
-<Tabs>
-
-  <TabItem value="javascript" label="JavaScript">
-
-<!-- prettier-ignore-start -->
-
 ```js title="Creating an erc725 instance to read data from a Universal Profile"
 import { ERC725 } from '@erc725/erc725.js';
 import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(
   profileSchema,
-  "0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e", // Universal Profile address
-  "https://rpc.testnet.lukso.network",
+  '0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e', // Universal Profile address
+  'https://rpc.testnet.lukso.network',
   {
     ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
   },
 );
 ```
-
-<!-- prettier-ignore-end -->
-
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
-
-<!-- prettier-ignore-start -->
-
-```ts title="Creating an erc725 instance to read data from a Universal Profile"
-import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
-import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
-
-const erc725js = new ERC725(
-  profileSchema as ERC725JSONSchema[], 
-  "0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e", // Universal Profile address
-  "https://rpc.testnet.lukso.network",
-  {
-    ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
-  },
-);
-```
-<!-- prettier-ignore-end -->
-
-  </TabItem>
-</Tabs>
 
 ## Retrieve encoded data
 
@@ -84,16 +63,16 @@ const erc725js = new ERC725(
 `await erc725js.getData()`
 
 ```js title="Get the encoded profile data"
-import { ERC725, ERC725JSONSchema } from "@erc725/erc725.js";
-import profileSchema from "@erc725/erc725.js/schemas/LSP3ProfileMetadata.json";
+import { ERC725 } from '@erc725/erc725.js';
+import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(
-  profileSchema as ERC725JSONSchema[],
-  "0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e",
-  "https://rpc.testnet.lukso.network",
+  profileSchema,
+  '0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e',
+  'https://rpc.testnet.lukso.network',
   {
-  ipfsGateway: "https://api.universalprofile.cloud/ipfs/",
-  }
+    ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
+  },
 );
 
 const encodedProfileData = await erc725js.getData();
@@ -152,21 +131,21 @@ Main data keys for retrieving specific data:
 Find all data keys on the [ERC725Y Inspect](https://erc725-inspect.lukso.tech/data-fetcher) tool or in the [erc725 repo](https://github.com/ERC725Alliance/erc725.js/tree/develop/schemas).
 
 ```js title="Get data of the LSP3Profile and LSP1UniversalReceiverDelegate data keys"
-import { ERC725, ERC725JSONSchema } from "@erc725/erc725.js";
-import profileSchema from "@erc725/erc725.js/schemas/LSP3ProfileMetadata.json";
+import { ERC725 } from '@erc725/erc725.js';
+import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(
-  profileSchema as ERC725JSONSchema[],
-  "0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e",
-  "https://rpc.testnet.lukso.network",
+  profileSchema,
+  '0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e',
+  'https://rpc.testnet.lukso.network',
   {
-    ipfsGateway: "https://api.universalprofile.cloud/ipfs/",
-  }
+    ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
+  },
 );
 
 const specificProfileData = await erc725js.getData([
-  "LSP3Profile",
-  "LSP1UniversalReceiverDelegate",
+  'LSP3Profile',
+  'LSP1UniversalReceiverDelegate',
 ]);
 ```
 
@@ -201,21 +180,19 @@ const specificProfileData = await erc725js.getData([
 Example to retrieve the content of the JSON file from the verifiable URI stored on the smart contract. It will download the JSON file and verify its hash automatically.
 
 ```js title="Get all profile metadata"
-import { ERC725, ERC725JSONSchema } from "@erc725/erc725.js";
-import profileSchema from "@erc725/erc725.js/schemas/LSP3ProfileMetadata.json";
+import { ERC725 } from '@erc725/erc725.js';
+import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(
-  profileSchema as ERC725JSONSchema[],
-  "0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e",
-  "https://rpc.testnet.lukso.network",
+  profileSchema,
+  '0x03B2689E4843ca56B2A933e7eC1E1ee6C3e6982e',
+  'https://rpc.testnet.lukso.network',
   {
-  ipfsGateway: "https://api.universalprofile.cloud/ipfs/",
-  }
+    ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
+  },
 );
 
-  const decodedProfileMetadata = await erc725js.fetchData([
-    "LSP3Profile",
-  ]);
+const decodedProfileMetadata = await erc725js.fetchData(['LSP3Profile']);
 ```
 
 <details>
@@ -243,22 +220,22 @@ const erc725js = new ERC725(
 </details>
 
 ```js title="Get issued and received assets"
-import { ERC725, ERC725JSONSchema } from "@erc725/erc725.js";
-import profileSchema from "@erc725/erc725.js/schemas/LSP3ProfileMetadata.json";
+import { ERC725 } from '@erc725/erc725.js';
+import profileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 
 const erc725js = new ERC725(
-  profileSchema as ERC725JSONSchema[],
-  "0xFF7E89acaBce3ed97Ed528288D3b8F113557A8c8",
-  "https://rpc.testnet.lukso.network",
+  profileSchema,
+  '0xFF7E89acaBce3ed97Ed528288D3b8F113557A8c8',
+  'https://rpc.testnet.lukso.network',
   {
-  ipfsGateway: "https://api.universalprofile.cloud/ipfs/",
-  }
+    ipfsGateway: 'https://api.universalprofile.cloud/ipfs/',
+  },
 );
 
-  const decodedIssuedAndRetrievedAssetAddresses = await erc725js.fetchData([
-    "LSP12IssuedAssets[]","LSP5ReceivedAssets[]"
-  ]);
-
+const decodedIssuedAndRetrievedAssetAddresses = await erc725js.fetchData([
+  'LSP12IssuedAssets[]',
+  'LSP5ReceivedAssets[]',
+]);
 ```
 
 <details>
@@ -291,7 +268,3 @@ const erc725js = new ERC725(
 ```
 
 </details>
-
-## Take advantage of our ERC725 inspect tool
-
-🔍 You can retrieve encoded Universal Profile data easily with our [ERC725 Inspect](https://erc725-inspect.lukso.tech/data-fetcher) tool. You only have to paste your Universal Profile address and choose the data key to retrieve data from.

--- a/docs/learn/universal-profile/metadata/register-lsp12-issued-assets.md
+++ b/docs/learn/universal-profile/metadata/register-lsp12-issued-assets.md
@@ -37,14 +37,14 @@ The following code snippets require the installation of the following libraries:
 - [`@erc725/erc725.js`](https://github.com/ERC725Alliance/erc725.js/)
 
 <Tabs groupId="web3-lib">
-  <TabItem value="ethersjs" label="ethers.js" default>
+  <TabItem value="ethers" label="ethers" default>
 
 ```shell
 npm install ethers @lukso/lsp-smart-contracts @erc725/erc725.js
 ```
 
   </TabItem>
-    <TabItem value="web3js" label="web3.js">
+    <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
@@ -58,7 +58,7 @@ npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
 Import `web3.js`/`ethers`, the [`UniversalProfile`](../../../contracts/contracts/UniversalProfile.md) ABI from [`@lukso/lsp-smart-contracts`](../../../contracts/introduction.md) and create an instance of this contract with the `UNIVERSAL_PROFILE_ADDRESS`.
 
 <Tabs groupId="web3-lib">
-  <TabItem value="ethersjs" label="ethers.js" default>
+  <TabItem value="ethers" label="ethers" default>
 
 ```javascript
 import { ethers } from 'ethers';
@@ -95,7 +95,7 @@ const myWallet = await provider.getSigner();
 ```
 
   </TabItem>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript
 import Web3 from 'web3';
@@ -245,7 +245,7 @@ const { keys: lsp12DataKeys, values: lsp12Values } = erc725.encodeData([
 Create an instance of the Universal Profile contract to read or set the issued assets on:
 
 <Tabs groupId="web3-lib">
-  <TabItem value="ethersjs" label="ethers.js" default>
+  <TabItem value="ethers" label="ethers" default>
 
 ```javascript
 const myUPContract = new ethers.Contract(
@@ -256,7 +256,7 @@ const myUPContract = new ethers.Contract(
 ```
 
   </TabItem>
-    <TabItem value="web3js" label="web3.js">
+    <TabItem value="web3" label="web3">
 
 ```javascript
 const myUPContract = new web3.eth.Contract(
@@ -273,14 +273,14 @@ const myUPContract = new web3.eth.Contract(
 Next, use the `setDataBatch(...)` function of the Universal Profile to initially set or update multiple data keys.
 
 <Tabs groupId="web3-lib">
-    <TabItem value="ethersjs" label="ethers.js" default>
+    <TabItem value="ethers" label="ethers" default>
 
 ```javascript
 await myUPContract.setDataBatch(lsp12DataKeys, lsp12Values);
 ```
 
   </TabItem>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```javascript
 await myUPContract.methods

--- a/docs/learn/universal-receiver/accept-reject-assets.md
+++ b/docs/learn/universal-receiver/accept-reject-assets.md
@@ -110,7 +110,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts
@@ -118,7 +118,7 @@ npm install web3 @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
@@ -136,7 +136,7 @@ Then we will initialize the controller address.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Imports, Constants & EOA"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -156,7 +156,7 @@ const EOA = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Imports, Constants & EOA"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -186,7 +186,7 @@ At this point we need to create an instance of the [**Universal Profile**](../..
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Contract instance for the Universal Profile"
 // create an instance of the Universal Profile
@@ -198,7 +198,7 @@ const universalProfile = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Contract instance for the Universal Profile"
 // create an instance of the Universal Profile
@@ -218,7 +218,7 @@ Finally, we need to send the transaction that will update the URD of the Univers
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Update the Universal Profile data"
 // Update the profile data
@@ -232,7 +232,7 @@ await universalProfile.methods
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Update the Universal Profile data"
 // Update the profile data
@@ -249,7 +249,7 @@ await universalProfile
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Update the Universal Profile URD"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -283,7 +283,7 @@ await universalProfile.methods
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Update the Universal Profile URD"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';

--- a/docs/learn/universal-receiver/accept-reject-assets.md
+++ b/docs/learn/universal-receiver/accept-reject-assets.md
@@ -109,19 +109,19 @@ Make sure you have the following dependencies installed before beginning this tu
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```shell title="Install the dependencies"
-npm install web3 @lukso/lsp-smart-contracts
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```shell title="Install the dependencies"
+npm install web3 @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
@@ -135,26 +135,6 @@ After that we need to store the address of our Universal Profile and the new URD
 Then we will initialize the controller address.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```typescript title="Imports, Constants & EOA"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
-import Web3 from 'web3';
-
-// constants
-const web3 = new Web3('https://rpc.testnet.lukso.network');
-const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
-const universalProfileAddress = '0x...';
-const universalProfileURDAddress = '0x...';
-
-// setup your EOA
-const privateKey = '0x...';
-const EOA = web3.eth.accounts.wallet.add(privateKey);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -177,6 +157,26 @@ const EOA = new ethers.Wallet(privateKey).connect(provider);
 ```
 
   </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```typescript title="Imports, Constants & EOA"
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
+import Web3 from 'web3';
+
+// constants
+const web3 = new Web3('https://rpc.testnet.lukso.network');
+const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
+const universalProfileAddress = '0x...';
+const universalProfileURDAddress = '0x...';
+
+// setup your EOA
+const privateKey = '0x...';
+const EOA = web3.eth.accounts.wallet.add(privateKey);
+```
+
+  </TabItem>
 
 </Tabs>
 
@@ -185,18 +185,6 @@ const EOA = new ethers.Wallet(privateKey).connect(provider);
 At this point we need to create an instance of the [**Universal Profile**](../../standards/universal-profile/lsp0-erc725account.md) contract:
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```typescript title="Contract instance for the Universal Profile"
-// create an instance of the Universal Profile
-const universalProfile = new web3.eth.Contract(
-  UniversalProfile.abi,
-  universalProfileAddress,
-);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -205,6 +193,18 @@ const universalProfile = new web3.eth.Contract(
 const universalProfile = new ethers.Contract(
   universalProfileAddress,
   UniversalProfile.abi,
+);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```typescript title="Contract instance for the Universal Profile"
+// create an instance of the Universal Profile
+const universalProfile = new web3.eth.Contract(
+  UniversalProfile.abi,
+  universalProfileAddress,
 );
 ```
 
@@ -217,6 +217,17 @@ const universalProfile = new ethers.Contract(
 Finally, we need to send the transaction that will update the URD of the Universal Profile.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Update the Universal Profile data"
+// Update the profile data
+await universalProfile
+  .connect(EOA)
+  .setData(URD_DATA_KEY, universalProfileURDAddress);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -232,22 +243,44 @@ await universalProfile.methods
 
   </TabItem>
 
+</Tabs>
+
+### Final code
+
+<Tabs>
+
   <TabItem value="ethers" label="ethers">
 
-```typescript title="Update the Universal Profile data"
-// Update the profile data
+```typescript title="Update the Universal Profile URD"
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
+import { ethers } from 'ethers';
+
+// constants
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
+const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
+const universalProfileAddress = '0x...';
+const universalProfileURDAddress = '0x...';
+
+// setup your EOA
+const privateKey = '0x...'; // your EOA private key (controller address)
+const EOA = new ethers.Wallet(privateKey).connect(provider);
+
+// create an instance of the Universal Profile
+const universalProfile = new ethers.Contract(
+  universalProfileAddress,
+  UniversalProfile.abi,
+);
+
+// execute the executeCalldata on the Key Manager
 await universalProfile
   .connect(EOA)
   .setData(URD_DATA_KEY, universalProfileURDAddress);
 ```
 
   </TabItem>
-
-</Tabs>
-
-### Final code
-
-<Tabs>
   
   <TabItem value="web3" label="web3">
 
@@ -283,39 +316,6 @@ await universalProfile.methods
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Update the Universal Profile URD"
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts/constants.js';
-import { ethers } from 'ethers';
-
-// constants
-const provider = new ethers.providers.JsonRpcProvider(
-  'https://rpc.testnet.lukso.network',
-);
-const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
-const universalProfileAddress = '0x...';
-const universalProfileURDAddress = '0x...';
-
-// setup your EOA
-const privateKey = '0x...'; // your EOA private key (controller address)
-const EOA = new ethers.Wallet(privateKey).connect(provider);
-
-// create an instance of the Universal Profile
-const universalProfile = new ethers.Contract(
-  universalProfileAddress,
-  UniversalProfile.abi,
-);
-
-// execute the executeCalldata on the Key Manager
-await universalProfile
-  .connect(EOA)
-  .setData(URD_DATA_KEY, universalProfileURDAddress);
-```
-
-  </TabItem>
-
 </Tabs>
 
 ## Accepting specific Assets
@@ -324,7 +324,7 @@ To accept specific assets, you should differentiate between the different assets
 
 Repeat the deployment steps in **[Rejecting all Assets](#rejecting-all-assets)** section and replace the solidity code with the one written below.
 
-```sol title="Solidity Code snippet of the Custom URD that accept specific assets"
+```solidity title="Solidity Code snippet of the Custom URD that accept specific assets"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 

--- a/docs/learn/universal-receiver/deploy-universal-receiver.md
+++ b/docs/learn/universal-receiver/deploy-universal-receiver.md
@@ -49,7 +49,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
@@ -57,7 +57,7 @@ npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts @erc725/erc725.js
@@ -77,7 +77,7 @@ We need to;
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Imports, Constants & EOA"
 import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
@@ -100,7 +100,7 @@ const EOA = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Imports, Constants & EOA"
 import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
@@ -140,7 +140,7 @@ At this step we will create an instance of the Universal profile URD that we wil
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Contract instance of the Universal Profile URD"
 // create an instance of the LSP1UniversalReceiverDelegateUP
@@ -151,7 +151,7 @@ let universalProfileURD = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Contract instance of the Universal Profile URD"
 // create a LSP1UniversalReceiverDelegateUP Contract Factory
@@ -171,7 +171,7 @@ Send the deployment transaction to get a newly deployed URD.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Send the transaction for deploying a new Universal Profile URD"
 // deploy the Universal Receiver Delegate UP contract
@@ -188,7 +188,7 @@ await universalProfileURD
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Send the transaction for deploying a new Universal Profile URD"
 // deploy the Universal Receiver Delegate UP contract
@@ -205,7 +205,7 @@ const universalProfileURD = await universalProfileURDFactory
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Deploy a Universal Receiver Delegate for the Universal Profile"
 const deployUniversalProfileURD = async () => {
@@ -238,7 +238,7 @@ const universalProfileURDAddress = await deployUniversalProfileURD();
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Deploy a Universal Receiver Delegate for the Universal Profile"
 const deployUniversalProfileURD = async () => {
@@ -274,7 +274,7 @@ Firstly we need to create an instance for the [**Universal Profile**](../../stan
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Contract instance for the Universal Profile"
 // create an instance of the Universal Profile
@@ -286,7 +286,7 @@ const universalProfile = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Contract instance for the Universal Profile"
 // create an instance of the Universal Profile
@@ -306,7 +306,7 @@ Generate _Data Keys & Values_ for [**adding a URD**](../../standards/generic-sta
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Encode Data Keys & Values for updating the URD and its permissions"
 import { ERC725 } from '@erc725/erc725.js';
@@ -351,7 +351,7 @@ const dataValues = [
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Encode Data Keys & Values for updating the URD and its permissions"
 import { ERC725 } from '@erc725/erc725.js';
@@ -403,7 +403,7 @@ Lastly, we need to send the transaction that will update the URD and its permiss
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Update the data on the Universal Profile"
 // update the Universal Profile data
@@ -415,7 +415,7 @@ await universalProfile.methods.setDataBatch(dataKeys, dataValues).send({
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Update the data on the Universal Profile"
 // update the Universal Profile data
@@ -430,7 +430,7 @@ await universalProfile.connect(EOA).setDataBatch(dataKeys, dataValues);
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Update the URD of the Universal Profile and its permissions"
 import { ERC725 } from '@erc725/erc725.js';
@@ -492,7 +492,7 @@ await updateUniversalProfileURD(universalProfileURDAddress);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Update the URD of the Universal Profile and its permissions"
 import { ERC725 } from '@erc725/erc725.js';
@@ -555,7 +555,7 @@ await updateUniversalProfileURD(universalProfileURDAddress);
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
 import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
@@ -660,7 +660,7 @@ await updateUniversalProfileURD(universalProfileURDAddress);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers">
 
 ```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
 import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';

--- a/docs/learn/universal-receiver/deploy-universal-receiver.md
+++ b/docs/learn/universal-receiver/deploy-universal-receiver.md
@@ -49,18 +49,18 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3" label="web3">
-
-```shell title="Install the dependencies"
-npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
-```
-
-  </TabItem>
-
   <TabItem value="ethers" label="ethers">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts @erc725/erc725.js
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```shell title="Install the dependencies"
+npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
 ```
 
   </TabItem>
@@ -76,29 +76,6 @@ We need to;
 3. Initialize the EOA that we will further use.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```typescript title="Imports, Constants & EOA"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import {
-  ERC725YDataKeys,
-  PERMISSIONS,
-} from '@lukso/lsp-smart-contracts/constants.js';
-import Web3 from 'web3';
-
-// constants
-const web3 = new Web3('https://rpc.testnet.lukso.network');
-const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
-const universalProfileAddress = '0x...';
-
-// setup your EOA
-const privateKey = '0x...';
-const EOA = web3.eth.accounts.wallet.add(privateKey);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -125,6 +102,29 @@ const EOA = new ethers.Wallet(privateKey).connect(provider);
 
   </TabItem>
 
+  <TabItem value="web3" label="web3">
+
+```typescript title="Imports, Constants & EOA"
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import {
+  ERC725YDataKeys,
+  PERMISSIONS,
+} from '@lukso/lsp-smart-contracts/constants.js';
+import Web3 from 'web3';
+
+// constants
+const web3 = new Web3('https://rpc.testnet.lukso.network');
+const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
+const universalProfileAddress = '0x...';
+
+// setup your EOA
+const privateKey = '0x...';
+const EOA = web3.eth.accounts.wallet.add(privateKey);
+```
+
+  </TabItem>
+
 </Tabs>
 
 ## Step 2 - Deploy the default Universal Receiver Delegate contract
@@ -139,17 +139,6 @@ The **Universal Profile** and the **Vault** don't use the same implementation of
 At this step we will create an instance of the Universal profile URD that we will further be used to deploy one.
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```typescript title="Contract instance of the Universal Profile URD"
-// create an instance of the LSP1UniversalReceiverDelegateUP
-let universalProfileURD = new web3.eth.Contract(
-  LSP1UniversalReceiverDelegateUP.abi,
-);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -162,6 +151,17 @@ let universalProfileURDFactory = new ethers.ContractFactory(
 ```
 
   </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```typescript title="Contract instance of the Universal Profile URD"
+// create an instance of the LSP1UniversalReceiverDelegateUP
+let universalProfileURD = new web3.eth.Contract(
+  LSP1UniversalReceiverDelegateUP.abi,
+);
+```
+
+  </TabItem>
 
 </Tabs>
 
@@ -170,6 +170,17 @@ let universalProfileURDFactory = new ethers.ContractFactory(
 Send the deployment transaction to get a newly deployed URD.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Send the transaction for deploying a new Universal Profile URD"
+// deploy the Universal Receiver Delegate UP contract
+const universalProfileURD = await universalProfileURDFactory
+  .connect(EOA)
+  .deploy();
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -188,22 +199,35 @@ await universalProfileURD
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Send the transaction for deploying a new Universal Profile URD"
-// deploy the Universal Receiver Delegate UP contract
-const universalProfileURD = await universalProfileURDFactory
-  .connect(EOA)
-  .deploy();
-```
-
-  </TabItem>
-
 </Tabs>
 
 ### Final code
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Deploy a Universal Receiver Delegate for the Universal Profile"
+const deployUniversalProfileURD = async () => {
+  // create a LSP1UniversalReceiverDelegateUP Contract Factory
+  let universalProfileURDFactory = new ethers.ContractFactory(
+    LSP1UniversalReceiverDelegateUP.abi,
+    LSP1UniversalReceiverDelegateUP.bytecode,
+  );
+
+  // deploy the Universal Receiver Delegate UP contract
+  const universalProfileURD = await universalProfileURDFactory
+    .connect(EOA)
+    .deploy();
+
+  return testnetuniversalProfileURD.address;
+};
+
+// deploy a new Universal Profile URD and retrieve its address
+const universalProfileURDAddress = await deployUniversalProfileURD();
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -238,30 +262,6 @@ const universalProfileURDAddress = await deployUniversalProfileURD();
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Deploy a Universal Receiver Delegate for the Universal Profile"
-const deployUniversalProfileURD = async () => {
-  // create a LSP1UniversalReceiverDelegateUP Contract Factory
-  let universalProfileURDFactory = new ethers.ContractFactory(
-    LSP1UniversalReceiverDelegateUP.abi,
-    LSP1UniversalReceiverDelegateUP.bytecode,
-  );
-
-  // deploy the Universal Receiver Delegate UP contract
-  const universalProfileURD = await universalProfileURDFactory
-    .connect(EOA)
-    .deploy();
-
-  return testnetuniversalProfileURD.address;
-};
-
-// deploy a new Universal Profile URD and retrieve its address
-const universalProfileURDAddress = await deployUniversalProfileURD();
-```
-
-  </TabItem>
-
 </Tabs>
 
 ## Step 3 - Set the address of the URD in the storage
@@ -273,6 +273,18 @@ After deploying the contract, we need to set its address under the **[LSP1-Unive
 Firstly we need to create an instance for the [**Universal Profile**](../../standards/universal-profile/lsp0-erc725account.md) contract.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Contract instance for the Universal Profile"
+// create an instance of the Universal Profile
+const universalProfile = new ethers.Contract(
+  universalProfileAddress,
+  UniversalProfile.abi,
+);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -286,18 +298,6 @@ const universalProfile = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Contract instance for the Universal Profile"
-// create an instance of the Universal Profile
-const universalProfile = new ethers.Contract(
-  universalProfileAddress,
-  UniversalProfile.abi,
-);
-```
-
-  </TabItem>
-
 </Tabs>
 
 ### Register URD on the UP + set the URD permissions
@@ -305,6 +305,50 @@ const universalProfile = new ethers.Contract(
 Generate _Data Keys & Values_ for [**adding a URD**](../../standards/generic-standards/lsp1-universal-receiver-delegate.md#how-delegation-works) to the Universal Profile and for granting [**SUPER_SETDATA**](../../standards/universal-profile/lsp6-key-manager.md#super-permissions) permission to the **URD**.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Encode Data Keys & Values for updating the URD and its permissions"
+import { ERC725 } from '@erc725/erc725.js';
+
+const addressPermissionsOldArrayLengthHex = await universalProfile[
+  'getData(bytes32)'
+](ERC725YDataKeys.LSP6['AddressPermissions[]'].length);
+
+const addressPermissionsNewArrayLength =
+  ethers.toBigInt(addressPermissionsOldArrayLengthHex) + ethers.toBigInt(1);
+
+const addressPermissionsNewArrayLengthHex =
+  '0x' + addressPermissionsNewArrayLength.toString(16).padStart(32, '0');
+
+// create bytes32 permission value for the LSP1 Delegate
+const lsp1DelegatePermissions = ERC725.encodePermissions({
+  SUPER_SETDATA: true,
+  REENTRANCY: true,
+});
+
+// bytes16 index `addressPermissionsOldArrayLengthHex` will serve as index
+const newElementIndexInArrayHex =
+  addressPermissionsOldArrayLengthHex.substring(2);
+
+const dataKeys = [
+  URD_DATA_KEY,
+  ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+  ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+    newElementIndexInArrayHex,
+  ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+    universalProfileURDAddress.substring(2),
+];
+
+const dataValues = [
+  universalProfileURDAddress,
+  addressPermissionsNewArrayLengthHex,
+  universalProfileURDAddress,
+  lsp1DelegatePermissions,
+];
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -351,50 +395,6 @@ const dataValues = [
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Encode Data Keys & Values for updating the URD and its permissions"
-import { ERC725 } from '@erc725/erc725.js';
-
-const addressPermissionsOldArrayLengthHex = await universalProfile[
-  'getData(bytes32)'
-](ERC725YDataKeys.LSP6['AddressPermissions[]'].length);
-
-const addressPermissionsNewArrayLength =
-  ethers.toBigInt(addressPermissionsOldArrayLengthHex) + ethers.toBigInt(1);
-
-const addressPermissionsNewArrayLengthHex =
-  '0x' + addressPermissionsNewArrayLength.toString(16).padStart(32, '0');
-
-// create bytes32 permission value for the LSP1 Delegate
-const lsp1DelegatePermissions = ERC725.encodePermissions({
-  SUPER_SETDATA: true,
-  REENTRANCY: true,
-});
-
-// bytes16 index `addressPermissionsOldArrayLengthHex` will serve as index
-const newElementIndexInArrayHex =
-  addressPermissionsOldArrayLengthHex.substring(2);
-
-const dataKeys = [
-  URD_DATA_KEY,
-  ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
-  ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
-    newElementIndexInArrayHex,
-  ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-    universalProfileURDAddress.substring(2),
-];
-
-const dataValues = [
-  universalProfileURDAddress,
-  addressPermissionsNewArrayLengthHex,
-  universalProfileURDAddress,
-  lsp1DelegatePermissions,
-];
-```
-
-  </TabItem>
-
 </Tabs>
 
 ### Set the URD and its permissions
@@ -402,6 +402,15 @@ const dataValues = [
 Lastly, we need to send the transaction that will update the URD and its permissions on the Universal Profile.
 
 <Tabs>
+
+  <TabItem value="ethers" label="ethers">
+
+```typescript title="Update the data on the Universal Profile"
+// update the Universal Profile data
+await universalProfile.connect(EOA).setDataBatch(dataKeys, dataValues);
+```
+
+  </TabItem>
   
   <TabItem value="web3" label="web3">
 
@@ -415,82 +424,11 @@ await universalProfile.methods.setDataBatch(dataKeys, dataValues).send({
 
   </TabItem>
 
-  <TabItem value="ethers" label="ethers">
-
-```typescript title="Update the data on the Universal Profile"
-// update the Universal Profile data
-await universalProfile.connect(EOA).setDataBatch(dataKeys, dataValues);
-```
-
-  </TabItem>
-
 </Tabs>
 
 ### Final code
 
 <Tabs>
-  
-  <TabItem value="web3" label="web3">
-
-```typescript title="Update the URD of the Universal Profile and its permissions"
-import { ERC725 } from '@erc725/erc725.js';
-
-const updateUniversalProfileURD = async (universalProfileURDAddress) => {
-  // create an instance of the Universal Profile
-  const universalProfile = new web3.eth.Contract(
-    UniversalProfile.abi,
-    universalProfileAddress,
-  );
-
-  const addressPermissionsOldArrayLengthHex = await universalProfile.methods[
-    'getData(bytes32)'
-  ](ERC725YDataKeys.LSP6['AddressPermissions[]'].length).call();
-
-  const addressPermissionsNewArrayLength =
-    web3.utils.hexToNumber(addressPermissionsOldArrayLengthHex) + 1;
-
-  const addressPermissionsNewArrayLengthHex = web3.utils.padLeft(
-    web3.utils.numberToHex(addressPermissionsNewArrayLength),
-    32,
-  );
-
-  // create bytes32 permission value for the LSP1 Delegate
-  const lsp1DelegatePermissions = ERC725.encodePermissions({
-    SUPER_SETDATA: true,
-    REENTRANCY: true,
-  });
-
-  // bytes16 index `addressPermissionsOldArrayLengthHex` will serve as index
-  const newElementIndexInArrayHex =
-    addressPermissionsOldArrayLengthHex.substring(2);
-
-  const dataKeys = [
-    URD_DATA_KEY,
-    ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
-    ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
-      newElementIndexInArrayHex,
-    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-      universalProfileURDAddress.substring(2),
-  ];
-  const dataValues = [
-    universalProfileURDAddress,
-    addressPermissionsNewArrayLengthHex,
-    universalProfileURDAddress,
-    lsp1DelegatePermissions,
-  ];
-
-  // update the Universal Profile data
-  await universalProfile.methods.setDataBatch(dataKeys, dataValues).send({
-    from: EOA.address,
-    gasLimit: 600_000,
-  });
-};
-
-// update the URD of the Universal profile
-await updateUniversalProfileURD(universalProfileURDAddress);
-```
-
-  </TabItem>
 
   <TabItem value="ethers" label="ethers">
 
@@ -548,57 +486,11 @@ await updateUniversalProfileURD(universalProfileURDAddress);
 ```
 
   </TabItem>
-
-</Tabs>
-
-## Final code - Deploy & Update
-
-<Tabs>
   
   <TabItem value="web3" label="web3">
 
-```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
-import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
-import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
-import {
-  ERC725YDataKeys,
-  PERMISSIONS,
-} from '@lukso/lsp-smart-contracts/constants.js';
-import Web3 from 'web3';
+```typescript title="Update the URD of the Universal Profile and its permissions"
 import { ERC725 } from '@erc725/erc725.js';
-
-// constants
-const web3 = new Web3('https://rpc.testnet.lukso.network');
-const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
-const universalProfileAddress = '0x...';
-
-// setup your EOA
-const privateKey = '0x...';
-const EOA = web3.eth.accounts.wallet.add(privateKey);
-
-const deployUniversalProfileURD = async () => {
-  // create an instance of the LSP1UniversalReceiverDelegateUP
-  const universalProfileURD = new web3.eth.Contract(
-    LSP1UniversalReceiverDelegateUP.abi,
-  );
-  let universalProfileURDAddress;
-
-  // deploy the Universal Receiver Delegate UP contract
-  await universalProfileURD
-    .deploy({
-      data: LSP1UniversalReceiverDelegateUP.bytecode,
-    })
-    .send({
-      from: EOA.address,
-      gas: 5_000_000,
-      gasPrice: '1000000000',
-    })
-    .on('receipt', (receipt) => {
-      universalProfileURDAddress = receipt.contractAddress;
-    });
-
-  return universalProfileURDAddress;
-};
 
 const updateUniversalProfileURD = async (universalProfileURDAddress) => {
   // create an instance of the Universal Profile
@@ -651,14 +543,17 @@ const updateUniversalProfileURD = async (universalProfileURDAddress) => {
   });
 };
 
-// deploy a new Universal Profile URD and retrieve its address
-const universalProfileURDAddress = await deployUniversalProfileURD();
-
 // update the URD of the Universal profile
 await updateUniversalProfileURD(universalProfileURDAddress);
 ```
 
   </TabItem>
+
+</Tabs>
+
+## Final code - Deploy & Update
+
+<Tabs>
 
   <TabItem value="ethers" label="ethers">
 
@@ -742,6 +637,111 @@ const updateUniversalProfileURD = async (universalProfileURDAddress) => {
 
   // update the Universal Profile data
   await universalProfile.connect(EOA).setDataBatch(dataKeys, dataValues);
+};
+
+// deploy a new Universal Profile URD and retrieve its address
+const universalProfileURDAddress = await deployUniversalProfileURD();
+
+// update the URD of the Universal profile
+await updateUniversalProfileURD(universalProfileURDAddress);
+```
+
+  </TabItem>
+  
+  <TabItem value="web3" label="web3">
+
+```typescript title="Deploy a Universal Profile URD, update its permissions and add it to the Universal Profile"
+import LSP1UniversalReceiverDelegateUP from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateUP.json';
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
+import {
+  ERC725YDataKeys,
+  PERMISSIONS,
+} from '@lukso/lsp-smart-contracts/constants.js';
+import Web3 from 'web3';
+import { ERC725 } from '@erc725/erc725.js';
+
+// constants
+const web3 = new Web3('https://rpc.testnet.lukso.network');
+const URD_DATA_KEY = ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate;
+const universalProfileAddress = '0x...';
+
+// setup your EOA
+const privateKey = '0x...';
+const EOA = web3.eth.accounts.wallet.add(privateKey);
+
+const deployUniversalProfileURD = async () => {
+  // create an instance of the LSP1UniversalReceiverDelegateUP
+  const universalProfileURD = new web3.eth.Contract(
+    LSP1UniversalReceiverDelegateUP.abi,
+  );
+  let universalProfileURDAddress;
+
+  // deploy the Universal Receiver Delegate UP contract
+  await universalProfileURD
+    .deploy({
+      data: LSP1UniversalReceiverDelegateUP.bytecode,
+    })
+    .send({
+      from: EOA.address,
+      gas: 5_000_000,
+      gasPrice: '1000000000',
+    })
+    .on('receipt', (receipt) => {
+      universalProfileURDAddress = receipt.contractAddress;
+    });
+
+  return universalProfileURDAddress;
+};
+
+const updateUniversalProfileURD = async (universalProfileURDAddress) => {
+  // create an instance of the Universal Profile
+  const universalProfile = new web3.eth.Contract(
+    UniversalProfile.abi,
+    universalProfileAddress,
+  );
+
+  const addressPermissionsOldArrayLengthHex = await universalProfile.methods[
+    'getData(bytes32)'
+  ](ERC725YDataKeys.LSP6['AddressPermissions[]'].length).call();
+
+  const addressPermissionsNewArrayLength =
+    web3.utils.hexToNumber(addressPermissionsOldArrayLengthHex) + 1;
+
+  const addressPermissionsNewArrayLengthHex = web3.utils.padLeft(
+    web3.utils.numberToHex(addressPermissionsNewArrayLength),
+    32,
+  );
+
+  // create bytes32 permission value for the LSP1 Delegate
+  const lsp1DelegatePermissions = ERC725.encodePermissions({
+    SUPER_SETDATA: true,
+    REENTRANCY: true,
+  });
+
+  // bytes16 index `addressPermissionsOldArrayLengthHex` will serve as index
+  const newElementIndexInArrayHex =
+    addressPermissionsOldArrayLengthHex.substring(2);
+
+  const dataKeys = [
+    URD_DATA_KEY,
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+      newElementIndexInArrayHex,
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+      universalProfileURDAddress.substring(2),
+  ];
+  const dataValues = [
+    universalProfileURDAddress,
+    addressPermissionsNewArrayLengthHex,
+    universalProfileURDAddress,
+    lsp1DelegatePermissions,
+  ];
+
+  // update the Universal Profile data
+  await universalProfile.methods.setDataBatch(dataKeys, dataValues).send({
+    from: EOA.address,
+    gasLimit: 600_000,
+  });
 };
 
 // deploy a new Universal Profile URD and retrieve its address

--- a/docs/learn/vault/create-a-vault.md
+++ b/docs/learn/vault/create-a-vault.md
@@ -32,7 +32,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts
@@ -40,7 +40,7 @@ npm install web3 @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
@@ -57,7 +57,7 @@ For the constants we will need the _private key_ and _the address of the vault r
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Imports & Constants"
 import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
@@ -73,7 +73,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Imports & Constants"
 import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
@@ -99,7 +99,7 @@ Create instance for `LSP9Vault`, that is needed in order to deploy the contract.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Contract instance"
 // create an instance of the LSP9Vault contract
@@ -108,7 +108,7 @@ let myVault = new web3.eth.Contract(LSP9Vault.abi);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Contract instance"
 // create an factory for the LSP9Vault contract
@@ -128,7 +128,7 @@ Finally send the **contract deployment** transaction.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Sending contract deployment transaction"
 // deploy the vault contract
@@ -146,7 +146,7 @@ await myVault
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Sending contract deployment transaction"
 // deploy the vault contract
@@ -167,7 +167,7 @@ You need to have LYXt in your EOA in order to pay for the transaction fees. Visi
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Deploying the vault"
 import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';
@@ -198,7 +198,7 @@ await myVault
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Deploying the vault"
 import LSP9Vault from '@lukso/lsp-smart-contracts/artifacts/LSP9Vault.json';

--- a/docs/learn/vault/edit-vault-data.md
+++ b/docs/learn/vault/edit-vault-data.md
@@ -28,14 +28,14 @@ Make sure you have the following dependencies installed before beginning this tu
 - [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/)
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell
 npm install web3 @lukso/lsp-smart-contracts
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell
 npm install ethers @lukso/lsp-smart-contracts
@@ -51,7 +51,7 @@ After that we need to store the address of our LSP9 Vault and our Universal Prof
 Then we will initialize the EOA that we will further use.
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
@@ -71,7 +71,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
@@ -107,7 +107,7 @@ The **Universal Profile** and the **Vault** don't use the same implementation of
 At this step we will create an instance of the Vault URD that we will further be used to deploy one.
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 // create an instance of the LSP1UniversalReceiverDelegateVault
@@ -115,7 +115,7 @@ const vaultURD = new web3.eth.Contract(LSP1UniversalReceiverDelegateVault.abi);
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 // create a LSP1UniversalReceiverDelegateVault Contract Factory
@@ -133,7 +133,7 @@ const vaultURDFactory = new ethers.ContractFactory(
 Send the deployment transaction and in a few seconds you will get a new deployed Vault URD.
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 // deploy the Universal Receiver Delegate Vault contract
@@ -149,7 +149,7 @@ await vaultURD
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 // deploy the Universal Receiver Delegate Vault contract
@@ -162,7 +162,7 @@ const vaultURD = await vaultURDFactory.connect(myEOA).deploy();
 ### Final code
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 const deployVaultURD = async () => {
@@ -192,7 +192,7 @@ const vaultURDAddress = await deployVaultURD();
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 const deployVaultURD = async () => {
@@ -231,7 +231,7 @@ Firstly we need to create instances for the following contracts:
 - [**Universal Profile**](../../standards/universal-profile/lsp0-erc725account.md)
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 // create an instance of the LSP9Vault
@@ -244,7 +244,7 @@ const universalProfile = new web3.eth.Contract(
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 // create an instance of the LSP9Vault
@@ -264,7 +264,7 @@ const universalProfile = new ethers.Contract(
 Secondly, we need to encode a calldata that will update the address of the Vault URD.
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 // encode setData Calldata on the Vault
@@ -274,7 +274,7 @@ const setDataCalldata = await vault.methods
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 // encode setData Calldata on the Vault
@@ -292,7 +292,7 @@ const setDataCalldata = vault.interface.encodeFunctionData('setData', [
 Lastly, we need to send the transaction that will update the Vault data through the Universal Profile's `execute(..)`.
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 // execute the `setData(bytes32,bytes)` calldata that updates the Vault data
@@ -311,7 +311,7 @@ await universalProfile.methods
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 // execute the `setData(bytes32,bytes)` calldata that updates the Vault data
@@ -329,7 +329,7 @@ await universalProfile.connect(myEOA).execute(
 ### Final code
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript
 const updateVaultURD = async (vaultURDAddress) => {
@@ -368,7 +368,7 @@ await updateVaultURD(vaultURDAddress);
 ```
 
   </TabItem>
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 const updateVaultURD = async (vaultURDAddress) => {
@@ -405,7 +405,7 @@ await updateVaultURD(vaultURDAddress);
 ## Final code - Deploy & Update
 
 <Tabs>
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Deploy new Vault URD and update Vault's URD"
 import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';
@@ -483,7 +483,7 @@ await updateVaultURD(vaultURDAddress);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript
 import LSP1UniversalReceiverDelegateVault from '@lukso/lsp-smart-contracts/artifacts/LSP1UniversalReceiverDelegateVault.json';

--- a/docs/learn/vault/grant-vault-permissions.md
+++ b/docs/learn/vault/grant-vault-permissions.md
@@ -44,7 +44,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
@@ -52,7 +52,7 @@ npm install web3 @lukso/lsp-smart-contracts @erc725/erc725.js
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts @erc725/erc725.js
@@ -70,7 +70,7 @@ Finally, we will need a private key with the proper _permissions_, in our case [
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Imports, Constants & EOA initialization"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -91,7 +91,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Imports, Constants & EOA initialization"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -122,7 +122,7 @@ At this point we will create instance for the [**Universal Profile**](../../stan
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Universal Profile contract instance"
 // create an instance of the UP
@@ -134,7 +134,7 @@ const universalProfile = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Universal Profile contract instance"
 // create an instance of the UP
@@ -154,7 +154,7 @@ Now we need to generate a data key & a data value for the **Allowed Calls** that
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Data key & value for updating the Allowed Calls of a Controller address"
 const allowedCallsDataKey = // constructing the data key of allowed addresses
@@ -178,7 +178,7 @@ const allowedCallsDataValue = encodeKey(allowedCallsSchema, [
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Data key & value for updating the Allowed Calls of a Controller address"
 const allowedCallsDataKey = // constructing the data key of allowed addresses
@@ -210,7 +210,7 @@ Finally we will send a transaction that will update the Universal Profile Allowe
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -229,7 +229,7 @@ await universalProfile.methods.setData(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Set the data key on the Universal Profile"
 // Set the AllowedCalls data key on the Universal Profile
@@ -246,7 +246,7 @@ await universalProfile
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 <!-- prettier-ignore-start -->
 
@@ -304,7 +304,7 @@ await universalProfile.methods.setData(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Setting Allowed Addresses for the 3rd party address"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';

--- a/docs/learn/vault/interact-with-contracts.md
+++ b/docs/learn/vault/interact-with-contracts.md
@@ -50,7 +50,7 @@ Make sure you have the following dependencies installed before beginning this tu
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```shell title="Install the dependencies"
 npm install web3 @lukso/lsp-smart-contracts
@@ -58,7 +58,7 @@ npm install web3 @lukso/lsp-smart-contracts
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```shell title="Install the dependencies"
 npm install ethers @lukso/lsp-smart-contracts
@@ -82,7 +82,7 @@ You can quickly compile and get a contract's ABI in [**Remix IDO**](https://remi
 
 <Tabs>
 
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Imports & Constants"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -102,7 +102,7 @@ const myEOA = web3.eth.accounts.wallet.add(privateKey);
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Imports & Constants"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -135,7 +135,7 @@ Further we will create instances for our contracts
 
 <Tabs>
 
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Contracts instances"
 // Create Universal Profile contract instance
@@ -154,7 +154,7 @@ const targetContract = new web3.eth.Contract(
 
   </TabItem>
 
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Contracts instances"
 // Create Universal Profile contract instance
@@ -188,7 +188,7 @@ Encoding the calldata that will be be executed on the Target Contract.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Target calldata"
 // 1. encode the calldata to be run at the targetContract
@@ -200,7 +200,7 @@ const targetCalldata = targetContract.methods
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Target calldata"
 // 1. encode the calldata to be run at the targetContract
@@ -221,7 +221,7 @@ Encoding the calldata that will be be executed on the Vault. This calldata will 
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Vault calldata"
 // 2. encode the calldata to be run on the Vault,
@@ -233,7 +233,7 @@ const vaultCalldata = await vault.methods
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Vault calldata"
 // 2. encode the calldata to be run on the Vault,
@@ -256,7 +256,7 @@ The final step is to execute the encoded calldata through the Universal Profile.
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Send transaction"
 // Execute the calldata through the Universal Profile
@@ -268,7 +268,7 @@ await universalProfile.methods.execute(0, vaultAddress, 0, vaultCalldata).send({
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Send transaction"
 // Execute the calldata through the Universal Profile
@@ -285,7 +285,7 @@ await universalProfile
 
 <Tabs>
   
-  <TabItem value="web3js" label="web3.js">
+  <TabItem value="web3" label="web3">
 
 ```typescript title="Interacting with other contracts through the vault"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
@@ -336,7 +336,7 @@ await universalProfile.methods.execute(0, vaultAddress, 0, vaultCalldata).send({
 
   </TabItem>
   
-  <TabItem value="ethersjs" label="ethers.js">
+  <TabItem value="ethers" label="ethers.js">
 
 ```typescript title="Interacting with other contracts through the vault"
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';


### PR DESCRIPTION
Some tabs have written (A):

<img width="237" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/aa53d759-1da4-4c87-8da1-6facaba79748">

While others have (B):

<img width="220" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/81b636ac-bd2f-4be9-9b7a-f0affa46bb51">


- [x] This PR makes it consistent across all the guides by using (A) with **web3** and **ethers**.
- [x] Always make any code snippets to show **ethers** by default as the first tab. (Some guides have the code tabs inverted like below)

<img width="231" alt="image" src="https://github.com/lukso-network/docs/assets/31145285/a22f5ac8-75dd-49b5-b709-542b2fd29667">

- [x] Remove any `// prettier-disable` comment to format correctly all code snippet by default aaccording to prettier's repo settings
- [x] Add extra code snippet in ethers for connect Universal Profile EIP6963
- [x] Move mention of ERC725-Inspect in one guide from the bottom to the top as a callout to make it more CTA