### PR TITLE
fix/remove-stats-consensus

### DIFF
--- a/docs/networks/mainnet/parameters.md
+++ b/docs/networks/mainnet/parameters.md
@@ -17,7 +17,6 @@ import AddNetworkButton from '@site/src/components/AddNetworkButton'
 | Execution Block Explorer   | [https://explorer.lukso.network](https://explorer.lukso.network)                                     |
 | Execution Status Page      | [https://stats.execution.mainnet.lukso.network](https://stats.execution.mainnet.lukso.network)       |
 | Consensus Block Explorer   | [https://explorer.consensus.mainnet.lukso.network](https://explorer.consensus.mainnet.lukso.network) |
-| Consensus Status Page      | [https://stats.consensus.mainnet.lukso.network](https://stats.consensus.mainnet.lukso.network)       |
 | Client Diversity Dashboard | [https://clientdiversity.lukso.network/](https://clientdiversity.lukso.network/)                     |
 | Launchpad                  | [https://deposit.mainnet.lukso.network](https://deposit.mainnet.lukso.network)                       |
 | Checkpoints                | [https://checkpoints.mainnet.lukso.network](https://checkpoints.mainnet.lukso.network)               |

--- a/docs/networks/testnet/parameters.md
+++ b/docs/networks/testnet/parameters.md
@@ -23,7 +23,6 @@ The Public Testnet runs alongside the LUKSO mainnet for developers to test dApps
 | Execution Block Explorer | [https://explorer.execution.testnet.lukso.network](https://explorer.execution.testnet.lukso.network) |
 | Execution Status Page    | [https://stats.execution.testnet.lukso.network](https://stats.execution.testnet.lukso.network)       |
 | Consensus Block Explorer | [https://explorer.consensus.testnet.lukso.network](https://explorer.consensus.testnet.lukso.network) |
-| Consensus Status Page    | [https://stats.consensus.testnet.lukso.network](https://stats.consensus.testnet.lukso.network)       |
 | Faucet                   | [https://faucet.testnet.lukso.network](https://faucet.testnet.lukso.network)                         |
 | Launchpad                | [https://deposit.testnet.lukso.network](https://deposit.testnet.lukso.network)                       |
 | Checkpoints              | [https://checkpoints.testnet.lukso.network](https://checkpoints.testnet.lukso.network)               |


### PR DESCRIPTION
This PR removes the consensus status pages from the parameters list on the Network section, as neither page is planned to be maintained.