### PR TITLE
fix: add redirects + flexible codesandbox

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -301,6 +301,22 @@ export default {
             to: '/standards/accounts/lsp0-erc725account',
           },
           {
+            from: '/standards/generic-standards/lsp2-json-schema',
+            to: '/standards/metadata/lsp2-json-schema',
+          },
+          {
+            from: '/standards/universal-profile/lsp9-vault',
+            to: '/standards/accounts/lsp9-vault',
+          },
+          {
+            from: '/standards/universal-profile/lsp1-universal-receiver-delegate',
+            to: '/standards/accounts/lsp1-universal-receiver-delegate',
+          },
+          {
+            from: '/standards/generic-standards/lsp1-universal-receiver',
+            to: '/standards/accounts/lsp1-universal-receiver',
+          },
+          {
             from: '/standards/universal-profile/lsp6-key-manager',
             to: '/standards/access-control/lsp6-key-manager',
           },

--- a/src/components/CodeSandbox/index.tsx
+++ b/src/components/CodeSandbox/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
 interface CodeSandboxProps {
-  src: string;
+  src?: string;
 }
 
-const CodeSandbox: React.FC<CodeSandboxProps> = ({ src }) => {
+const CodeSandbox: React.FC<CodeSandboxProps> = ({ 
+  src = "https://codesandbox.io/embed/c4tfhf?view=split+%2B+preview&module=%2Fsrc%2Findex.ts&previewwindow=console&fontsize=11&hidenavigation=1&theme=dark" 
+}) => {
   return (
     <div style={{
       position: 'relative',


### PR DESCRIPTION
This PR fixes the broken redirects from the erc725js docs repo as well as makes the codesandbox parameter optional. 