### PR TITLE
Fix: page title on the tab + redirect changes

### DIFF
--- a/docs/learn/getting-started.mdx
+++ b/docs/learn/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: '🏎️ Quick Start'
 description: Introduction to the LUKSO Ecosystem - why choose LUKSO? Who is LUKSO intended for?
+title: '🏎️ Quick Start'
 ---
 
 import CallToActionButton from '@site/src/components/CallToActionButton';
@@ -18,8 +19,8 @@ export const CardData = [
     cardHeading: 'Dapp Developer',
     cardContent: [
       {
-        linkText: 'Fork our boilerplate dapp',
-        linkPath: 'https://github.com/lukso-network/tools-dapp-boilerplate',
+        linkText: 'Learn how to develop with Universal Profiles',
+        linkPath: '../learn/universal-profile/getting-started.md',
       },
       {
         linkText: 'Explore code examples in our playground repository',
@@ -133,8 +134,8 @@ LUKSO is a Layer 1 EVM chain that uses the same consensus as Ethereum. It is fun
   </tbody>
 </table>
 
-:::success
-Learn more about the LSPs 🧱
+:::success Learn more about the LSPs 🧱
+
 To learn more about the main building blocks of LUKSO check out the [LUKSO Standard Proposals (**LSPs**)](../standards/introduction.md) page.
 :::
 

--- a/docs/learn/getting-started.mdx
+++ b/docs/learn/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: '🏎️ Quick Start'
 description: Introduction to the LUKSO Ecosystem - why choose LUKSO? Who is LUKSO intended for?
-title: '🏎️ Quick Start'
+title: 'Quick Start'
 ---
 
 import CallToActionButton from '@site/src/components/CallToActionButton';


### PR DESCRIPTION
-fixed the title on the browser tab 
-changed the redirect to the docs page
![image](https://github.com/user-attachments/assets/0dd089c6-5aa1-49e9-bd81-f3e44a208bc5)
