### PR TITLE
Update mainnet "running a node" page

### DIFF
--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -252,7 +252,7 @@ Execution layer clients:
 - [Besu](https://besu.hyperledger.org/public-networks/reference/cli/options#network) Example command:
 
 ```bash
-besu --network=lukso`
+besu --network=lukso
 ```
 
 You should consider adding more flags, e.g. `--data-path=<PATH>`


### PR DESCRIPTION
This PR removes unexpected **`** sign from "Running a node" doc page.