### PR TITLE
docs: highlighting ERC725 Inspect Tool 

### DIFF
--- a/docs/learn/digital-assets/metadata-management/read-asset-data.md
+++ b/docs/learn/digital-assets/metadata-management/read-asset-data.md
@@ -43,6 +43,8 @@ Before following this guide, it is recommended to be a bit familiar with the tok
 
 You can use the 🔎 [ERC725 Inspect](https://erc725-inspect.lukso.tech/inspector) tool for inspecting assets within the browser.
 
+<img style={{ verticalAlign: 'right' }} src={ERC725} />
+
 :::
 
 ## Setup
@@ -229,6 +231,8 @@ console.log(tokenSymbol);
 }
 */
 ```
+
+import ERC725 from '@site/static/img/tools/erc725-tools.png';
 
 ### Global Token Information
 

--- a/docs/learn/universal-profile/key-manager/get-controller-permissions.md
+++ b/docs/learn/universal-profile/key-manager/get-controller-permissions.md
@@ -4,6 +4,8 @@ sidebar_position: 1
 description: Learn how to retrieve the list of controller addresses and their associated permissions from a Universal Profile on LUKSO.
 ---
 
+import ERC725 from '@site/static/img/tools/erc725-tools.png';
+
 # Get List of Permissioned Addresses
 
 :::tip Code repository
@@ -21,6 +23,11 @@ Alongside each controller, we will also retrieve their associated permissions. A
 3. **decode these permissions** in a human readable way
 
 ![Get controller addresses](/img/standards/lsp6/lsp6-address-permissions-array.jpeg)
+
+:::tip ERC725 Inspect
+[ERC725 Inspect Tool](https://erc725-inspect.lukso.tech/) allows you get all controllers of a Universal Profile under the `AddressPermissions[]` section.
+<img style={{ verticalAlign: 'right' }} src={ERC725} />
+:::
 
 ## Setup
 

--- a/docs/learn/universal-profile/metadata/edit-profile.md
+++ b/docs/learn/universal-profile/metadata/edit-profile.md
@@ -4,6 +4,8 @@ sidebar_position: 2
 description: Learn how to edit the LSP3Profile Metadata of a Universal Profile using web3.js or ethers.js.
 ---
 
+import ERC725 from '@site/static/img/tools/erc725-tools.png';
+
 # Edit a Universal Profile
 
 This guide will teach you how to **customize our Universal Profile** programmatically in JavaScript and includes:
@@ -294,6 +296,11 @@ await universalProfileContract.methods.setData(
 ```
 
 <!-- prettier-ignore-end -->
+
+:::tip ERC725 Inspect
+You can also validate your LSP3Profile metadata of your Universal Profile using the [ERC725 Inspect Tool](https://erc725-inspect.lukso.tech/).
+<img style={{ verticalAlign: 'right' }} src={ERC725} />
+:::
 
 ## Visualize our updated Universal Profile
 

--- a/docs/tools/dapps/erc725js/getting-started.md
+++ b/docs/tools/dapps/erc725js/getting-started.md
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import ERC725 from '@site/static/img/tools/erc725-tools.png';
+
 # Getting Started
 
 :::caution
@@ -14,6 +16,11 @@ This package is currently in the early stages of development. Feel free to [repo
 <br/><br/>
 
 The `@erc725/erc725.js` package allows you to retrieve, encode and decode data easily from any ERC725Y smart contracts using ERC725Y JSON Schemas.
+
+:::tip ERC725 Inspect
+You can easily retrieve the list of metadata and permissions from Universal Profile and Digital Assets, as well as encoding and decoding data using the [ERC725 Inspect Tool](https://erc725-inspect.lukso.tech/).
+<img style={{ verticalAlign: 'right' }} src={ERC725} />
+:::
 
 ## Installation
 

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -17,10 +17,23 @@ import DIALogo from '@site/static/img/tools/dia_logo.png';
 import DappnodeLogo from '@site/static/img/tools/dappnode_logo.png';
 import RemixLogo from '@site/static/img/tools/remix-ide.png';
 import Gateway from '@site/static/img/tools/gateway-logo.png';
+import ERC725 from '@site/static/img/tools/erc725-tools.png';
 
 # Tools
 
 Explore the different tools available for developers to build dApps, smart contracts and protocols more easily on LUKSO.
+
+## ERC725 Tools
+
+<ReferenceCard name="🔍 Inspector Tool" links={[ 
+  {label: 'View inspector', to: 'https://erc725-inspect.lukso.tech/' },
+]}>
+
+Inspector tool for developers to easily retrieve the list of metadata and permission from Universal Profile and Digital Assets, as well as encoding and decoding data.
+
+<img style={{ verticalAlign: 'right' }} src={ERC725} />
+
+</ReferenceCard>
 
 ## APIs
 
@@ -47,6 +60,127 @@ Query easily any information about Universal Profiles and LSP7/8 Digital Assets.
 ]}>
 
 Available RPC endpoints for the Universal Profile Browser Extension 🧩.
+
+</ReferenceCard>
+
+</div>
+
+<br />
+
+## Smart Contracts
+
+<div className={styles.referenceCardGrid}>
+
+<ReferenceCard name="LSP Smart Contracts" links={[ 
+  {label: 'Overview', to: '/tools/lsp-smart-contracts/getting-started' },
+  {label: 'GitHub', to: 'https://github.com/lukso-network/lsp-smart-contracts' },
+]}>
+
+<a
+  href="https://github.com/lukso-network/lsp-smart-contracts"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{
+    display: 'flex',
+    justifyContent: 'center',
+  }}
+>
+  <img
+    style={{
+      verticalAlign: 'middle',
+      padding: '0 2rem 2rem',
+      cursor: 'pointer',
+      pointerEvents: 'none',
+      height: '100px',
+      width: 'auto',
+      objectFit: 'contain',
+    }}
+    src={SolidityLogo}
+  />
+</a>
+
+<a
+  class="imageLink"
+  href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{
+    display: 'flex',
+    justifyContent: 'center',
+  }}
+>
+  <img
+    style={{ verticalAlign: 'middle' }}
+    alt="npm badge"
+    class="shield-badge"
+    src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"
+  />
+</a>
+
+The reference Solidity implementation of the LUKSO LSP Standards. Available as whole umbrella package or individual packages for specific LSPs.
+
+</ReferenceCard>
+
+<ReferenceCard name="Foundry Template" links={[ 
+  {label: 'GitHub', to: 'https://github.com/lukso-network/lukso-foundry-template' },
+]}>
+
+<a
+  href="https://github.com/lukso-network/lukso-foundry-template"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{
+    display: 'flex',
+    justifyContent: 'center',
+  }}
+>
+  <img
+    style={{
+      verticalAlign: 'middle',
+      padding: '0 2rem 2rem',
+      cursor: 'pointer',
+      pointerEvents: 'none',
+      height: '100px',
+      width: 'auto',
+      objectFit: 'contain',
+    }}
+    src={FoundryLogo}
+  />
+</a>
+
+Foundry repository template with pre-installed `@lukso/lsp-smart-contracts` package and example contracts ready to use.
+
+</ReferenceCard>
+
+<ReferenceCard name="Working with Remix IDE" links={[ 
+  {label: 'Website', to: 'https://remix.ethereum.org/' },
+  {label: 'Guide', to: '/tools/lsp-smart-contracts/working-with-remix' },
+]}>
+
+<a
+  href="/tools/lsp-smart-contracts/working-with-remix"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{
+    display: 'flex',
+    justifyContent: 'center',
+  }}
+>
+  <img
+    style={{
+      verticalAlign: 'middle',
+      padding: '0 2rem 2rem',
+      cursor: 'pointer',
+      pointerEvents: 'none',
+      height: '100px',
+      width: 'auto',
+      objectFit: 'contain',
+    }}
+    src={RemixLogo}
+  />
+</a>
+
+Write and deploy LSP smart contracts quickly and easily with the Remix IDE, a ready-to-use browser-based development environment.
 
 </ReferenceCard>
 
@@ -224,128 +358,7 @@ Create docker compose file to connect to LUKSO network.
 
 <br />
 
-## Smart Contracts
-
-<div className={styles.referenceCardGrid}>
-
-<ReferenceCard name="LSP Smart Contracts" links={[ 
-  {label: 'Overview', to: '/tools/lsp-smart-contracts/getting-started' },
-  {label: 'GitHub', to: 'https://github.com/lukso-network/lsp-smart-contracts' },
-]}>
-
-<a
-  href="https://github.com/lukso-network/lsp-smart-contracts"
-  target="_blank"
-  rel="noopener noreferrer"
-  style={{
-    display: 'flex',
-    justifyContent: 'center',
-  }}
->
-  <img
-    style={{
-      verticalAlign: 'middle',
-      padding: '0 2rem 2rem',
-      cursor: 'pointer',
-      pointerEvents: 'none',
-      height: '100px',
-      width: 'auto',
-      objectFit: 'contain'
-    }}
-    src={SolidityLogo}
-  />
-</a>
-
-<a
-  class="imageLink"
-  href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts"
-  target="_blank"
-  rel="noopener noreferrer"
-  style={{
-    display: 'flex',
-    justifyContent: 'center',
-  }}
->
-  <img
-    style={{ verticalAlign: 'middle' }}
-    alt="npm badge"
-    class="shield-badge"
-    src="https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat&label=%40lukso%2Flsp-smart-contracts"
-  />
-</a>
-
-The reference Solidity implementation of the LUKSO LSP Standards. Available as whole umbrella package or individual packages for specific LSPs.
-
-</ReferenceCard>
-
-<ReferenceCard name="Foundry Template" links={[ 
-  {label: 'GitHub', to: 'https://github.com/lukso-network/lukso-foundry-template' },
-]}>
-
-<a
-  href="https://github.com/lukso-network/lukso-foundry-template"
-  target="_blank"
-  rel="noopener noreferrer"
-  style={{
-    display: 'flex',
-    justifyContent: 'center',
-  }}
->
-  <img
-    style={{
-      verticalAlign: 'middle',
-      padding: '0 2rem 2rem',
-      cursor: 'pointer',
-      pointerEvents: 'none',
-      height: '100px',
-      width: 'auto',
-      objectFit: 'contain'
-    }}
-    src={FoundryLogo}
-  />
-</a>
-
-Foundry repository template with pre-installed `@lukso/lsp-smart-contracts` package and example contracts ready to use.
-
-</ReferenceCard>
-
-<ReferenceCard name="Working with Remix IDE" links={[ 
-  {label: 'Website', to: 'https://remix.ethereum.org/' },
-  {label: 'Guide', to: '/tools/lsp-smart-contracts/working-with-remix' },
-]}>
-
-<a
-  href="/tools/lsp-smart-contracts/working-with-remix"
-  target="_blank"
-  rel="noopener noreferrer"
-  style={{
-    display: 'flex',
-    justifyContent: 'center',
-  }}
->
-  <img
-    style={{
-      verticalAlign: 'middle',
-      padding: '0 2rem 2rem',
-      cursor: 'pointer',
-      pointerEvents: 'none',
-      height: '100px',
-      width: 'auto',
-      objectFit: 'contain'
-    }}
-    src={RemixLogo}
-  />
-</a>
-
-Write and deploy LSP smart contracts quickly and easily with the Remix IDE, a ready-to-use browser-based development environment.
-
-</ReferenceCard>
-
-</div>
-
-<br />
-
-## Explorers & Debuggers
+## Explorers
 
 <div className={styles.referenceCardGrid}>
 
@@ -355,14 +368,6 @@ Write and deploy LSP smart contracts quickly and easily with the Remix IDE, a re
 ]}>
 
 Network explorer for the LUKSO networks.
-
-</ReferenceCard>
-
-<ReferenceCard name="🔍 ERC725 Inspect" links={[ 
-  {label: 'View inspector', to: 'https://erc725-inspect.lukso.tech/' },
-]}>
-
-Inspector tool for developers to easily retrieve the list of metadata and permission from Universal Profile and Digital Assets, as well as encoding and decoding data.
 
 </ReferenceCard>
 
@@ -410,7 +415,7 @@ Third-party services and tools that are integrated with LUKSO to provide additio
       pointerEvents: 'none',
       height: '100px',
       width: 'auto',
-      objectFit: 'contain'
+      objectFit: 'contain',
     }}
     src={EnvioLogo}
   />
@@ -441,7 +446,7 @@ Indexer with playground to query data for Universal Profiles and Digital Assets 
       pointerEvents: 'none',
       height: '100px',
       width: 'auto',
-      objectFit: 'contain'
+      objectFit: 'contain',
     }}
     src={DIALogo}
   />
@@ -472,7 +477,7 @@ Oracle with different data feeds available for LUKSO.
       pointerEvents: 'none',
       height: '100px',
       width: 'auto',
-      objectFit: 'contain'
+      objectFit: 'contain',
     }}
     src={DappnodeLogo}
   />
@@ -503,7 +508,7 @@ Start running your own validator to stake and earn rewards.
       pointerEvents: 'none',
       height: '100px',
       width: 'auto',
-      objectFit: 'contain'
+      objectFit: 'contain',
     }}
     src={Gateway}
   />


### PR DESCRIPTION
This PR improves the visibility of ERC725 Inspect Tool by replacing it's place on the Tools section and adding a few more instances to our guides.

![image](https://github.com/user-attachments/assets/1e28c1dd-f433-4cc0-8bed-2caf9014cc5d)


![image](https://github.com/user-attachments/assets/3b09e68d-eb73-48b1-84f8-e9a100e06c49)
