### PR TITLE
fix: Downgrade geth version

### DIFF
--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -61,7 +61,7 @@ The LUKSO network currently supports the following clients versions:
   </tr>
   <tr>
     <td><a href="https://geth.ethereum.org/">Geth</a></td>
-    <td><a href="https://github.com/ethereum/go-ethereum/releases/tag/v1.16.1">v1.16.1</a></td>
+    <td><a href="https://github.com/ethereum/go-ethereum/releases/tag/v1.15.11">v1.15.11</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/ethereum/go-ethereum"><GithubIcon /></a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://geth.ethereum.org/docs"><BookIcon /></a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://discord.com/invite/nthXNEv"><DiscordIcon /></a></td>


### PR DESCRIPTION
After issues with the participation rate and dropped EL-CL connection on some geth nodes, the geth version has been downgraded to `v1.15.11`