### PR TITLE
feat: Bump erigon version

### DIFF
--- a/docs/faq/network/network-configuration.md
+++ b/docs/faq/network/network-configuration.md
@@ -15,7 +15,7 @@ There are no extra rewards for being very quick. When the appointed time for a v
 You can find more information about firewall and port settings within the specifications of the supported blockchain clients:
 
 - [Geth Port Specification](https://geth.ethereum.org/docs/fundamentals/security)
-- [Erigon Port Specification](https://github.com/ledgerwatch/erigon#default-ports-and-firewalls)
+- [Erigon Port Specification](https://github.com/erigontech/erigon#default-ports-and-firewalls)
 - [Nethermind Port Specification](https://docs.nethermind.io/fundamentals/security/#networking-security)
 - [Besu Port Specification](https://besu.hyperledger.org/development/public-networks/how-to/connect/configure-ports)
 - [Prysm Port Specification](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#configure-your-firewall)

--- a/docs/faq/network/node-setup.md
+++ b/docs/faq/network/node-setup.md
@@ -16,7 +16,7 @@ Currently, LUKSO officially supports Geth, Erigon, Lighthouse, and Prysm. All cl
 
 - **[Geth](https://github.com/ethereum/go-ethereum)** is the most popular and widely used Ethereum execution client. It's written in the Go programming language. Geth can be used for various tasks, including creating smart contracts, transferring tokens, mining ether, and exploring block history. It's developed and maintained by the Ethereum Foundation.
 
-- **[Erigon](https://github.com/ledgerwatch/erigon)** is an Ethereum execution client that aims to offer a more efficient and faster alternative to Geth. It's written in Go and includes several optimizations to reduce the amount of data stored and improve processing speed. However, these optimizations can make Erigon more complex to maintain and update.
+- **[Erigon](https://github.com/erigontech/erigon)** is an Ethereum execution client that aims to offer a more efficient and faster alternative to Geth. It's written in Go and includes several optimizations to reduce the amount of data stored and improve processing speed. However, these optimizations can make Erigon more complex to maintain and update.
 
 - **[Nethermind](https://github.com/NethermindEth/nethermind)** is an Ethereum execution client built on .NET framework and developed by Nethermind. Its plugin system makes it especially easy to configure and use it. Combining this with a very stable runtime, this makes it a great client to use on the network.
 

--- a/docs/networks/advanced-guides/update-clients.md
+++ b/docs/networks/advanced-guides/update-clients.md
@@ -68,7 +68,7 @@ lukso install --prysm-tag v4.0.8
 lukso install --lighthouse-tag v4.1.0
 
 # Manually overwrite Erigon Version
-# https://github.com/ledgerwatch/erigon/releases
+# https://github.com/erigontech/erigon/releases
 lukso install ---erigon-tag 2.52.1
 
 # Manually overwrite Teku Version

--- a/docs/networks/advanced-guides/update-clients.md
+++ b/docs/networks/advanced-guides/update-clients.md
@@ -68,6 +68,7 @@ lukso install --prysm-tag v4.0.8
 lukso install --lighthouse-tag v4.1.0
 
 # Manually overwrite Erigon Version
+# Please note that erigon underwent changes in repository structure, making the CLI unable to install versions <2.60.9
 # https://github.com/erigontech/erigon/releases
 lukso install ---erigon-tag 2.52.1
 

--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -72,8 +72,8 @@ The LUKSO network currently supports the following clients versions:
   </tr>
   <tr>
     <td><a href="https://erigon.tech/">Erigon</a></td>
-    <td><a href="https://github.com/erigontech/erigon/releases/tag/v2.60.4">v2.60.4</a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/ledgerwatch/erigon"><GithubIcon /></a></td>
+    <td><a href="https://github.com/erigontech/erigon/releases/tag/v2.60.10">v2.60.10</a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/erigontech/erigon"><GithubIcon /></a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://erigon.gitbook.io/erigon"><BookIcon /></a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/erigontech/erigon?tab=readme-ov-file#erigon-discord-server"><DiscordIcon /></a></td>
     <td>Stable</td>


### PR DESCRIPTION
This PR bumps the erigon version of the CLI and adjusts the repository links to a new repository - [`erigontech/erigon`](https://github.com/erigontech/erigon)