### PR TITLE
fix: Repair main deploy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,11 @@ jobs:
             echo "branch=--branch pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           else
             echo "branch_name=" >> $GITHUB_OUTPUT
-            echo "branch=" >> $GITHUB_OUTPUT
+            echo "branch=--branch main" >> $GITHUB_OUTPUT
           fi
         id: extract_branch
 
       - name: 🚀 Deploy
-        if: ${{ steps.extract_branch.outputs.branch_name != '' }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
fix: Repair main deploys.

The code path for deploys is now a single one called "Deploy" which should deploy PRs and main.
Unfortunately the job still had a `if isPR` type of condition.
