### PR TITLE
fix: update broken and stale links

### DIFF
--- a/docs/faq/lukso/feature-requests.md
+++ b/docs/faq/lukso/feature-requests.md
@@ -12,7 +12,7 @@ Yes, developer meetings and events are planned to present our monthly tech progr
 
 ## Are there financial support opportunities available for developers?
 
-Yes, developers have several options for financial support when building on LUKSO. The [LUKSO Grants Program](https://lukso.network/grants) offers funding through periodic application cycles. Furthermore, developers can participate in regular hackathons, including the [BuildUP hackathon series](https://app.buidlbox.io/lukso/build-up-2). Stay tuned for opportunities to engage and receive support on [Twitter](https://twitter.com/lukso_io) and [Discord](https://discord.gg/lukso).
+Yes, developers have several options for financial support when building on LUKSO. The [LUKSO Grants Program](https://lukso.network/grants) offers funding through periodic application cycles. Stay tuned for opportunities to engage and receive support on [Twitter](https://twitter.com/lukso_io) and [Discord](https://discord.gg/lukso).
 
 ## Will LUKSO be listed on additional exchanges?
 

--- a/docs/faq/network/network-configuration.md
+++ b/docs/faq/network/network-configuration.md
@@ -18,7 +18,7 @@ You can find more information about firewall and port settings within the specif
 - [Erigon Port Specification](https://github.com/erigontech/erigon#default-ports-and-firewalls)
 - [Nethermind Port Specification](https://docs.nethermind.io/fundamentals/security/#networking-security)
 - [Besu Port Specification](https://besu.hyperledger.org/public-networks/how-to/connect/configure-ports)
-- [Prysm Port Specification](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#configure-your-firewall)
+- [Prysm Port Specification](https://prysm.offchainlabs.com/docs/manage-connections/p2p-host-ip#configure-your-firewall)
 - [Lighthouse Port Specification](https://lighthouse-book.sigmaprime.io/advanced_networking.html#how-to-open-ports)
 - [Teku Port Specification](https://docs.teku.consensys.io/how-to/find-and-connect/improve-connectivity)
 

--- a/docs/faq/network/staking.md
+++ b/docs/faq/network/staking.md
@@ -62,7 +62,7 @@ If you created your validator keys with the [LUKSO Keygen CLI](https://github.co
 For details on how to enable withdrawals manually, have a look at these guides:
 
 - [Withdrawals Guide](https://notes.ethereum.org/@launchpad/withdrawals-guide) by Ethereum
-- [Withdraw Validator](https://docs.prylabs.network/docs/wallet/withdraw-validator) by Prylabs
+- [Withdraw Validator](https://prysm.offchainlabs.com/docs/manage-validator/withdraw-validator) by Prylabs
 
 ## Can I update my withdrawal credentials?
 

--- a/docs/faq/network/validators.md
+++ b/docs/faq/network/validators.md
@@ -107,6 +107,6 @@ Exiting a validator requires a signed message from your validator client. The LU
 
 If you use a custom setup, the exit process differs for each client. These are the links for the exit process for each supported consensus client:
 
-- [Exiting a Prysm validator](https://docs.prylabs.network/docs/wallet/exiting-a-validator)
+- [Exiting a Prysm validator](https://prysm.offchainlabs.com/docs/manage-validator/exiting-a-validator)
 - [Exiting a Lighthouse validator](https://lighthouse-book.sigmaprime.io/validator_voluntary_exit.html)
 - [Exiting a DAppNode validator](https://forum.dappnode.io/t/how-to-exit-an-eth2-validator/786)

--- a/docs/networks/advanced-guides/exit-validators.md
+++ b/docs/networks/advanced-guides/exit-validators.md
@@ -21,7 +21,7 @@ After your node is synced up and running, you will be able to go through the com
 lukso validator exit
 ```
 
-The exit setup will be different depending on your consensus client. Within [Prysm](https://docs.prylabs.network/docs/getting-started), you can select all or a specific number of validators by navigating the user interface in the terminal and selecting the public keys. For [Lighthouse](https://lighthouse-book.sigmaprime.io/intro.html), you have to input your validator and exit one at a time.
+The exit setup will be different depending on your consensus client. Within [Prysm](https://prysm.offchainlabs.com/docs/), you can select all or a specific number of validators by navigating the user interface in the terminal and selecting the public keys. For [Lighthouse](https://lighthouse-book.sigmaprime.io/intro.html), you have to input your validator and exit one at a time.
 
 :::info Exit Submission
 
@@ -50,6 +50,6 @@ Your validators stay active until the full withdrawal exit time. Ensure your nod
 If you are using Dappnode or a custom client, please refer to the following sources:
 
 - [Exit Dappnode Validators](https://discourse.dappnode.io/t/how-to-exit-your-validator-from-the-ui/1745)
-- [Prysm Validator Exit Documentation](https://docs.prylabs.network/docs/wallet/exiting-a-validator)
+- [Prysm Validator Exit Documentation](https://prysm.offchainlabs.com/docs/manage-validator/exiting-a-validator)
 - [Lighthouse Withdrawal Guide](https://lighthouse-book.sigmaprime.io/validator_voluntary_exit.html)
 - [How to exit Teku Validators](https://docs.teku.consensys.io/how-to/voluntarily-exit)

--- a/docs/networks/advanced-guides/withdrawal-update.md
+++ b/docs/networks/advanced-guides/withdrawal-update.md
@@ -260,7 +260,7 @@ A **maximum of 16 validator keys** can update their withdrawal credentials **per
 
 ## Client Documentation
 
-- [Prysm Withdrawal Guide](https://docs.prylabs.network/docs/wallet/withdraw-validator)
+- [Prysm Withdrawal Guide](https://prysm.offchainlabs.com/docs/manage-validator/withdraw-validator)
 - [Lighthouse Exit Description](https://lighthouse-book.sigmaprime.io/validator_voluntary_exit.html)
 - [Updating Teku Credentials](https://docs.teku.consensys.io/how-to/update-withdrawal-keys)
 

--- a/docs/networks/mainnet/parameters.md
+++ b/docs/networks/mainnet/parameters.md
@@ -75,7 +75,7 @@ The LUKSO's Blockchain runs an **unmodified version** of the Ethereum protocol. 
 
 ## IPFS Storage
 
-We highly recommend that developers fetch and store profile or asset data using **their own IPFS gateway** solutions like [Pinata](https://docs.pinata.cloud/docs/welcome-to-pinata) or [Infura](https://docs.infura.io/networks/ipfs) for production needs, ensuring distribution and availability across the IPFS network. We do not provide an official gateway for uploading asset data. For development purposes, you may use the following RPC to fetch data:
+We highly recommend that developers fetch and store profile or asset data using **their own IPFS gateway** solutions like [Pinata](https://docs.pinata.cloud/quickstart) or [Infura](https://docs.infura.io/networks/ipfs) for production needs, ensuring distribution and availability across the IPFS network. We do not provide an official gateway for uploading asset data. For development purposes, you may use the following RPC to fetch data:
 
 - IPFS Download (for development only): `https://api.universalprofile.cloud/ipfs`
 

--- a/docs/networks/mainnet/running-a-node.md
+++ b/docs/networks/mainnet/running-a-node.md
@@ -123,7 +123,7 @@ The LUKSO network currently supports the following clients versions:
     <td><a href="https://prysmaticlabs.com/">Prysm</a></td>
     <td><a href="https://github.com/prysmaticlabs/prysm/releases/tag/v6.0.4">v6.0.4</a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://github.com/prysmaticlabs/prysm"><GithubIcon /></a></td>
-    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://docs.prylabs.network/docs/getting-started"><BookIcon /></a></td>
+    <td style={{textAlign: 'center'}}><a class="imageLink" href="https://prysm.offchainlabs.com/docs/"><BookIcon /></a></td>
     <td style={{textAlign: 'center'}}><a class="imageLink" href="https://discord.com/invite/prysmaticlabs"><DiscordIcon /></a></td>
     <td>Stable</td>
     <td>Linux, Win, macOS, ARM</td>

--- a/docs/networks/testnet/parameters.md
+++ b/docs/networks/testnet/parameters.md
@@ -55,7 +55,7 @@ We recommend developers to use these RPC providers over our public RPC URL as th
 
 ## IPFS Storage
 
-We highly recommend that developers fetch and store profile or asset data using **their own IPFS gateway** solutions like [Pinata](https://docs.pinata.cloud/docs/welcome-to-pinata) or [Infura](https://docs.infura.io/networks/ipfs), ensuring distribution and availability across the IPFS network. We do not provide an official gateway for uploading asset data. For development purposes, you may use the following RPC to fetch data:
+We highly recommend that developers fetch and store profile or asset data using **their own IPFS gateway** solutions like [Pinata](https://docs.pinata.cloud/quickstart) or [Infura](https://docs.infura.io/networks/ipfs), ensuring distribution and availability across the IPFS network. We do not provide an official gateway for uploading asset data. For development purposes, you may use the following RPC to fetch data:
 
 - IPFS Download (for development only): `https://api.universalprofile.cloud/ipfs`
 

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -412,7 +412,6 @@ Third-party services and tools that are integrated with LUKSO to provide additio
 
 <ReferenceCard name="Envio" links={[ 
   {label: 'Docs', to: 'https://docs.envio.dev/blog/envio-data-indexing-supports-developers-building-on-lukso' },
-  {label: 'Playground', to: 'https://envio-testing.mainnet.lukso.dev' },
 ]}>
 
 <a

--- a/src/links.js
+++ b/src/links.js
@@ -12,7 +12,7 @@ import UniversalSwapsLogo from '@site/static/img/dapps/universalswaps-logo.png';
 import UniversalPageLogo from '@site/static/img/dapps/universalpage-logo.png';
 import StakingverseLogo from '@site/static/img/dapps/stakingverse-logo.png';
 import CommongroundLogo from '@site/static/img/dapps/common-ground-logo.png';
-import DefolioLogo from '@site/static/img/dapps/defolio-logo.png';
+
 import UFeedLogo from '@site/static/img/dapps/ufeed-logo.png';
 import UpTurnLogo from '@site/static/img/dapps/upturn-logo-scaled.png';
 import LSP8AppLogo from '@site/static/img/dapps/lsp8app-logo.png';
@@ -267,13 +267,7 @@ export const dappsSlider = [
     backgroundColor: '#404bbb',
     link: 'https://app.cg/',
   },
-  {
-    name: 'DeFolio',
-    description: 'Universal Profiles management platform.',
-    image: DefolioLogo,
-    backgroundColor: '#fcfcfc',
-    link: 'https://www.de-folio.com/',
-  },
+
   {
     name: 'Airdrop Tool',
     description: 'Distribute tokens to specific set of Universal Profiles.',


### PR DESCRIPTION
Automated broken link scan found several dead/stale links across the docs (25k+ links crawled).

## Changes

### Removed (dead domains/pages)
- `www.de-folio.com` — domain no longer exists (removed from `src/links.js`)
- `app.buidlbox.io/lukso/build-up-2` — hackathon page removed, 404 (removed from FAQ)
- `envio-testing.mainnet.lukso.dev` — dev endpoint no longer available (removed from tools)

### Updated (stale redirects)
- `docs.pinata.cloud/docs/welcome-to-pinata` → `docs.pinata.cloud/quickstart` (2 files)
- `docs.prylabs.network` → `prysm.offchainlabs.com` with updated paths (6 files)

### Not touched
- `explorer.consensus.mainnet.lukso.network` — may be temporarily down (503), not permanently broken
- `explorer.consensus.testnet.lukso.network/tools/broadcast` — same reason

---
*Found via automated crawl of docs.lukso.tech*