### PR TITLE
feat: new options + styling to page assistant

### DIFF
--- a/src/components/AssistantMenu/index.tsx
+++ b/src/components/AssistantMenu/index.tsx
@@ -9,6 +9,7 @@ import {
   ListItemIcon,
   ListItemText,
   Box,
+  Divider,
 } from '@mui/material';
 import styles from './styles.module.scss';
 
@@ -31,7 +32,7 @@ export default function AssistantMenu({ currentPath }) {
   const openChatGPTAssistant = () => {
     // Get the full URL of the current page without hash
     const pathname = location.pathname || currentPath || '';
-    const prompt = `Fetch the document at ${encodeURIComponent(siteConfig.url + pathname)}/. I want to review its content so I can ask targeted questions.`;
+    const prompt = `Fetch the document at ${encodeURIComponent(siteConfig.url + pathname)}. I want to review its content so I can ask targeted questions.`;
 
     // Create the ChatGPT URL with the prompt
     const chatGptUrl = `https://chatgpt.com/g/g-681a44ae29108191b12d97296ab25912-lukso-assistant?hints=search&prompt=${prompt}`;
@@ -71,6 +72,7 @@ export default function AssistantMenu({ currentPath }) {
         }}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        className={styles.dropdownMenu}
       >
         <AssistantOption
           icon="mdi:content-copy"
@@ -85,6 +87,19 @@ export default function AssistantMenu({ currentPath }) {
           title="Open in LUKSO Assistant"
           description="Ask a question about this page"
           onClickAction={openChatGPTAssistant}
+        />
+        <Divider className={styles.menuDivider} />
+        <AssistantOption
+          icon="mdi:file-document-outline"
+          title="LLMs.txt"
+          description="Documentation index for LLMs"
+          onClickAction={() => window.open('/llms.txt', '_blank')}
+        />
+        <AssistantOption
+          icon="mdi:book-open-page-variant"
+          title="Full Documentation"
+          description="Complete documentation as text"
+          onClickAction={() => window.open('/llms-full.txt', '_blank')}
         />
       </Menu>
     </div>

--- a/src/components/AssistantMenu/styles.module.scss
+++ b/src/components/AssistantMenu/styles.module.scss
@@ -16,7 +16,6 @@
   background-color: transparent !important;
   color: var(--ifm-font-color-base) !important;
   border: 1.5px solid var(--ifm-color-emphasis-600) !important;
-  border-radius: 16px !important;
   font-size: 14px !important;
   font-weight: 500 !important;
   min-height: 32px !important;
@@ -57,6 +56,9 @@
   border: 1px solid var(--ifm-color-emphasis-200) !important;
   border-radius: 8px !important;
   overflow: hidden !important;
+}
+
+.dropdownMenu {
   margin-top: 8px !important;
 }
 
@@ -74,11 +76,15 @@
 .dropdownItem {
   padding: 12px 16px !important;
   transition: background-color 0.15s ease !important;
-  border-bottom: 1px solid var(--ifm-color-emphasis-200) !important;
 }
 
 .dropdownItem:last-child {
   border-bottom: none !important;
+}
+
+.menuDivider {
+  margin: 12px 0 !important;
+  background-color: var(--ifm-color-emphasis-200) !important;
 }
 
 .dropdownItem:hover {
@@ -91,7 +97,7 @@
 
 .dropdownItemIcon {
   color: var(--ifm-color-primary) !important;
-  min-width: 40px !important;
+  min-width: 48px !important;
 }
 
 .dropdownItemText {


### PR DESCRIPTION
This PR adds two new options to the Page Assistant menu: LLMs.txt and Full Documentation. 
<img width="305" height="326" alt="image" src="https://github.com/user-attachments/assets/aa9e8d68-abae-4cbf-84ac-bb5628553290" />


It also includes styling changes to the main button and dropdown menu:

before: 
<img width="305" height="326" alt="image" src="https://github.com/user-attachments/assets/1771f59e-ce3c-4b1a-89c1-0cd576a4407d" />

after:
<img width="327" height="385" alt="image" src="https://github.com/user-attachments/assets/117af160-dd86-4284-8a62-ed048359c8df" />

