### PR TITLE
ci: fix erc725js docs path

### DIFF
--- a/scripts/tools-sync.sh
+++ b/scripts/tools-sync.sh
@@ -7,7 +7,7 @@ git clone --depth 1  --branch main https://github.com/ERC725Alliance/erc725.js.g
 rm erc725.js/docs/README.md
 
 # Copy Docs
-rsync -av --progress erc725.js/docs/. ../docs/tools/libraries/erc725js --exclude technical-reference
+rsync -av --progress erc725.js/docs/. ../docs/tools/dapps/erc725js --exclude technical-reference
 
 # -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -16,7 +16,7 @@ rsync -av --progress erc725.js/docs/. ../docs/tools/libraries/erc725js --exclude
 git clone --depth 1 --branch develop https://github.com/lukso-network/tools-eip191-signer
 
 # Copy Docs
-rsync -av --progress tools-eip191-signer/docs/. ../docs/tools/libraries/eip191-signerjs
+rsync -av --progress tools-eip191-signer/docs/. ../docs/tools/dapps/eip191-signerjs
 
 
 cd ..


### PR DESCRIPTION
We recently updated the branch of the erc725js repo via #1240 PR, however, it was using the old path for the erc725js docs. 

This PR updates the path of the erc725js docs.