### PR TITLE
re-write completely guide to Execute Relay Call

### DIFF
--- a/docs/standards/universal-profile/lsp6-key-manager.md
+++ b/docs/standards/universal-profile/lsp6-key-manager.md
@@ -896,11 +896,20 @@ Since the Key Manager offers **relay execution** via signed message, it's import
 
 - Signed messages with sequential nonces should be **executed in order**, meaning a signed message with nonce 4 can't be executed before the signed message with nonce 3. This is a critical problem which can limit the usage of relay execution.
 
-Here comes the **Multi-channel** nonces which provide the ability to execute signed message **with**/**without** a specific order depending on the signer choice.
+Here comes the **Multi-channel** nonces which provide the ability to execute signed message **with**/**without** a specific order depending on the signer choice. It allows for transactions to be processed:
 
-Signed messages should be executed sequentially if signed on the same channel and should be executed independently if signed on different channel.
+- either in parallel without relying on the order of their arrival.
+- or enforce their order in a queue, sequentially.
 
-- Message signed with nonce 4 on channel 1 can't be executed before the message signed with nonce 3 on channel 1 but can be executed before the message signed with nonce 3 on channel 2.
+Therefore, if a sequence of signed messages must be executed sequentially, they must be signed on the same channel.
+
+Alternatively, it they should be executed independently, they should be signed across different channels.
+
+> _Example:_
+> A message signed with nonce 4 on channel 1:
+>
+> - ❌ can't be executed before the message signed with nonce 3 on channel 1.
+> - ✅ can be executed before the message signed with nonce 3 on channel 2.
 
 ![LSP6 Key Manager Relay Service](/img/standards/lsp6/lsp6-multi-channel-nonce.jpeg)
 


### PR DESCRIPTION
This guide was extremelly complex and the terms were mixed up. It was very confusing to understand any of it.

I have removed the number of steps and clarify the whole grammar, so that it is easier to follow, included diagram at the top (re-used from LSP6 standard page) and added some more tables to explain the function parameters in a user-friendly manner.