### PR TITLE
fix: no magnifier show be shown when hovering on github/hpm badges

### DIFF
--- a/docs/contracts/introduction.md
+++ b/docs/contracts/introduction.md
@@ -9,9 +9,9 @@ import {ContractCardsGallery} from '@site/src/components/ContractCardsGallery';
 
 # Smart Contracts
 
-> The smart contracts are public and open source on [GitHub](https://github.com/lukso-network/lsp-smart-contracts). <a href="https://github.com/lukso-network/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="github badge" src="https://img.shields.io/github/v/release/lukso-network/lsp-smart-contracts?logo=github&label=Github"/></a>
+> The smart contracts are public and open source on [GitHub](https://github.com/lukso-network/lsp-smart-contracts). <a href="https://github.com/lukso-network/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="github badge" class="shield-badge" src="https://img.shields.io/github/v/release/lukso-network/lsp-smart-contracts?logo=github&label=Github"/></a>
 >
-> They are available as a npm package [`@lukso/lsp-smart-contracts`](https://www.npmjs.com/package/@lukso/lsp-smart-contracts). <a href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=NPM&logo=npm"/></a>
+> They are available as a npm package [`@lukso/lsp-smart-contracts`](https://www.npmjs.com/package/@lukso/lsp-smart-contracts). <a href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=NPM&logo=npm"/></a>
 
 <br/>
 

--- a/docs/tools/erc725js/getting-started.md
+++ b/docs/tools/erc725js/getting-started.md
@@ -8,8 +8,8 @@ sidebar_position: 1
 This package is currently in the early stages of development. Feel free to [report issues or feature requests](https://github.com/ERC725Alliance/erc725.js/issues) through the Github repository.
 :::
 
-<a href="https://github.com/ERC725Alliance/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="github badge" src="https://img.shields.io/github/v/release/ERC725Alliance/erc725.js?logo=github&label=Github"/></a>
-<a href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=NPM&logo=npm"/></a>
+<a href="https://github.com/ERC725Alliance/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="github badge" class="shield-badge" src="https://img.shields.io/github/v/release/ERC725Alliance/erc725.js?logo=github&label=Github"/></a>
+<a href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=NPM&logo=npm"/></a>
 
 <br/><br/>
 

--- a/docs/tools/getting-started.md
+++ b/docs/tools/getting-started.md
@@ -16,32 +16,32 @@ Libraries that are actively maintained by the LUKSO team.
   </tr>
   <tr>
     <td><a href="/tools/lsp-smart-contracts/getting-started">lsp-smart-contracts</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"/></a></td>
     <td><a href="https://github.com/lukso-network/lsp-smart-contracts" target="_blank" rel="noopener noreferrer">lukso-network/lsp-smart-contracts</a></td>
   </tr>
   <tr>
     <td><a href="/tools/lsp-utils/getting-started">lsp-utils</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-utils" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/lsp-utils.svg?style=flat&label=%40lukso%2Flsp-utils"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/lsp-utils" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@lukso/lsp-utils.svg?style=flat&label=%40lukso%2Flsp-utils"/></a></td>
     <td><a href="https://github.com/lukso-network/lsp-utils" target="_blank" rel="noopener noreferrer">lukso-network/lsp-utils</a></td>
   </tr>
   <tr>
     <td><a href="/tools/erc725js/getting-started">erc725.js</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=%40erc725%2Ferc725.js"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@erc725/erc725.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@erc725/erc725.js.svg?style=flat&label=%40erc725%2Ferc725.js"/></a></td>
     <td><a href="https://github.com/ERC725Alliance/erc725.js" target="_blank" rel="noopener noreferrer">ERC725Alliance/erc725.js</a></td>
   </tr>
   <tr>
     <td><a href="/tools/eip191-signerjs/getting-started">eip191-signer.js</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/eip191-signer.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/eip191-signer.js.svg?style=flat&label=%40lukso%2Feip191-signer.js"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/@lukso/eip191-signer.js" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@lukso/eip191-signer.js.svg?style=flat&label=%40lukso%2Feip191-signer.js"/></a></td>
     <td><a href="https://github.com/lukso-network/tools-eip191-signer" target="_blank" rel="noopener noreferrer">lukso-network/tools-eip191-signer</a></td>
   </tr>
   <tr>
     <td><a href="https://github.com/lukso-network/web3-onboard-config">web3-onboard-config</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/lukso/web3-onboard-config" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badgen badge" src="https://img.shields.io/npm/v/@lukso/web3-onboard-config.svg?style=flat&label=%40lukso%2Fweb3-onboard-config"/></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://www.npmjs.com/package/lukso/web3-onboard-config" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="npm badge" class="shield-badge" src="https://img.shields.io/npm/v/@lukso/web3-onboard-config.svg?style=flat&label=%40lukso%2Fweb3-onboard-config"/></a></td>
     <td><a href="https://github.com/lukso-network/web3-onboard-config" target="_blank" rel="noopener noreferrer">lukso-network/web3-onboard-config</a></td>
   </tr>
   <tr>
     <td><a href="https://github.com/lukso-network/tools-mock-relayer">mock relayer</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/lukso-network/tools-mock-relayer" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="Github badgen badge" src="https://img.shields.io/badge/Github-white?logo=github&logoColor=black&link=https%3A%2F%2Fgithub.com%2Flukso-network%2Ftools-mock-relayer
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/lukso-network/tools-mock-relayer" target="_blank" rel="noopener noreferrer"><img style={{verticalAlign: 'middle'}} alt="Github badgen badge" class="shield-badge" src="https://img.shields.io/badge/Github-white?logo=github&logoColor=black&link=https%3A%2F%2Fgithub.com%2Flukso-network%2Ftools-mock-relayer
     "/></a></td>
     <td><a href="https://github.com/lukso-network/tools-mock-relayer" target="_blank" rel="noopener noreferrer">lukso-network/tools-mock-relayer</a></td>
   </tr>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -365,6 +365,9 @@ export default {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },
+    zoom: {
+      selector: '.markdown img:not(.shield-badge)',
+    },
   },
   presets: [
     [


### PR DESCRIPTION
### Issue


https://github.com/user-attachments/assets/4b589200-d6a1-40ca-bc1c-621881be14ee



Following https://www.npmjs.com/package/docusaurus-plugin-image-zoom?activeTab=readme adding a custom class like `.shield-badge` and the zoom plugin config in docusaurus.config.js `selector: .markdown image:not(.shield-badge)` should disable magnifier glass.

Somehow it doesn't yet work correctly even with the new config. `selector` seems to be not applying.