### PR TITLE
ci: fetch _erc725.js_ latest docs from `main` branch

### DIFF
--- a/scripts/tools-sync.sh
+++ b/scripts/tools-sync.sh
@@ -3,7 +3,7 @@
 # Pull erc725.js repo
 mkdir tmpDocsSync 
 cd tmpDocsSync
-git clone --depth 1  --branch develop https://github.com/ERC725Alliance/erc725.js.git
+git clone --depth 1  --branch main https://github.com/ERC725Alliance/erc725.js.git
 rm erc725.js/docs/README.md
 
 # Copy Docs


### PR DESCRIPTION
Since we do not use the `develop` branch in _erc725.js_ and merge everything to `main`, the latest docs are on the `main` branch in this repository.

But the CI in the docs still fetches from the `develop` branch and does not see the latest changes.

This PR fixes that to now fetch from the `main` branch on _erc725.js_ repo.